### PR TITLE
[WIP] Autogenerate docs by reading schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ terraform.tfstate*
 # custom user federation example
 custom-user-federation-example/build
 !custom-user-federation-example/build/libs
+
+# docsgen binary
+docsgen/docsgen

--- a/docsgen/docs/keycloak_group.md
+++ b/docsgen/docs/keycloak_group.md
@@ -1,0 +1,50 @@
+# keycloak_group
+Allows for creating and managing Groups within Keycloak.
+Groups provide a logical wrapping for users within Keycloak. Users within a
+group can share attributes and roles, and group membership can be mapped
+to a claim.
+Groups can also be federated from external data sources, such as LDAP or Active Directory.
+This resource **should not** be used to manage groups that were created this way.
+
+### Example usage
+
+```hcl
+resource "keycloak_realm" "realm" {
+   realm   = "my-realm"
+   enabled = true
+}
+resource "keycloak_group" "parent_group" {
+realm_id = "${keycloak_realm.realm.id}"
+name     = "parent-group"
+}
+resource "keycloak_group" "child_group" {
+realm_id  = "${keycloak_realm.realm.id}"
+parent_id = "${keycloak_group.parent_group.id}"
+name      = "child-group"
+}
+
+```
+
+### Argument Reference
+The following arguments are supported:
+
+- `parent_id` - (Optional) The ID of this group's parent. If omitted, this group will be defined at the root level.
+- `name` - (Required) The name of the group.
+- `realm_id` - (Required) The realm this groups exists in.
+
+
+### Attributes Reference
+In addition to the arguments listed above, the following computed attributes are exported:
+
+- `path` - The complete path of the group. For example, the child group's path in the example configuration would be `/parent-group/child-group`.
+
+
+### Import
+Groups can be imported using the format `{{realm_id}}/{{group_id}}`, where `group_id` is the unique ID that Keycloak
+assigns to the group upon creation. This value can be found in the URI when editing this group in the GUI, and is typically a GUID.
+ Example:
+ ```bash
+$ terraform import keycloak_group.child_group my-realm/934a4a4e-28bd-4703-a0fa-332df153aabd
+```
+
+

--- a/docsgen/docs/keycloak_openid_user_attribute_protocol_mapper.md
+++ b/docsgen/docs/keycloak_openid_user_attribute_protocol_mapper.md
@@ -1,0 +1,48 @@
+# keycloak_openid_user_attribute_protocol_mapper
+Takes an attribute from a user and adds it as a claim on a JWT
+
+### Example usage
+
+```hcl
+// client
+resource "keycloak_openid_user_attribute_protocol_mapper" "map_user_attributes_client" {
+    name           = "tf-test-open-id-user-attribute-protocol-mapper-client"
+    realm_id       = "${keycloak_realm.test.id}"
+    client_id      = "${keycloak_openid_client.test_client.id}"
+    user_attribute = "foo"
+    claim_name     = "bar"
+}
+
+// client scope
+resource "keycloak_openid_user_attribute_protocol_mapper" "map_user_attributes_client_scope" {
+    name            = "tf-test-open-id-user-attribute-protocol-mapper-client-scope"
+    realm_id        = "${keycloak_realm.test.id}"
+    client_scope_id = "${keycloak_openid_client_scope.test_client_scope.id}"
+    user_attribute  = "foo2"
+    claim_name      = "bar2"
+}
+
+```
+
+### Argument Reference
+The following arguments are supported:
+
+- `add_to_user_info` - (Optional) Indicates if the attribute should appear in the userinfo response body.
+- `user_attribute` - (Required) 
+- `claim_name` - (Required) 
+- `name` - (Required) A human-friendly name that will appear in the Keycloak console.
+- `realm_id` - (Required) The realm id where the associated client or client scope exists.
+- `client_id` - (Optional) The mapper's associated client. Cannot be used at the same time as client_scope_id.
+- `add_to_id_token` - (Optional) Indicates if the attribute should be a claim in the id token.
+- `client_scope_id` - (Optional) The mapper's associated client scope. Cannot be used at the same time as client_id.
+- `add_to_access_token` - (Optional) Indicates if the attribute should be a claim in the access token.
+- `multivalued` - (Optional) Indicates whether this attribute is a single value or an array of values.
+- `claim_value_type` - (Optional) Claim type used when serializing tokens.
+
+
+
+### Import
+To import a mapper tied to a client, use the import command with the format `{{realmId}}/client/{{clientId}}/{{protocolMapperId}}`
+Importing a mapper for a client scope is similar, `{{realmId}}/client-scope/{{clientScopeId}}/{{protocolMapperId}}`
+
+

