### PR TITLE
generic implementation for a client protocol mapper

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,12 +17,12 @@ sure which to use, the client credentials grant is recommended, as it was design
 
 1. Create a new client using the `openid-connect` protocol. This client can be created in the `master` realm if you would
 like to manage your entire Keycloak instance, or in any other realm if you only want to manage that realm.
-2. Update the client you just created:
-    2a. Set "Access Type" to "confidential".
-    2b. Set "Standard Flow Enabled" to "OFF".
-    2c. Set "Direct Access Grants Enabled" to "OFF"
-    2d. Set "Service Accounts Enabled" to "ON".
-3. Grant required roles for managing Keycloak via the "Service Account Roles" tab in the client you created in step 1.
+1. Update the client you just created:
+    1. Set "Access Type" to "confidential".
+    1. Set "Standard Flow Enabled" to "OFF".
+    1. Set "Direct Access Grants Enabled" to "OFF"
+    1. Set "Service Accounts Enabled" to "ON".
+1. Grant required roles for managing Keycloak via the "Service Account Roles" tab in the client you created in step 1.
 
 ## Password Grant Setup
 
@@ -30,7 +30,7 @@ These steps will assume that you are using the `admin-cli` client, which is alre
 of authentication. Do not follow these steps if you have already followed the steps for the client credentials grant.
 
 1. Create or identify the user who's credentials will be used for authentication.
-2. Edit this user in the "Users" section of the management console and assign roles using the "Role Mappings" tab.
+1. Edit this user in the "Users" section of the management console and assign roles using the "Role Mappings" tab.
 
 ## Assigning Roles
 

--- a/docs/resources/keycloak_generic_client_protocol_mapper.md
+++ b/docs/resources/keycloak_generic_client_protocol_mapper.md
@@ -1,6 +1,6 @@
 # keycloak_generic_client_protocol_mapper
 
-Allows for creating and managing protocol mapper for both types of clients (` and saml) within Keycloak.
+Allows for creating and managing protocol mapper for both types of clients (openid-connect and saml) within Keycloak.
 
 There are two uses cases for using this resource:
 * If you implemented a custom protocol mapper, this resource can be used to configure it

--- a/docs/resources/keycloak_generic_client_protocol_mapper.md
+++ b/docs/resources/keycloak_generic_client_protocol_mapper.md
@@ -1,0 +1,60 @@
+# keycloak_generic_client_protocol_mapper
+
+Allows for creating and managing protocol mapper for both types of clients (` and saml) within Keycloak.
+
+There are two uses cases for using this resource:
+* If you implemented a custom protocol mapper, this resource can be used to configure it
+* If the provider doesn't support a particular protocol mapper, this resource can be used instead.
+
+Due to the generic nature of this mapper, it is less user-friendly and more prone to configuration errors. 
+Therefore, if possible, a specific mapper should be used.
+
+### Example Usage
+
+```hcl
+resource "keycloak_realm" "realm" {
+    realm   = "my-realm"
+    enabled = true
+}
+
+resource "keycloak_saml_client" "saml_client" {
+  realm_id  = "${keycloak_realm.realm.id}"
+  client_id = "test-client"
+}
+
+resource "keycloak_generic_client_protocol_mapper" "saml_hardcode_attribute_mapper" {
+  realm_id        = "${keycloak_realm.realm.id}"
+  client_id       = "${keycloak_saml_client.saml_client.id}"
+  name            = "tes-mapper"
+  protocol        = "saml"
+  protocol_mapper = "saml-hardcode-attribute-mapper"
+  config = {
+    "attribute.name"       = "name"
+    "attribute.nameformat" = "Basic"
+    "attribute.value"      = "value"
+    "friendly.name"        = "display name"
+  }
+}
+```
+
+### Argument Reference
+
+The following arguments are supported:
+
+- `realm_id` - (Required) The realm this protocol mapper exists within.
+- `client_id` - (Required) The client this protocol mapper is attached to.
+- `name` - (Required) The display name of this protocol mapper in the GUI.
+- `protocol` - (Required) The type of client (either `openid-connect` or `saml`). The type must match the type of the client.
+- `protocol_mapper` - (Required) The name of the protocol mapper. The protocol mapper must be
+   compatible with the specified client.
+- `config` - (Required) A map with key / value pairs for configuring the protocol mapper. The supported keys depends on the protocol mapper.
+
+### Import
+
+Protocol mappers can be imported using the following format: `{{realm_id}}/client/{{client_keycloak_id}}/{{protocol_mapper_id}}`
+
+Example:
+
+```bash
+$ terraform import keycloak_generic_client_protocol_mapper.saml_hardcode_attribute_mapper my-realm/client/a7202154-8793-4656-b655-1dd18c181e14/71602afa-f7d1-4788-8c49-ef8fd00af0f4
+```

--- a/docs/resources/keycloak_ldap_user_federation.md
+++ b/docs/resources/keycloak_ldap_user_federation.md
@@ -60,13 +60,13 @@ The following arguments are supported:
 - `bind_credential` - (Optional) Password of LDAP admin. This attribute must be set if `bind_dn` is set.
 - `custom_user_search_filter` - (Optional) Additional LDAP filter for filtering searched users. Must begin with `(` and end with `)`.
 - `search_scope` - (Optional) Can be one of `ONE_LEVEL` or `SUBTREE`:
-  - `ONE_LEVEL`: Only search for users in the DN specified by `user_dn`.
-  - `SUBTREE`: Search entire LDAP subtree.
+    - `ONE_LEVEL`: Only search for users in the DN specified by `user_dn`.
+    - `SUBTREE`: Search entire LDAP subtree.
 - `validate_password_policy` - (Optional) When `true`, Keycloak will validate passwords using the realm policy before updating it.
 - `use_truststore_spi` - (Optional) Can be one of `ALWAYS`, `ONLY_FOR_LDAPS`, or `NEVER`:
-  - `ALWAYS` - Always use the truststore SPI for LDAP connections.
-  - `NEVER` - Never use the truststore SPI for LDAP connections.
-  - `ONLY_FOR_LDAPS` - Only use the truststore SPI if your LDAP connection uses the ldaps protocol.
+    - `ALWAYS` - Always use the truststore SPI for LDAP connections.
+    - `NEVER` - Never use the truststore SPI for LDAP connections.
+    - `ONLY_FOR_LDAPS` - Only use the truststore SPI if your LDAP connection uses the ldaps protocol.
 - `connection_timeout` - (Optional) LDAP connection timeout in the format of a [Go duration string](https://golang.org/pkg/time/#Duration.String).
 - `read_timeout` - (Optional) LDAP read timeout in the format of a [Go duration string](https://golang.org/pkg/time/#Duration.String).
 - `pagination` - (Optional) When true, Keycloak assumes the LDAP server supports pagination. Defaults to `true`.

--- a/docs/resources/keycloak_openid_client.md
+++ b/docs/resources/keycloak_openid_client.md
@@ -38,11 +38,11 @@ The following arguments are supported:
 - `enabled` - (Optional) When false, this client will not be able to initiate a login or obtain access tokens. Defaults to `true`.
 - `description` - (Optional) The description of this client in the GUI.
 - `access_type` - (Required) Specifies the type of client, which can be one of the following:
-	- `CONFIDENTIAL` - Used for server-side clients that require both client ID and secret when authenticating.
-	This client should be used for applications using the Authorization Code or Client Credentials grant flows.
-	- `PUBLIC` - Used for browser-only applications that do not require a client secret, and instead rely only on authorized redirect
-	URIs for security. This client should be used for applications using the Implicit grant flow.
-	- `BEARER-ONLY` - Used for services that never initiate a login. This client will only allow bearer token requests.
+    - `CONFIDENTIAL` - Used for server-side clients that require both client ID and secret when authenticating.
+      This client should be used for applications using the Authorization Code or Client Credentials grant flows.
+    - `PUBLIC` - Used for browser-only applications that do not require a client secret, and instead rely only on authorized redirect
+      URIs for security. This client should be used for applications using the Implicit grant flow.
+    - `BEARER-ONLY` - Used for services that never initiate a login. This client will only allow bearer token requests.
 - `client_secret` - (Optional) The secret for clients with an `access_type` of `CONFIDENTIAL` or `BEARER-ONLY`. This value is sensitive and
 should be treated with the same care as a password. If omitted, Keycloak will generate a GUID for this attribute.
 - `standard_flow_enabled` - (Optional) When `true`, the OAuth2 Authorization Code Grant will be enabled for this client. Defaults to `false`.

--- a/docs/resources/keycloak_user.md
+++ b/docs/resources/keycloak_user.md
@@ -48,8 +48,8 @@ The following arguments are supported:
 - `username` - (Required) The unique username of this user.
 - `initial_password` (Optional) When given, the user's initial password will be set.
    This attribute is only respected during initial user creation.
-  - `value` (Required) The initial password.
-  - `temporary` (Optional) If set to `true`, the initial password is set up for renewal on first use. Default to `false`.
+    - `value` (Required) The initial password.
+    - `temporary` (Optional) If set to `true`, the initial password is set up for renewal on first use. Default to `false`.
 - `enabled` - (Optional) When false, this user cannot log in. Defaults to `true`.
 - `email` - (Optional) The user's email.
 - `first_name` - (Optional) The user's first name.

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.36.0 h1:+aCSj7tOo2LODWVEuZDZeGCckdt6MlSF+X/rB3wUiS8=
 cloud.google.com/go v0.36.0/go.mod h1:RUoy9p/M4ge0HzT8L+SDZ8jg+Q6fth0CiBuhFJpSV40=
 dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl+fi1br7+Rr3LqpNJf1/uxUdtRUV+Tnj0o93V2B9MU=
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
@@ -101,7 +102,9 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
+github.com/googleapis/gax-go/v2 v2.0.3 h1:siORttZ36U2R/WjiJuDz8znElWBiAlO9rVt+mqJt0Cc=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/gophercloud/gophercloud v0.0.0-20190208042652-bc37892e1968/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/utils v0.0.0-20190128072930-fbb6ab446f01/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=
@@ -124,6 +127,7 @@ github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-getter v1.1.0 h1:iGVeg7L4V5FTFV3D6w+1NAyvth7BIWWSzD60pWloe2Q=
 github.com/hashicorp/go-getter v1.1.0/go.mod h1:q+PoBhh16brIKwJS9kt18jEtXHTg2EGkmrA9P7HVS+U=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
+github.com/hashicorp/go-hclog v0.0.0-20181001195459-61d530d6c27f h1:Yv9YzBlAETjy6AOX9eLBZ3nshNVRREgerT/3nvxlGho=
 github.com/hashicorp/go-hclog v0.0.0-20181001195459-61d530d6c27f/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.7.0 h1:TwD6x3r9IdHnoVSBmfvEgKKLRu08augeYi8fwWcbmiE=
 github.com/hashicorp/go-hclog v0.7.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
@@ -147,12 +151,14 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl2 v0.0.0-20181208003705-670926858200/go.mod h1:ShfpTh661oAaxo7VcNxg0zcZW6jvMa7Moy2oFx7e5dE=
 github.com/hashicorp/hcl2 v0.0.0-20190503210054-6e4ec17113ca h1:roLn75Q2QkZE1V3kitKaOazz0INIj53v4OlH4kJzWbA=
 github.com/hashicorp/hcl2 v0.0.0-20190503210054-6e4ec17113ca/go.mod h1:4oI94iqF3GB10QScn46WqbG0kgTUpha97SAzzg2+2ec=
+github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 h1:2yzhWGdgQUWZUCNK+AoO35V+HTsgEmcM4J9IkArh7PI=
 github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 h1:T1Q6ag9tCwun16AW+XK3tAql24P4uTGUMIn1/92WsQQ=
 github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
@@ -215,6 +221,7 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2Em
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
+github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -313,6 +320,7 @@ github.com/zclconf/go-cty v0.0.0-20181129180422-88fbe721e0f8/go.mod h1:xnAOWiHeO
 github.com/zclconf/go-cty v0.0.0-20190426224007-b18a157db9e2/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190430221426-d36a6f0dbffd h1:NZOOU7h+pDtcKo6xlqm8PwnarS8nJ+6+I83jT8ZfLPI=
 github.com/zclconf/go-cty v0.0.0-20190430221426-d36a6f0dbffd/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
@@ -350,6 +358,7 @@ golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.0.0-20190220154721-9b3c75971fc9 h1:pfyU+l9dEu0vZzDDMsdAKa1gZbJYEn6urYXj/+Xkz7s=
 golang.org/x/oauth2 v0.0.0-20190220154721-9b3c75971fc9/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -387,6 +396,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181030000716-a0a13e073c7b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
+google.golang.org/api v0.1.0 h1:K6z2u68e86TPdSdefXdzvXgR1zEMa+459vBSfWYAZkI=
 google.golang.org/api v0.1.0/go.mod h1:UGEZY7KEX120AnNLIHFMKIo4obdJhkp2tPbaPlQx13Y=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/keycloak/generic_client_protocol_mapper.go
+++ b/keycloak/generic_client_protocol_mapper.go
@@ -2,14 +2,12 @@ package keycloak
 
 import (
 	"fmt"
-
-	"github.com/google/uuid"
 )
 
 type GenericClientProtocolMapper struct {
 	ClientId       string            `json:"-"`
 	Config         map[string]string `json:"config"`
-	Id             string            `json:"id"`
+	Id             string            `json:"id,omitempty"`
 	Name           string            `json:"name"`
 	Protocol       string            `json:"protocol"`
 	ProtocolMapper string            `json:"protocolMapper"`
@@ -17,15 +15,14 @@ type GenericClientProtocolMapper struct {
 }
 
 func (keycloakClient *KeycloakClient) NewGenericClientProtocolMapper(genericClientProtocolMapper *GenericClientProtocolMapper) error {
-	// Keycloak does not generate an Id when a new protocol mapper is created
-	genericClientProtocolMapper.Id = uuid.New().String()
-
-	_, _, err := keycloakClient.post(
+	_, location, err := keycloakClient.post(
 		fmt.Sprintf("/realms/%s/clients/%s/protocol-mappers/models", genericClientProtocolMapper.RealmId, genericClientProtocolMapper.ClientId),
 		genericClientProtocolMapper)
 	if err != nil {
 		return err
 	}
+
+	genericClientProtocolMapper.Id = getIdFromLocationHeader(location)
 
 	return nil
 }

--- a/keycloak/generic_client_protocol_mapper.go
+++ b/keycloak/generic_client_protocol_mapper.go
@@ -1,0 +1,56 @@
+package keycloak
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+type GenericClientProtocolMapper struct {
+	ClientId       string            `json:"-"`
+	Config         map[string]string `json:"config"`
+	Id             string            `json:"id"`
+	Name           string            `json:"name"`
+	Protocol       string            `json:"protocol"`
+	ProtocolMapper string            `json:"protocolMapper"`
+	RealmId        string            `json:"-"`
+}
+
+func (keycloakClient *KeycloakClient) NewGenericClientProtocolMapper(genericClientProtocolMapper *GenericClientProtocolMapper) error {
+	// Keycloak does not generate an Id when a new protocol mapper is created
+	genericClientProtocolMapper.Id = uuid.New().String()
+
+	_, _, err := keycloakClient.post(
+		fmt.Sprintf("/realms/%s/clients/%s/protocol-mappers/models", genericClientProtocolMapper.RealmId, genericClientProtocolMapper.ClientId),
+		genericClientProtocolMapper)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (keycloakClient *KeycloakClient) GetGenericClientProtocolMapper(realmId string, clientId string, id string) (*GenericClientProtocolMapper, error) {
+	var genericClientProtocolMapper GenericClientProtocolMapper
+
+	err := keycloakClient.get(fmt.Sprintf("/realms/%s/clients/%s/protocol-mappers/models/%s", realmId, clientId, id), &genericClientProtocolMapper, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// these values are not provided by the keycloak API
+	genericClientProtocolMapper.ClientId = clientId
+	genericClientProtocolMapper.RealmId = realmId
+
+	return &genericClientProtocolMapper, nil
+}
+
+func (keycloakClient *KeycloakClient) UpdateGenericClientProtocolMapper(genericClientProtocolMapper *GenericClientProtocolMapper) error {
+	return keycloakClient.put(
+		fmt.Sprintf("/realms/%s/clients/%s/protocol-mappers/models/%s", genericClientProtocolMapper.RealmId, genericClientProtocolMapper.ClientId, genericClientProtocolMapper.Id),
+		genericClientProtocolMapper)
+}
+
+func (keycloakClient *KeycloakClient) DeleteGenericClientProtocolMapper(realmId string, clientId string, id string) error {
+	return keycloakClient.delete(fmt.Sprintf("/realms/%s/clients/%s/protocol-mappers/models/%s", realmId, clientId, id), nil)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -33,6 +33,7 @@ func KeycloakProvider() *schema.Provider {
 			"keycloak_openid_client_default_scopes":                    resourceKeycloakOpenidClientDefaultScopes(),
 			"keycloak_openid_client_optional_scopes":                   resourceKeycloakOpenidClientOptionalScopes(),
 			"keycloak_saml_client":                                     resourceKeycloakSamlClient(),
+			"keycloak_generic_client_protocol_mapper":                  resourceKeycloakGenericClientProtocolMapper(),
 			"keycloak_saml_user_attribute_protocol_mapper":             resourceKeycloakSamlUserAttributeProtocolMapper(),
 			"keycloak_saml_user_property_protocol_mapper":              resourceKeycloakSamlUserPropertyProtocolMapper(),
 			"keycloak_hardcoded_attribute_identity_provider_mapper":    resourceKeycloakHardcodedAttributeIdentityProviderMapper(),

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -12,6 +12,7 @@ var testAccProvider *schema.Provider
 
 var requiredEnvironmentVariables = []string{
 	"KEYCLOAK_CLIENT_ID",
+	"KEYCLOAK_REALM",
 	"KEYCLOAK_URL",
 }
 

--- a/provider/resource_keycloak_generic_client_protocol_mapper.go
+++ b/provider/resource_keycloak_generic_client_protocol_mapper.go
@@ -1,0 +1,147 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
+	"log"
+)
+
+func resourceKeycloakGenericClientProtocolMapper() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceKeycloakGenericClientProtocolMapperCreate,
+		Read:   resourceKeycloakGenericClientProtocolMapperRead,
+		Delete: resourceKeycloakGenericClientProtocolMapperDelete,
+		Update: resourceKeycloakGenericClientProtocolMapperUpdate,
+		// This resource can be imported using {{realmId}}/client/{{clientId}}/{{protocolMapperId}}
+		Importer: &schema.ResourceImporter{
+			State: genericProtocolMapperImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "A human-friendly name that will appear in the Keycloak console.",
+			},
+			"realm_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The realm id where the associated client exists.",
+			},
+			"client_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The mapper's associated client.",
+			},
+			"protocol": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "The protocol of the client (openid-connect / saml).",
+				ValidateFunc: validation.StringInSlice([]string{"openid-connect", "saml"}, false),
+			},
+			"protocol_mapper": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The type of the protocol mapper.",
+			},
+			"config": {
+				Type:     schema.TypeMap,
+				Required: true,
+			},
+		},
+	}
+}
+
+func getGenericClientProtocolMapperFromData(data *schema.ResourceData) *keycloak.GenericClientProtocolMapper {
+	config := make(map[string]string)
+	if v, ok := data.GetOk("config"); ok {
+		for key, value := range v.(map[string]interface{}) {
+			config[key] = value.(string)
+		}
+	}
+
+	return &keycloak.GenericClientProtocolMapper{
+		ClientId:       data.Get("client_id").(string),
+		Config:         config,
+		Id:             data.Id(),
+		Name:           data.Get("name").(string),
+		Protocol:       data.Get("protocol").(string),
+		ProtocolMapper: data.Get("protocol_mapper").(string),
+		RealmId:        data.Get("realm_id").(string),
+	}
+}
+
+func setGenericClientProtocolMapperData(data *schema.ResourceData, resource *keycloak.GenericClientProtocolMapper) {
+	data.SetId(resource.Id)
+	data.Set("client_id", resource.ClientId)
+	data.Set("config", resource.Config)
+	data.Set("name", resource.Name)
+	data.Set("protocol", resource.Protocol)
+	data.Set("protocol_mapper", resource.ProtocolMapper)
+	data.Set("realm_id", resource.RealmId)
+}
+
+func resourceKeycloakGenericClientProtocolMapperCreate(data *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] creating\n")
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	resource := getGenericClientProtocolMapperFromData(data)
+
+	err := keycloakClient.NewGenericClientProtocolMapper(resource)
+	if err != nil {
+		return err
+	}
+	setGenericClientProtocolMapperData(data, resource)
+
+	return resourceKeycloakGenericClientProtocolMapperRead(data, meta)
+}
+
+func resourceKeycloakGenericClientProtocolMapperRead(data *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] geting\n")
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	clientId := data.Get("client_id").(string)
+	id := data.Id()
+
+	resource, err := keycloakClient.GetGenericClientProtocolMapper(realmId, clientId, id)
+	if err != nil {
+		return handleNotFoundError(err, data)
+	}
+
+	setGenericClientProtocolMapperData(data, resource)
+
+	return nil
+}
+
+func resourceKeycloakGenericClientProtocolMapperUpdate(data *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] updating\n")
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	resource := getGenericClientProtocolMapperFromData(data)
+
+	err := keycloakClient.UpdateGenericClientProtocolMapper(resource)
+	if err != nil {
+		return err
+	}
+
+	setGenericClientProtocolMapperData(data, resource)
+
+	return nil
+}
+
+func resourceKeycloakGenericClientProtocolMapperDelete(data *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] deleting\n")
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	clientId := data.Get("client_id").(string)
+	id := data.Id()
+
+	return keycloakClient.DeleteGenericClientProtocolMapper(realmId, clientId, id)
+}

