### PR TITLE
allow extra config for a custom user federation implementation

### DIFF
--- a/custom-user-federation-example/src/main/kotlin/com/github/mrparkers/keycloak/CustomUserStorageProviderFactory.kt
+++ b/custom-user-federation-example/src/main/kotlin/com/github/mrparkers/keycloak/CustomUserStorageProviderFactory.kt
@@ -2,15 +2,32 @@ package com.github.mrparkers.keycloak
 
 import org.keycloak.component.ComponentModel
 import org.keycloak.models.KeycloakSession
+import org.keycloak.provider.ProviderConfigProperty
 import org.keycloak.storage.UserStorageProviderFactory
 
 class CustomUserStorageProviderFactory : UserStorageProviderFactory<CustomUserStorageProvider> {
-    override fun getId(): String = "custom"
+	override fun getId(): String = "custom"
 
-    override fun init(config: org.keycloak.Config.Scope) {
-        super.init(config)
-    }
+	override fun init(config: org.keycloak.Config.Scope) {
+		super.init(config)
+	}
 
-    override fun create(session: KeycloakSession, model: ComponentModel): CustomUserStorageProvider =
-            CustomUserStorageProvider(session, model)
+	override fun create(session: KeycloakSession, model: ComponentModel): CustomUserStorageProvider =
+		CustomUserStorageProvider(session, model)
+
+	override fun getConfigProperties(): List<ProviderConfigProperty> = configPropertyList
+
+	companion object {
+		private val configPropertyList = ArrayList<ProviderConfigProperty>()
+
+		init {
+			val property = ProviderConfigProperty()
+			property.setName("dummyConfig")
+			property.setLabel("Dummy Config")
+			property.setDefaultValue("")
+			property.setType(ProviderConfigProperty.STRING_TYPE)
+			property.setHelpText("Dummy config for testing")
+			configPropertyList.add(property)
+		}
+	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,9 @@ services:
     environment:
     - DB_VENDOR=POSTGRES
     - KEYCLOAK_LOGLEVEL=DEBUG
-    - POSTGRES_USER=keycloak
-    - POSTGRES_DATABASE=keycloak
-    - POSTGRES_PASSWORD=password
+    - DB_USER=keycloak
+    - DB_DATABASE=keycloak
+    - DB_PASSWORD=password
     - KEYCLOAK_USER=keycloak
     - KEYCLOAK_PASSWORD=password
     - POSTGRES_PORT_5432_TCP_ADDR=postgres

--- a/provider/resource_keycloak_custom_user_federation.go
+++ b/provider/resource_keycloak_custom_user_federation.go
@@ -56,11 +56,23 @@ func resourceKeycloakCustomUserFederation() *schema.Resource {
 				Default:      "DEFAULT",
 				ValidateFunc: validation.StringInSlice(keycloakUserFederationCachePolicies, false),
 			},
+
+			"config": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 		},
 	}
 }
 
 func getCustomUserFederationFromData(data *schema.ResourceData) *keycloak.CustomUserFederation {
+	config := map[string][]string{}
+	if v, ok := data.GetOk("config"); ok {
+		for key, value := range v.(map[string]interface{}) {
+			config[key] = strings.Split(value.(string), ",")
+		}
+	}
+
 	return &keycloak.CustomUserFederation{
 		Id:         data.Id(),
 		Name:       data.Get("name").(string),
@@ -71,6 +83,8 @@ func getCustomUserFederationFromData(data *schema.ResourceData) *keycloak.Custom
 		Priority: data.Get("priority").(int),
 
 		CachePolicy: data.Get("cache_policy").(string),
+
+		Config: config,
 	}
 }
 
@@ -85,6 +99,7 @@ func setCustomUserFederationData(data *schema.ResourceData, custom *keycloak.Cus
 	data.Set("priority", custom.Priority)
 
 	data.Set("cache_policy", custom.CachePolicy)
+	data.Set("config", custom.Config)
 }
 
 func resourceKeycloakCustomUserFederationCreate(data *schema.ResourceData, meta interface{}) error {

--- a/provider/resource_keycloak_custom_user_federation_test.go
+++ b/provider/resource_keycloak_custom_user_federation_test.go
@@ -41,7 +41,6 @@ func TestAccKeycloakCustomUserFederation_customConfig(t *testing.T) {
 
 	realmName := "terraform-" + acctest.RandString(10)
 	name := "terraform-" + acctest.RandString(10)
-	configKey := "key" //needs to be a key supported by provider `custom`, otherwise it is never returned in the getCustomUserFederation
 	configValue := "value-" + acctest.RandString(10)
 	providerId := "custom"
 
@@ -51,8 +50,8 @@ func TestAccKeycloakCustomUserFederation_customConfig(t *testing.T) {
 		CheckDestroy: testAccCheckKeycloakCustomUserFederationDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakCustomUserFederation_customConfig(realmName, name, providerId, configKey, configValue),
-				Check:  testAccCheckKeycloakCustomUserFederationExistsWithCustomConfig("keycloak_custom_user_federation.custom", configKey, configValue),
+				Config: testKeycloakCustomUserFederation_customConfig(realmName, name, providerId, configValue),
+				Check:  testAccCheckKeycloakCustomUserFederationExistsWithCustomConfig("keycloak_custom_user_federation.custom", configValue),
 			},
 		},
 	})
@@ -121,16 +120,15 @@ func testAccCheckKeycloakCustomUserFederationExists(resourceName string) resourc
 	}
 }
 
-func testAccCheckKeycloakCustomUserFederationExistsWithCustomConfig(resourceName, customConfigKey, customConfigValue string) resource.TestCheckFunc {
+func testAccCheckKeycloakCustomUserFederationExistsWithCustomConfig(resourceName, customConfigValue string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		fetchedFederation, err := getCustomUserFederationFromState(s, resourceName)
 		if err != nil {
 			return err
 		}
 
-		if len(fetchedFederation.Config[customConfigKey]) <= 0 || fetchedFederation.Config[customConfigKey][0] != customConfigValue {
-			//disabled check because custom provider needs to supported customConfigKey
-			//return fmt.Errorf("expected user federation provider to have config with a custom key '%s' with a value %s", customConfigKey, customConfigValue)
+		if len(fetchedFederation.Config["dummyConfig"]) <= 0 || fetchedFederation.Config["dummyConfig"][0] != customConfigValue {
+			return fmt.Errorf("expected user federation provider to have config with a custom key 'dummyConfig' with a value %s", customConfigValue)
 		}
 
 		return nil
@@ -208,7 +206,7 @@ resource "keycloak_custom_user_federation" "custom" {
 	`, realm, name, providerId)
 }
 
-func testKeycloakCustomUserFederation_customConfig(realm, name, providerId, customConfigKey, customConfigValue string) string {
+func testKeycloakCustomUserFederation_customConfig(realm, name, providerId, customConfigValue string) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
 	realm = "%s"
@@ -222,8 +220,8 @@ resource "keycloak_custom_user_federation" "custom" {
 	enabled     = true
 
 	config 		= {
-		%s = "%s"
+		dummyConfig = "%s"
 	}
 }
-	`, realm, name, providerId, customConfigKey, customConfigValue)
+	`, realm, name, providerId, customConfigValue)
 }


### PR DESCRIPTION
allow extra config for a custom user federation implementation.

I had some troubles writing a good test, as keycloak only returns custom config keys and values that the custom implementation understands. I used the written tests on a keycloak installation with my custom user federation spi, and everything worked as expected.
Any suggestions how to make better tests for this type of configuration?