### PR TITLE
Realm Password policies

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -51,7 +51,7 @@ resource "keycloak_realm" "test" {
 		}
 	}
 
-	password_policy = "upperCase(1) and length(8) and forceExpiredPasswordChange(365) and notUsernametwo()"
+	password_policy = "upperCase(1) and length(8) and forceExpiredPasswordChange(365) and notUsername"
 }
 
 resource "keycloak_required_action" "custom-terms-and-conditions" {

--- a/example/main.tf
+++ b/example/main.tf
@@ -9,7 +9,7 @@ resource "keycloak_realm" "test" {
 	enabled      = true
 	display_name = "foo"
 
-	smtp_server {
+	smtp_server = {
 		host                  = "mysmtphost.com"
 		port                  = 25
 		from_display_name     = "Tom"
@@ -20,7 +20,7 @@ resource "keycloak_realm" "test" {
 		starttls              = true
 		envelope_from         = "nottom@myhost.com"
 
-		auth {
+		auth  = {
 			username = "tom"
 			password = "tom"
 		}
@@ -30,7 +30,7 @@ resource "keycloak_realm" "test" {
 
 	access_code_lifespan = "30m"
 
-	internationalization {
+	internationalization = {
 		supported_locales = [
 			"en",
 			"de",
@@ -39,8 +39,8 @@ resource "keycloak_realm" "test" {
 		default_locale    = "en"
 	}
 
-	security_defenses {
-		headers {
+	security_defenses = {
+		headers = {
 			x_frame_options = "DENY"
 			content_security_policy = "frame-src 'self'; frame-ancestors 'self'; object-src 'none';"
 			content_security_policy_report_only = ""
@@ -50,6 +50,8 @@ resource "keycloak_realm" "test" {
 			strict_transport_security = "max-age=31536000; includeSubDomains"
 		}
 	}
+
+	password_policy = "upperCase(1) and length(8) and forceExpiredPasswordChange(365) and notUsernametwo()"
 }
 
 resource "keycloak_required_action" "custom-terms-and-conditions" {

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -310,6 +310,11 @@ func resourceKeycloakRealm() *schema.Resource {
 					},
 				},
 			},
+			"password_policy": {
+				Type:        schema.TypeString,
+				Description: "String that represents the passwordPolicies that are in place. Each policy is separated with \" and \". Supported policies can be found in the server-info providers page. example: \"upperCase(1) and length(8) and forceExpiredPasswordChange(365) and notUsername(undefined)\"",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -534,6 +539,10 @@ func getRealmFromData(data *schema.ResourceData) (*keycloak.Realm, error) {
 	} else {
 		setDefaultSecuritySettings(realm)
 	}
+
+	if passwordPolicy, ok := data.GetOk("password_policy"); ok {
+		realm.PasswordPolicy = passwordPolicy.(string)
+	}
 	return realm, nil
 }
 
@@ -647,6 +656,8 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm) {
 			data.Set("security_defenses", []interface{}{securityDefensesSettings})
 		}
 	}
+
+	data.Set("password_policy", realm.PasswordPolicy)
 }
 
 func resourceKeycloakRealmCreate(data *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Added Support for password policies.
It checks if the password policy provider is installed.
I did not change or wrap the syntax of the realm password policy string the keycloak API uses. 