### PR TITLE
Allow for using the password grant with a confidential client

### DIFF
--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -43,13 +43,13 @@ func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, passwor
 	}
 	clientCredentials := &ClientCredentials{
 		ClientId: clientId,
+		ClientSecret: clientSecret,
 	}
 	if password != "" && username != "" {
 		clientCredentials.Username = username
 		clientCredentials.Password = password
 		clientCredentials.GrantType = "password"
 	} else if clientSecret != "" {
-		clientCredentials.ClientSecret = clientSecret
 		clientCredentials.GrantType = "client_credentials"
 	} else {
 		return nil, fmt.Errorf("must specify client id, username and password for password grant, or client id and secret for client credentials grant")

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -42,7 +42,7 @@ func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, passwor
 		Timeout: time.Second * 5,
 	}
 	clientCredentials := &ClientCredentials{
-		ClientId: clientId,
+		ClientId:     clientId,
 		ClientSecret: clientSecret,
 	}
 	if password != "" && username != "" {


### PR DESCRIPTION
The current implementation only allows direct access grants with a public client. 