### PR TITLE
[WIP] Add hostname attribute to realm

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://mrparkers.github.io/terraform-provider-keycloak/
 ## Building
 
 This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) which requires Go 1.11.
-I personally test the provider with version 0.11.11 of Terraform, and version 4.8.3.Final of Keycloak. Other versions may also work.
+I personally test the provider with version 0.11.11 of Terraform, and version 6.0.1 of Keycloak. Other versions may also work.
 
 ```
 GO111MODULE=on go mod download && make build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     - POSTGRES_PASSWORD=password
     - KEYCLOAK_USER=keycloak
     - KEYCLOAK_PASSWORD=password
+    - KEYCLOAK_HOSTNAME=localhost
     - POSTGRES_PORT_5432_TCP_ADDR=postgres
     - POSTGRES_PORT_5432_TCP_PORT=5432
     ports:

--- a/example/main.tf
+++ b/example/main.tf
@@ -8,6 +8,7 @@ resource "keycloak_realm" "test" {
   realm        = "test"
   enabled      = true
   display_name = "foo"
+  hostname     = "localhost"
 
   account_theme = "base"
 

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -10,8 +10,6 @@ type Realm struct {
 	Enabled     bool   `json:"enabled"`
 	DisplayName string `json:"displayName"`
 
-	Hostname string `json:"hostname,omitempty"`
-
 	// Login Config
 	RegistrationAllowed         bool `json:"registrationAllowed"`
 	RegistrationEmailAsUsername bool `json:"registrationEmailAsUsername"`
@@ -42,6 +40,10 @@ type Realm struct {
 	AccessCodeLifespanUserAction        int  `json:"accessCodeLifespanUserAction,omitempty"`
 	ActionTokenGeneratedByUserLifespan  int  `json:"actionTokenGeneratedByUserLifespan,omitempty"`
 	ActionTokenGeneratedByAdminLifespan int  `json:"actionTokenGeneratedByAdminLifespan,omitempty"`
+
+	Attributes struct {
+		Hostname string `json:"hostname"`
+	} `json:"attributes,omitempty"`
 }
 
 func (keycloakClient *KeycloakClient) NewRealm(realm *Realm) error {

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -10,6 +10,8 @@ type Realm struct {
 	Enabled     bool   `json:"enabled"`
 	DisplayName string `json:"displayName"`
 
+	Hostname string `json:"hostname,omitempty"`
+
 	// Login Config
 	RegistrationAllowed         bool `json:"registrationAllowed"`
 	RegistrationEmailAsUsername bool `json:"registrationEmailAsUsername"`

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -29,6 +29,10 @@ func resourceKeycloakRealm() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"hostname": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 
 			// Login Config
 
@@ -187,6 +191,10 @@ func getRealmFromData(data *schema.ResourceData) (*keycloak.Realm, error) {
 		DuplicateEmailsAllowed:      data.Get("duplicate_emails_allowed").(bool),
 	}
 
+	if hostname, ok := data.GetOk("hostname"); ok {
+		realm.Hostname = hostname.(string)
+	}
+
 	// Themes
 
 	if loginTheme, ok := data.GetOk("login_theme"); ok {
@@ -311,6 +319,8 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm) {
 	data.Set("realm", realm.Realm)
 	data.Set("enabled", realm.Enabled)
 	data.Set("display_name", realm.DisplayName)
+
+	data.Set("hostname", realm.Hostname)
 
 	// Login Config
 	data.Set("registration_allowed", realm.RegistrationAllowed)

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -192,7 +192,7 @@ func getRealmFromData(data *schema.ResourceData) (*keycloak.Realm, error) {
 	}
 
 	if hostname, ok := data.GetOk("hostname"); ok {
-		realm.Hostname = hostname.(string)
+		realm.Attributes.Hostname = hostname.(string)
 	}
 
 	// Themes
@@ -320,7 +320,7 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm) {
 	data.Set("enabled", realm.Enabled)
 	data.Set("display_name", realm.DisplayName)
 
-	data.Set("hostname", realm.Hostname)
+	data.Set("hostname", realm.Attributes.Hostname)
 
 	// Login Config
 	data.Set("registration_allowed", realm.RegistrationAllowed)


### PR DESCRIPTION
This attribute configures the [fixed hostname provider](https://www.keycloak.org/docs/latest/server_admin/index.html#fixed-provider); it controls the issuer claim and any other generated URLs. Out of the box, Keycloak uses the `request` hostname provider, which reads the `Host` header in order to set the issuer. 

From running the example, this PR seems to work but I'd like to update the config for an acceptance test. Also, this needs a feature check, since Keycloak is happy to accept changes to hostname even when the fixed provider isn't being used. All of the providers are part of `serverinfo`, so I'm planning to add to that struct.