--- a/docsgen/main.go
+++ b/docsgen/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"fmt"
+	"github.com/mrparkers/terraform-provider-keycloak/provider"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+	"text/template"
+)
+
+const (
+	OutputDir    = "docs"
+	TemplateFile = "resource.tmpl"
+)
+
+type Attribute struct {
+	Type          string
+	Description   string
+	Name          string
+	ConflictsWith []string
+}
+
+type Resource struct {
+	Name      string
+	CanImport bool
+
+	UserProvidedAttributes []Attribute
+	ComputedAttributes     []Attribute
+}
+
+type ResourceMetadata struct {
+	Description string `yaml:"description"`
+	Example     string `yaml:"example"`
+	Import      string `yaml:"import"`
+}
+
+type TemplateModel struct {
+	Resource Resource
+	Meta     ResourceMetadata
+}
+
+func readResourcesFromProvider() (resources []Resource, warnings []string) {
+	terraformProviderResources := provider.KeycloakProvider().ResourcesMap
+
+	for terraformResourceName, terraformResource := range terraformProviderResources {
+		if !(terraformResourceName == "keycloak_openid_user_attribute_protocol_mapper" || terraformResourceName == "keycloak_group") {
+			continue
+		}
+		resource := Resource{
+			Name:      terraformResourceName,
+			CanImport: terraformResource.Importer != nil,
+		}
+
+		for attributeName, attributeSchema := range terraformResource.Schema {
+			attribute := Attribute{
+				Name:          attributeName,
+				ConflictsWith: attributeSchema.ConflictsWith,
+				Description:   attributeSchema.Description,
+			}
+
+			if attribute.Description == "" {
+				warnings = append(warnings, fmt.Sprintf("%s.%s is missing a description.\n", terraformResourceName, attributeName))
+			}
+
+			if attributeSchema.Required {
+				attribute.Type = "Required"
+			} else if attributeSchema.Optional {
+				attribute.Type = "Optional"
+			}
+
+			if attributeSchema.Computed {
+				resource.ComputedAttributes = append(resource.ComputedAttributes, attribute)
+			} else {
+				resource.UserProvidedAttributes = append(resource.UserProvidedAttributes, attribute)
+			}
+		}
+
+		resources = append(resources, resource)
+	}
+
+	return resources, warnings
+}
+
+func generateDocs(resources []Resource) error {
+
+	if _, err := os.Stat(OutputDir); os.IsNotExist(err) {
+		os.Mkdir(OutputDir, os.ModePerm)
+	}
+
+	for _, r := range resources {
+		file, err := os.Create(fmt.Sprintf("%s/%s.md", OutputDir, r.Name))
+		if err != nil {
+			return err
+		}
+
+		metaFile, err := ioutil.ReadFile(fmt.Sprintf("resource-metadata/%s.meta.yml", r.Name))
+
+		if err != nil {
+			return err
+		}
+
+		var resourceMeta ResourceMetadata
+		err = yaml.Unmarshal(metaFile, &resourceMeta)
+
+		if err != nil {
+			return err
+		}
+
+		t := template.Must(template.ParseFiles(TemplateFile))
+		err = t.ExecuteTemplate(file, "base", TemplateModel{
+			Resource: r,
+			Meta:     resourceMeta,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		file.Close()
+	}
+
+	return nil
+}
+
+func main() {
+	resources, warnings := readResourcesFromProvider()
+
+	fmt.Printf("Discovered %d resources from provider \n", len(resources))
+
+	if len(warnings) > 0 {
+		fmt.Println("\nThe following issues should be addressed in order to generate high-quality documentation:")
+	}
+
+	for _, warning := range warnings {
+		fmt.Printf("- %s", warning)
+	}
+
+	err := generateDocs(resources)
+
+	if err != nil {
+		fmt.Printf("Error occured while generating docs %v\n", err)
+	}
+}

--- a/docsgen/makefile
+++ b/docsgen/makefile
@@ -1,0 +1,12 @@
+MAKEFLAGS += --silent
+
+.PHONY=build docs clean-docs
+
+build:
+	 GO111MODULE=on go build -o docsgen
+
+clean-docs:
+	rm -rf docs
+
+docs: clean-docs build
+	./docsgen

--- a/docsgen/resource-metadata/keycloak_group.meta.yml
+++ b/docsgen/resource-metadata/keycloak_group.meta.yml
@@ -1,0 +1,28 @@
+description: |
+    Allows for creating and managing Groups within Keycloak.
+    Groups provide a logical wrapping for users within Keycloak. Users within a
+    group can share attributes and roles, and group membership can be mapped
+    to a claim.
+    Groups can also be federated from external data sources, such as LDAP or Active Directory.
+    This resource **should not** be used to manage groups that were created this way.
+example: |
+    resource "keycloak_realm" "realm" {
+       realm   = "my-realm"
+       enabled = true
+    }
+    resource "keycloak_group" "parent_group" {
+    realm_id = "${keycloak_realm.realm.id}"
+    name     = "parent-group"
+    }
+    resource "keycloak_group" "child_group" {
+    realm_id  = "${keycloak_realm.realm.id}"
+    parent_id = "${keycloak_group.parent_group.id}"
+    name      = "child-group"
+    }
+import: |
+    Groups can be imported using the format `{{realm_id}}/{{group_id}}`, where `group_id` is the unique ID that Keycloak
+    assigns to the group upon creation. This value can be found in the URI when editing this group in the GUI, and is typically a GUID.
+     Example:
+     ```bash
+    $ terraform import keycloak_group.child_group my-realm/934a4a4e-28bd-4703-a0fa-332df153aabd
+    ```

--- a/docsgen/resource-metadata/keycloak_openid_user_attribute_protocol_mapper.meta.yml
+++ b/docsgen/resource-metadata/keycloak_openid_user_attribute_protocol_mapper.meta.yml
@@ -1,0 +1,23 @@
+description: |
+    Takes an attribute from a user and adds it as a claim on a JWT
+example: |
+    // client
+    resource "keycloak_openid_user_attribute_protocol_mapper" "map_user_attributes_client" {
+        name           = "tf-test-open-id-user-attribute-protocol-mapper-client"
+        realm_id       = "${keycloak_realm.test.id}"
+        client_id      = "${keycloak_openid_client.test_client.id}"
+        user_attribute = "foo"
+        claim_name     = "bar"
+    }
+
+    // client scope
+    resource "keycloak_openid_user_attribute_protocol_mapper" "map_user_attributes_client_scope" {
+        name            = "tf-test-open-id-user-attribute-protocol-mapper-client-scope"
+        realm_id        = "${keycloak_realm.test.id}"
+        client_scope_id = "${keycloak_openid_client_scope.test_client_scope.id}"
+        user_attribute  = "foo2"
+        claim_name      = "bar2"
+    }
+import: |
+    To import a mapper tied to a client, use the import command with the format `{{realmId}}/client/{{clientId}}/{{protocolMapperId}}`
+    Importing a mapper for a client scope is similar, `{{realmId}}/client-scope/{{clientScopeId}}/{{protocolMapperId}}`

--- a/docsgen/resource.tmpl
+++ b/docsgen/resource.tmpl
@@ -1,0 +1,24 @@
+{{ define "base" }}# {{ .Resource.Name }}
+{{ .Meta.Description }}
+### Example usage
+
+```hcl
+{{ .Meta.Example }}
+```
+
+### Argument Reference
+The following arguments are supported:
+
+{{ range .Resource.UserProvidedAttributes}}- `{{.Name}}` - ({{.Type}}) {{.Description}}
+{{ end }}
+{{ if.Resource.ComputedAttributes }}
+### Attributes Reference
+In addition to the arguments listed above, the following computed attributes are exported:
+
+{{ range .Resource.ComputedAttributes}}- `{{.Name}}` - {{.Description}}{{ end }}
+{{end}}
+{{ if .Resource.CanImport }}
+### Import
+{{ .Meta.Import }}
+{{ end }}
+{{ end }}

--- a/go.mod
+++ b/go.mod
@@ -37,4 +37,5 @@ require (
 	golang.org/x/net v0.0.0-20180826012351-8a410e7b638d // indirect
 	google.golang.org/genproto v0.0.0-20180831171423-11092d34479b // indirect
 	google.golang.org/grpc v1.14.0 // indirect
+	gopkg.in/yaml.v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,10 @@ github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Ao
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jtolds/gls v4.2.1+incompatible h1:fSuqC+Gmlu6l/ZYAoZzx2pyucC8Xza35fpRVWLVmUEE=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
@@ -132,6 +134,8 @@ google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoA
 google.golang.org/grpc v1.14.0 h1:ArxJuB1NWfPY6r9Gp9gqwplT0Ge7nqv9msgu03lHLmo=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 howett.net/plist v0.0.0-20180609054337-500bd5b9081b/go.mod h1:jInWmjR7JRkkon4jlLXDZGVEeY/wo3kOOJEWYhNE+9Y=

--- a/provider/keycloak_group.go
+++ b/provider/keycloak_group.go
@@ -18,22 +18,26 @@ func resourceKeycloakGroup() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"realm_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Description: "The realm this groups exists in.",
+				Required:    true,
+				ForceNew:    true,
 			},
 			"parent_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Description: "The ID of this group's parent. If omitted, this group will be defined at the root level.",
+				Optional:    true,
+				ForceNew:    true,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Description: "The name of the group.",
+				Required:    true,
 			},
 			"path": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Description: "The complete path of the group. For example, the child group's path in the example configuration would be `/parent-group/child-group`.",
+				Computed:    true,
 			},
 		},
 	}


### PR DESCRIPTION
This PR generates the "attributes/arguments" section of the documentation by reading the schema for each resource in the provider.
For parts of the documentation that cannot be sourced from the schema (e.g., examples, description), it expects a YML doc with the text to be placed in a certain directory.

This is pretty rough around the edges, but I included the generated docs for two resources in order to show the output (`keycloak_group` and `keycloak_openid_user_attribute_protocol_mapper`) . To generate them locally, run `make docs` in the `docsgen` directory.

Possible improvements:
- handle nested schemas
- clean up some of the spacing in the generated Markdown
- make a proper CLI
- remove hard-coded paths
- split arguments out by required/optional
- sort arguments in some fashion so that the output is consistent 
- generate docs for the provider itself
- handle missing descriptions better (or not generate docs for those resources or just fail hard)