### PR TITLE
fix: don't assume component fields are returned by Keycloak API

### DIFF
--- a/keycloak/ldap_full_name_mapper.go
+++ b/keycloak/ldap_full_name_mapper.go
@@ -38,12 +38,12 @@ func convertFromLdapFullNameMapperToComponent(ldapFullNameMapper *LdapFullNameMa
 }
 
 func convertFromComponentToLdapFullNameMapper(component *component, realmId string) (*LdapFullNameMapper, error) {
-	readOnly, err := strconv.ParseBool(component.getConfig("read.only"))
+	readOnly, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("read.only"))
 	if err != nil {
 		return nil, err
 	}
 
-	writeOnly, err := strconv.ParseBool(component.getConfig("write.only"))
+	writeOnly, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("write.only"))
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/ldap_group_mapper.go
+++ b/keycloak/ldap_group_mapper.go
@@ -93,17 +93,17 @@ func convertFromComponentToLdapGroupMapper(component *component, realmId string)
 		groupObjectClasses[i] = strings.TrimSpace(v)
 	}
 
-	preserveGroupInheritance, err := strconv.ParseBool(component.getConfig("preserve.group.inheritance"))
+	preserveGroupInheritance, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("preserve.group.inheritance"))
 	if err != nil {
 		return nil, err
 	}
 
-	ignoreMissingGroups, err := strconv.ParseBool(component.getConfig("ignore.missing.groups"))
+	ignoreMissingGroups, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("ignore.missing.groups"))
 	if err != nil {
 		return nil, err
 	}
 
-	dropNonExistingGroupsDuringSync, err := strconv.ParseBool(component.getConfig("drop.non.existing.groups.during.sync"))
+	dropNonExistingGroupsDuringSync, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("drop.non.existing.groups.during.sync"))
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/ldap_msad_user_account_control_mapper.go
+++ b/keycloak/ldap_msad_user_account_control_mapper.go
@@ -30,7 +30,7 @@ func convertFromLdapMsadUserAccountControlMapperToComponent(ldapMsadUserAccountC
 }
 
 func convertFromComponentToLdapMsadUserAccountControlMapper(component *component, realmId string) (*LdapMsadUserAccountControlMapper, error) {
-	ldapPasswordPolicyHintsEnabled, err := strconv.ParseBool(component.getConfig("ldap.password.policy.hints.enabled"))
+	ldapPasswordPolicyHintsEnabled, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("ldap.password.policy.hints.enabled"))
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/ldap_user_attribute_mapper.go
+++ b/keycloak/ldap_user_attribute_mapper.go
@@ -46,17 +46,17 @@ func convertFromLdapUserAttributeMapperToComponent(ldapUserAttributeMapper *Ldap
 }
 
 func convertFromComponentToLdapUserAttributeMapper(component *component, realmId string) (*LdapUserAttributeMapper, error) {
-	isMandatoryInLdap, err := strconv.ParseBool(component.getConfig("is.mandatory.in.ldap"))
+	isMandatoryInLdap, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("is.mandatory.in.ldap"))
 	if err != nil {
 		return nil, err
 	}
 
-	readOnly, err := strconv.ParseBool(component.getConfig("read.only"))
+	readOnly, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("read.only"))
 	if err != nil {
 		return nil, err
 	}
 
-	alwaysReadValueFromLdap, err := strconv.ParseBool(component.getConfig("always.read.value.from.ldap"))
+	alwaysReadValueFromLdap, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("always.read.value.from.ldap"))
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/ldap_user_federation.go
+++ b/keycloak/ldap_user_federation.go
@@ -162,7 +162,7 @@ func convertFromLdapUserFederationToComponent(ldap *LdapUserFederation) (*compon
 }
 
 func convertFromComponentToLdapUserFederation(component *component) (*LdapUserFederation, error) {
-	enabled, err := strconv.ParseBool(component.getConfig("enabled"))
+	enabled, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("enabled"))
 	if err != nil {
 		return nil, err
 	}
@@ -172,24 +172,24 @@ func convertFromComponentToLdapUserFederation(component *component) (*LdapUserFe
 		return nil, err
 	}
 
-	importEnabled, err := strconv.ParseBool(component.getConfig("importEnabled"))
+	importEnabled, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("importEnabled"))
 	if err != nil {
 		return nil, err
 	}
 
-	syncRegistrations, err := strconv.ParseBool(component.getConfig("syncRegistrations"))
+	syncRegistrations, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("syncRegistrations"))
 	if err != nil {
 		return nil, err
 	}
 
 	userObjectClasses := strings.Split(component.getConfig("userObjectClasses"), ", ")
 
-	validatePasswordPolicy, err := strconv.ParseBool(component.getConfig("validatePasswordPolicy"))
+	validatePasswordPolicy, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("validatePasswordPolicy"))
 	if err != nil {
 		return nil, err
 	}
 
-	pagination, err := strconv.ParseBool(component.getConfig("pagination"))
+	pagination, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("pagination"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #79 

This fixes a weird edge case where mappers (or components from an API perspective) are missing some fields in API responses, but only if they're created using the GUI.  Thus, I wasn't able to write a failing test for this :cry: