### PR TITLE
Build a specific linux target with CGO_ENABLED=0

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -9,12 +9,20 @@ mkdir -p ../artifacts
 for config in $(cat release-targets.json | jq -rc '.[]'); do
 	os=$(echo ${config} | jq -r '.os')
 	platform=$(echo ${config} | jq -r '.platform')
+	static=$(echo ${config} | jq -r '.static // false')
+  linkage=''
+  if [[ ${static} = 'true' ]]; then
+    export CGO_ENABLED=0
+    linkage='_static'
+  else
+    unset CGO_ENABLED
+  fi
 
-	echo "Building for ${os}_${platform}..."
+	echo "Building for ${os}_${platform}${linkage}..."
 
 	GOOS=${os} GOARCH=${platform} go build -o terraform-provider-keycloak_v${CIRCLE_TAG} ..
-	zip terraform-provider-keycloak_v${CIRCLE_TAG}_${os}_${platform}.zip terraform-provider-keycloak_v${CIRCLE_TAG} ../LICENSE
-	mv terraform-provider-keycloak_v${CIRCLE_TAG}_${os}_${platform}.zip ../artifacts
+	zip terraform-provider-keycloak_v${CIRCLE_TAG}_${os}_${platform}${linkage}.zip terraform-provider-keycloak_v${CIRCLE_TAG} ../LICENSE
+	mv terraform-provider-keycloak_v${CIRCLE_TAG}_${os}_${platform}${linkage}.zip ../artifacts
 	rm terraform-provider-keycloak_v${CIRCLE_TAG}
 done;
 

--- a/scripts/release-targets.json
+++ b/scripts/release-targets.json
@@ -8,6 +8,11 @@
 		"platform": "amd64"
 	},
 	{
+		"os": "linux",
+		"platform": "amd64",
+    "static": true
+	},
+	{
 		"os": "windows",
 		"platform": "amd64"
 	}


### PR DESCRIPTION
fixes #127 
After what you suggested in #127, I added a compilation target which is exported as `linux_amd64_static`.
Curiously enough, the darwin and windows build are already static (well, curious from my limited knowledge about Go compilation).