--- a/provider/resource_keycloak_generic_client_protocol_mapper.go
+++ b/provider/resource_keycloak_generic_client_protocol_mapper.go
@@ -87,7 +87,6 @@ func setGenericClientProtocolMapperData(data *schema.ResourceData, resource *key
 }
 
 func resourceKeycloakGenericClientProtocolMapperCreate(data *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] creating\n")
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
 	resource := getGenericClientProtocolMapperFromData(data)
@@ -102,7 +101,6 @@ func resourceKeycloakGenericClientProtocolMapperCreate(data *schema.ResourceData
 }
 
 func resourceKeycloakGenericClientProtocolMapperRead(data *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] geting\n")
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
 	realmId := data.Get("realm_id").(string)
@@ -136,7 +134,6 @@ func resourceKeycloakGenericClientProtocolMapperUpdate(data *schema.ResourceData
 }
 
 func resourceKeycloakGenericClientProtocolMapperDelete(data *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] deleting\n")
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
 	realmId := data.Get("realm_id").(string)

--- a/provider/resource_keycloak_generic_client_protocol_mapper_test.go
+++ b/provider/resource_keycloak_generic_client_protocol_mapper_test.go
@@ -1,0 +1,218 @@
+package provider
+
+import (
+	"fmt"
+	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+const (
+	TF_RESOURCE_NAME = "client_protocol_mapper"
+)
+
+func TestAccKeycloakGenericClientProtocolMapper_basicClient(t *testing.T) {
+	realmName := "terraform-realm-" + acctest.RandString(10)
+	clientId := "terraform-client-" + acctest.RandString(10)
+	mapperName := "terraform-generic-client-protocol-mapper-" + acctest.RandString(5)
+
+	resourceName := "keycloak_generic_client_protocol_mapper." + TF_RESOURCE_NAME
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccKeycloakGenericClientProtocolMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakGenericClientProtocolMapper_basic_client(realmName, clientId, mapperName),
+				Check:  testKeycloakGenericClientProtocolMapperExists(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakGenericClientProtocolMapper_import(t *testing.T) {
+	realmName := "terraform-realm-" + acctest.RandString(10)
+	clientId := "terraform-client-" + acctest.RandString(10)
+	mapperName := "terraform-generic-client-protocol-mapper-" + acctest.RandString(5)
+
+	resourceName := "keycloak_generic_client_protocol_mapper." + TF_RESOURCE_NAME
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccKeycloakGenericClientProtocolMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakGenericClientProtocolMapper_import(realmName, clientId, mapperName),
+				Check:  testKeycloakGenericClientProtocolMapperExists(resourceName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getGenericProtocolMapperIdForClient(resourceName),
+			},
+		},
+	})
+}
+
+func TestGenericClientProtocolMapper_update(t *testing.T) {
+	realmName := "terraform-realm-" + acctest.RandString(10)
+	clientId := "terraform-client-" + acctest.RandString(10)
+	mapperName := "terraform-generic-client-protocol-mapper-" + acctest.RandString(5)
+
+	resourceName := "keycloak_generic_client_protocol_mapper." + TF_RESOURCE_NAME
+
+	oldAttributeName := "attribute-name-" + acctest.RandString(10)
+	oldAttributeValue := "attribute-name-" + acctest.RandString(10)
+	newAttributeName := "attribute-value-" + acctest.RandString(10)
+	newAttributeValue := "attribute-value-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccKeycloakGenericClientProtocolMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakGenericClientProtocolMapper_update(realmName, clientId, mapperName, oldAttributeName, oldAttributeValue),
+				Check:  testKeycloakGenericClientProtocolMapperExists(resourceName),
+			},
+			{
+				Config: testKeycloakGenericClientProtocolMapper_update(realmName, clientId, mapperName, newAttributeName, newAttributeValue),
+				Check: resource.ComposeTestCheckFunc(
+					testKeycloakGenericClientProtocolMapperExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "config.attribute.name", newAttributeName),
+					resource.TestCheckResourceAttr(resourceName, "config.attribute.value", newAttributeValue)),
+			},
+		},
+	})
+}
+
+/*  =================================================================================================================
+    Helper functions
+    ================================================================================================================= */
+func testAccKeycloakGenericClientProtocolMapperDestroy() resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		for resourceName, rs := range state.RootModule().Resources {
+			if rs.Type != "keycloak_generic_client_protocol_mapper" {
+				continue
+			}
+
+			mapper, _ := getGenericClientProtocolMapperUsingState(state, resourceName)
+
+			if mapper != nil {
+				return fmt.Errorf("generic client protocol mapper with id %s still exists", rs.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+}
+
+func getGenericClientProtocolMapperUsingState(state *terraform.State, resourceName string) (*keycloak.GenericClientProtocolMapper, error) {
+	rs, ok := state.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("resource not found in TF state: %s ", resourceName)
+	}
+
+	id := rs.Primary.ID
+	realmId := rs.Primary.Attributes["realm_id"]
+	clientId := rs.Primary.Attributes["client_id"]
+
+	keycloakClient := testAccProvider.Meta().(*keycloak.KeycloakClient)
+
+	return keycloakClient.GetGenericClientProtocolMapper(realmId, clientId, id)
+}
+
+func testKeycloakGenericClientProtocolMapper_basic_client(realmName string, clientId string, mapperName string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+  realm = "%s"
+}
+
+resource "keycloak_saml_client" "saml_client" {
+  realm_id  = "${keycloak_realm.realm.id}"
+  client_id = "%s"
+}
+
+resource "keycloak_generic_client_protocol_mapper" "%s" {
+  client_id       = "${keycloak_saml_client.saml_client.id}"
+  name            = "%s"
+  protocol        = "saml"
+  protocol_mapper = "saml-hardcode-attribute-mapper"
+  realm_id        = "${keycloak_realm.realm.id}"
+  config = {
+    "attribute.name"       = "name"
+    "attribute.nameformat" = "Basic"
+    "attribute.value"      = "value"
+    "friendly.name"        = "%s"
+  }
+}`, realmName, clientId, TF_RESOURCE_NAME, mapperName, mapperName)
+}
+
+func testKeycloakGenericClientProtocolMapper_import(realmName string, clientId string, mapperName string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+  realm = "%s"
+}
+
+resource "keycloak_saml_client" "saml_client" {
+  realm_id  = "${keycloak_realm.realm.id}"
+  client_id = "%s"
+}
+
+resource "keycloak_generic_client_protocol_mapper" "%s" {
+  client_id       = "${keycloak_saml_client.saml_client.id}"
+  name            = "%s"
+  protocol        = "saml"
+  protocol_mapper = "saml-hardcode-attribute-mapper"
+  realm_id        = "${keycloak_realm.realm.id}"
+  config = {
+    "attribute.name"       = "name"
+    "attribute.nameformat" = "Basic"
+    "attribute.value"      = "value"
+    "friendly.name"        = "%s"
+  }
+}`, realmName, clientId, TF_RESOURCE_NAME, mapperName, mapperName)
+}
+
+func testKeycloakGenericClientProtocolMapper_update(realmName string, clientId string, mapperName string, attributeName string, attributeValue string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+  realm = "%s"
+}
+
+resource "keycloak_saml_client" "saml_client" {
+  realm_id  = "${keycloak_realm.realm.id}"
+  client_id = "%s"
+}
+
+resource "keycloak_generic_client_protocol_mapper" "%s" {
+  client_id       = "${keycloak_saml_client.saml_client.id}"
+  name            = "%s"
+  protocol        = "saml"
+  protocol_mapper = "saml-hardcode-attribute-mapper"
+  realm_id        = "${keycloak_realm.realm.id}"
+  config = {
+    "attribute.name"       = "%s"
+    "attribute.nameformat" = "Basic"
+    "attribute.value"      = "%s"
+    "friendly.name"        = "%s"
+  }
+}`, realmName, clientId, TF_RESOURCE_NAME, mapperName, attributeName, attributeValue, mapperName)
+}
+
+func testKeycloakGenericClientProtocolMapperExists(resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		_, err := getGenericClientProtocolMapperUsingState(state, resourceName)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
This is generic implementation for #14 . It supports saml and openid-connect clients. In order to support custom protocol mappers it does not enforce a specific structure.

example:
```hcl
resource "keycloak_generic_client_protocol_mapper" "Session_Duration" {
  name = "Session Duration"
  protocol = "saml"
  protocol_mapper = "saml-hardcode-attribute-mapper"
  realm_id = "${keycloak_realm.aws.id}"
  client_id = "${keycloak_saml_client.urn_amazon_webservices.id}"
  config = {
    "attribute.value" = "28800",
    "attribute.nameformat" = "Basic"
    "friendly.name" =  "Session Duration"
    "attribute.name" = "https://aws.amazon.com/SAML/Attributes/SessionDuration"
  }
} 
```

Before creating documentation and test cases it would be nice to get some feedback about the current code.