### PR TITLE
clients: support configuring of Scope

### DIFF
--- a/docs/resources/keycloak_saml_client.md
+++ b/docs/resources/keycloak_saml_client.md
@@ -56,6 +56,7 @@ The following arguments are supported:
 - `assertion_consumer_redirect_url` - (Optional) SAML Redirect Binding URL for the client's assertion consumer service (login responses).
 - `logout_service_post_binding_url` - (Optional) SAML POST Binding URL for the client's single logout service.
 - `logout_service_redirect_binding_url` - (Optional) SAML Redirect Binding URL for the client's single logout service.
+- `full_scope_allowed` - (Optional) - Allow to include all roles mappings in the access token
 
 ### Import
 

--- a/keycloak/saml_client.go
+++ b/keycloak/saml_client.go
@@ -40,6 +40,8 @@ type SamlClient struct {
 	BaseUrl                 string   `json:"baseUrl"`
 	MasterSamlProcessingUrl string   `json:"adminUrl"`
 
+	FullScopeAllowed bool `json:"fullScopeAllowed"`
+
 	Attributes *SamlClientAttributes `json:"attributes"`
 }
 

--- a/provider/resource_keycloak_saml_client.go
+++ b/provider/resource_keycloak_saml_client.go
@@ -139,6 +139,11 @@ func resourceKeycloakSamlClient() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"full_scope_allowed": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 	}
 }
@@ -229,6 +234,7 @@ func mapToSamlClientFromData(data *schema.ResourceData) *keycloak.SamlClient {
 		ValidRedirectUris:       validRedirectUris,
 		BaseUrl:                 data.Get("base_url").(string),
 		MasterSamlProcessingUrl: data.Get("master_saml_processing_url").(string),
+		FullScopeAllowed:        data.Get("full_scope_allowed").(bool),
 		Attributes:              samlAttributes,
 	}
 
@@ -308,6 +314,7 @@ func mapToDataFromSamlClient(data *schema.ResourceData, client *keycloak.SamlCli
 	data.Set("assertion_consumer_redirect_url", client.Attributes.AssertionConsumerRedirectURL)
 	data.Set("logout_service_post_binding_url", client.Attributes.LogoutServicePostBindingURL)
 	data.Set("logout_service_redirect_binding_url", client.Attributes.LogoutServiceRedirectBindingURL)
+	data.Set("full_scope_allowed", client.FullScopeAllowed)
 
 	return nil
 }


### PR DESCRIPTION
- add argument full_scope_allowed to resource keycloak_saml_client

REMARK: using default true due to backward compatibility