### PR TITLE
Optionally avoid Keycloak requests in provider setup

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ The following provider attributes are supported:
 - `username` (Optional) - The username of the user used by the provider for authentication via the password grant. Defaults to environment variable `KEYCLOAK_USER`. This attribute is required when using the password grant, and cannot be set when using the client credentials grant.
 - `password` (Optional) - The password of the user used by the provider for authentication via the password grant. Defaults to environment variable `KEYCLOAK_PASSWORD`. This attribute is required when using the password grant, and cannot be set when using the client credentials grant.
 - `realm` (Optional) - The realm used by the provider for authentication. Defaults to environment variable `KEYCLOAK_REALM`, or `master` if the environment variable is not specified.
+- `initial_login` (Optional) - Optionally avoid Keycloak login during provider setup, for when Keycloak itself is being provisioned by terraform. Defaults to true, which is the original method.
 
 #### Example (client credentials)
 

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -38,7 +38,7 @@ const (
 	tokenUrl = "%s/auth/realms/%s/protocol/openid-connect/token"
 )
 
-func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, password string) (*KeycloakClient, error) {
+func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, password string, initialLogin bool) (*KeycloakClient, error) {
 	httpClient := &http.Client{
 		Timeout: time.Second * 5,
 	}
@@ -60,10 +60,17 @@ func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, passwor
 		baseUrl:           baseUrl,
 		clientCredentials: clientCredentials,
 		httpClient:        httpClient,
-		initialLogin:      false,
+		initialLogin:      initialLogin,
 		realm:             realm,
 	}
 
+	if keycloakClient.initialLogin {
+		err := keycloakClient.login()
+		if err != nil {
+			return nil, "", fmt.Errorf("error logging in: %s", err)
+		}
+	}	
+	
 	return &keycloakClient, nil
 }
 

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -69,8 +69,8 @@ func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, passwor
 		if err != nil {
 			return nil, err
 		}
-	}	
-	
+	}
+
 	return &keycloakClient, nil
 }
 
@@ -186,7 +186,7 @@ func (keycloakClient *KeycloakClient) sendRequest(request *http.Request) ([]byte
 		if err != nil {
 			return nil, "", fmt.Errorf("error logging in: %s", err)
 		}
-	}	
+	}
 	requestMethod := request.Method
 	requestPath := request.URL.Path
 

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -67,7 +67,7 @@ func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, passwor
 	if keycloakClient.initialLogin {
 		err := keycloakClient.login()
 		if err != nil {
-			return nil, "", fmt.Errorf("error logging in: %s", err)
+			return nil, err
 		}
 	}	
 	

--- a/keycloak/keycloak_client_test.go
+++ b/keycloak/keycloak_client_test.go
@@ -44,7 +44,7 @@ func TestAccKeycloakApiClientRefresh(t *testing.T) {
 		defer log.SetOutput(os.Stdout)
 	}
 
-	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"))
+	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), true)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -90,7 +90,7 @@ func KeycloakProvider() *schema.Provider {
 				Type:        schema.TypeBool,
 				Description: "Whether or not to login to Keycloak instance on provider initialization",
 				Default:     true,
-			},			
+			},
 		},
 		ConfigureFunc: configureKeycloakProvider,
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -85,6 +85,12 @@ func KeycloakProvider() *schema.Provider {
 				Description: "The base URL of the Keycloak instance, before `/auth`",
 				DefaultFunc: schema.EnvDefaultFunc("KEYCLOAK_URL", nil),
 			},
+			"initial_login": {
+				Optional:    true,
+				Type:        schema.TypeBool,
+				Description: "Whether or not to login to Keycloak instance on provider initialization",
+				Default:     true,
+			},			
 		},
 		ConfigureFunc: configureKeycloakProvider,
 	}
@@ -97,5 +103,6 @@ func configureKeycloakProvider(data *schema.ResourceData) (interface{}, error) {
 	username := data.Get("username").(string)
 	password := data.Get("password").(string)
 	realm := data.Get("realm").(string)
-	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password)
+	initialLogin := data.Get("initial_login").(bool)
+	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password, initialLogin)
 }


### PR DESCRIPTION
An extension of #89, this adds the option to disable initial login, defaulting to false.  This will allow Keycloak itself to be provisioned via terraform and used as input to this provider.

Example:
```
data "helm_repository" "codecentric" {
  name = "codecentric"
  url  = "https://codecentric.github.io/helm-charts"
}

resource "helm_release" "keycloak" {
  repository = data.helm_repository.codecentric.metadata[0].name
  name       = "keycloak"
  namespace  = "keycloak"
  chart      = "keycloak"
  version    = "5.0.1"
}

resource "random_string" "keycloak_admin_password" {
  length  = 10
  special = false
}

provider "keycloak" {
  client_id     = "admin-cli"
  username      = "keycloak"
  password      = random_string.keycloak_admin_password.result
  url           = "http://keycloak.localhost"
  initial_login = false
}

resource "keycloak_realm" "realm" {
  depends_on = [helm_release.keycloak]
  realm  = "myrealm"
  enabled = true
}
```