### PR TITLE
Add keycloak_default_groups resource for creating realm default groups

### DIFF
--- a/docs/resources/keycloak_default_groups.md
+++ b/docs/resources/keycloak_default_groups.md
@@ -1,0 +1,42 @@
+# keycloak_default_groups
+
+Allows for managing a realm's default groups.
+
+Also note that you should not use `keycloak_default_groups` with a group with memberships managed
+by `keycloak_group_memberships`.
+
+### Example Usage
+
+```hcl
+resource "keycloak_realm" "realm" {
+    realm   = "my-realm"
+    enabled = true
+}
+
+resource "keycloak_group" "group" {
+    realm_id = "${keycloak_realm.realm.id}"
+    name     = "my-group"
+}
+
+resource "keycloak_default_groups" "default" {
+    realm_id  = "${keycloak_realm.realm.id}"
+    group_ids = ["${keycloak_group.group.id}"]
+} 
+```
+
+### Argument Reference
+
+The following arguments are supported:
+
+- `realm_id` - (Required) The realm this group exists in.
+- `group_ids` - (Required) A set of group ids that should be default groups on the realm referenced by `realm_id`.
+
+### Import
+
+Groups can be imported using the format `{{realm_id}}` where `realm_id` is the realm the group exists in.
+
+Example:
+
+```bash
+$ terraform import keycloak_default_groups.default my-realm
+```

--- a/docs/resources/keycloak_default_groups.md
+++ b/docs/resources/keycloak_default_groups.md
@@ -2,7 +2,7 @@
 
 Allows for managing a realm's default groups.
 
-Also note that you should not use `keycloak_default_groups` with a group with memberships managed
+Note that you should not use `keycloak_default_groups` with a group with memberships managed
 by `keycloak_group_memberships`.
 
 ### Example Usage

--- a/docs/resources/keycloak_group_memberships.md
+++ b/docs/resources/keycloak_group_memberships.md
@@ -8,6 +8,9 @@ to the group will be removed, and users that are manually removed from the group
 be added upon the next run of `terraform apply`.  Eventually, a non-authoritative resource
 for group membership will be added to this provider.
 
+Also note that you should not use `keycloak_group_memberships` with a group has been assigned
+as a default group via `keycloak_default_groups`.
+
 This resource **should not** be used to control membership of a group that has its members
 federated from an external source via group mapping.
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,595 +1,605 @@
 provider "keycloak" {
-	client_id     = "terraform"
-	client_secret = "884e0f95-0f42-4a63-9b1f-94274655669e"
-	url           = "http://localhost:8080"
+  client_id     = "terraform"
+  client_secret = "884e0f95-0f42-4a63-9b1f-94274655669e"
+  url           = "http://localhost:8080"
 }
 
 resource "keycloak_realm" "test" {
-	realm        = "test"
-	enabled      = true
-	display_name = "foo"
+  realm        = "test"
+  enabled      = true
+  display_name = "foo"
 
-	smtp_server = {
-		host                  = "mysmtphost.com"
-		port                  = 25
-		from_display_name     = "Tom"
-		from                  = "tom@myhost.com"
-		reply_to_display_name = "Tom"
-		reply_to              = "tom@myhost.com"
-		ssl                   = true
-		starttls              = true
-		envelope_from         = "nottom@myhost.com"
+  smtp_server = {
+    host                  = "mysmtphost.com"
+    port                  = 25
+    from_display_name     = "Tom"
+    from                  = "tom@myhost.com"
+    reply_to_display_name = "Tom"
+    reply_to              = "tom@myhost.com"
+    ssl                   = true
+    starttls              = true
+    envelope_from         = "nottom@myhost.com"
 
-		auth  = {
-			username = "tom"
-			password = "tom"
-		}
-	}
+    auth = {
+      username = "tom"
+      password = "tom"
+    }
+  }
 
-  	account_theme = "base"
+  account_theme = "base"
 
-	access_code_lifespan = "30m"
+  access_code_lifespan = "30m"
 
-	internationalization = {
-		supported_locales = [
-			"en",
-			"de",
-			"es"
-		]
-		default_locale    = "en"
-	}
+  internationalization = {
+    supported_locales = [
+      "en",
+      "de",
+      "es"
+    ]
+    default_locale = "en"
+  }
 
-	security_defenses = {
-		headers = {
-			x_frame_options = "DENY"
-			content_security_policy = "frame-src 'self'; frame-ancestors 'self'; object-src 'none';"
-			content_security_policy_report_only = ""
-			x_content_type_options = "nosniff"
-			x_robots_tag = "none"
-			x_xss_protection = "1; mode=block"
-			strict_transport_security = "max-age=31536000; includeSubDomains"
-		}
-	}
+  security_defenses = {
+    headers = {
+      x_frame_options                     = "DENY"
+      content_security_policy             = "frame-src 'self'; frame-ancestors 'self'; object-src 'none';"
+      content_security_policy_report_only = ""
+      x_content_type_options              = "nosniff"
+      x_robots_tag                        = "none"
+      x_xss_protection                    = "1; mode=block"
+      strict_transport_security           = "max-age=31536000; includeSubDomains"
+    }
+  }
 
-	password_policy = "upperCase(1) and length(8) and forceExpiredPasswordChange(365) and notUsername"
+  password_policy = "upperCase(1) and length(8) and forceExpiredPasswordChange(365) and notUsername"
 }
 
 resource "keycloak_required_action" "custom-terms-and-conditions" {
-	realm_id		= "${keycloak_realm.test.realm}"
-	alias			= "terms_and_conditions"
-	default_action 	= true
-	enabled			= true
-	name			= "Custom Terms and Conditions"
+  realm_id       = "${keycloak_realm.test.realm}"
+  alias          = "terms_and_conditions"
+  default_action = true
+  enabled        = true
+  name           = "Custom Terms and Conditions"
 }
 
 resource "keycloak_required_action" "custom-configured_totp" {
-	realm_id		= "${keycloak_realm.test.realm}"
-	alias			= "CONFIGURE_TOTP"
-	default_action 	= true
-	enabled			= true
-	name			= "Custom configure totp"
-	priority		= "${keycloak_required_action.custom-terms-and-conditions.priority+15}"
+  realm_id       = "${keycloak_realm.test.realm}"
+  alias          = "CONFIGURE_TOTP"
+  default_action = true
+  enabled        = true
+  name           = "Custom configure totp"
+  priority       = "${keycloak_required_action.custom-terms-and-conditions.priority + 15}"
 }
 
 resource "keycloak_group" "foo" {
-	realm_id = "${keycloak_realm.test.id}"
-	name     = "foo"
+  realm_id = "${keycloak_realm.test.id}"
+  name     = "foo"
 }
 
 resource "keycloak_group" "nested_foo" {
-	realm_id  = "${keycloak_realm.test.id}"
-	parent_id = "${keycloak_group.foo.id}"
-	name      = "nested-foo"
+  realm_id  = "${keycloak_realm.test.id}"
+  parent_id = "${keycloak_group.foo.id}"
+  name      = "nested-foo"
 }
 
 resource "keycloak_group" "bar" {
-	realm_id = "${keycloak_realm.test.id}"
-	name     = "bar"
+  realm_id = "${keycloak_realm.test.id}"
+  name     = "bar"
 }
 
 resource "keycloak_user" "user" {
-	realm_id = "${keycloak_realm.test.id}"
-	username = "test-user"
+  realm_id = "${keycloak_realm.test.id}"
+  username = "test-user"
 
-	email      = "test-user@fakedomain.com"
-	first_name = "Testy"
-	last_name  = "Tester"
+  email      = "test-user@fakedomain.com"
+  first_name = "Testy"
+  last_name  = "Tester"
 }
 
 resource "keycloak_user" "another_user" {
-	realm_id = "${keycloak_realm.test.id}"
-	username = "another-test-user"
+  realm_id = "${keycloak_realm.test.id}"
+  username = "another-test-user"
 
-	email      = "another-test-user@fakedomain.com"
-	first_name = "Testy"
-	last_name  = "Tester"
+  email      = "another-test-user@fakedomain.com"
+  first_name = "Testy"
+  last_name  = "Tester"
 }
 
 resource "keycloak_user" "user_with_password" {
-	realm_id = "${keycloak_realm.test.id}"
-	username = "user-with-password"
+  realm_id = "${keycloak_realm.test.id}"
+  username = "user-with-password"
 
-	email      = "user-with-password@fakedomain.com"
-	first_name = "Testy"
-	last_name  = "Tester"
+  email      = "user-with-password@fakedomain.com"
+  first_name = "Testy"
+  last_name  = "Tester"
 
-	initial_password {
-		value     = "my password"
-		temporary = false
-	}
+  initial_password {
+    value     = "my password"
+    temporary = false
+  }
 }
 
 resource "keycloak_group_memberships" "foo_members" {
-	realm_id = "${keycloak_realm.test.id}"
-	group_id = "${keycloak_group.foo.id}"
+  realm_id = "${keycloak_realm.test.id}"
+  group_id = "${keycloak_group.foo.id}"
 
-	members = [
-		"${keycloak_user.user.username}",
-		"${keycloak_user.another_user.username}",
-	]
+  members = [
+    "${keycloak_user.user.username}",
+    "${keycloak_user.another_user.username}",
+  ]
+}
+
+resource "keycloak_group" "baz" {
+  realm_id = "${keycloak_realm.test.id}"
+  name     = "baz"
+}
+
+resource "keycloak_default_groups" "default" {
+  realm_id  = "${keycloak_realm.test.id}"
+  group_ids = ["${keycloak_group.baz.id}"]
 }
 
 resource "keycloak_openid_client" "test_client" {
-	client_id   = "test-openid-client"
-	name        = "test-openid-client"
-	realm_id    = "${keycloak_realm.test.id}"
-	description = "a test openid client"
+  client_id   = "test-openid-client"
+  name        = "test-openid-client"
+  realm_id    = "${keycloak_realm.test.id}"
+  description = "a test openid client"
 
-	standard_flow_enabled = true
+  standard_flow_enabled = true
 
-	access_type = "CONFIDENTIAL"
+  access_type = "CONFIDENTIAL"
 
-	valid_redirect_uris = [
-		"http://localhost:5555/callback",
-	]
+  valid_redirect_uris = [
+    "http://localhost:5555/callback",
+  ]
 
-	client_secret = "secret"
+  client_secret = "secret"
 }
 
 resource "keycloak_openid_client_scope" "test_default_client_scope" {
-	name     = "test-default-client-scope"
-	realm_id = "${keycloak_realm.test.id}"
+  name     = "test-default-client-scope"
+  realm_id = "${keycloak_realm.test.id}"
 
-	description         = "test"
-	consent_screen_text = "hello"
+  description         = "test"
+  consent_screen_text = "hello"
 }
 
 resource "keycloak_openid_client_scope" "test_optional_client_scope" {
-	name     = "test-optional-client-scope"
-	realm_id = "${keycloak_realm.test.id}"
+  name     = "test-optional-client-scope"
+  realm_id = "${keycloak_realm.test.id}"
 
-	description         = "test"
-	consent_screen_text = "hello"
+  description         = "test"
+  consent_screen_text = "hello"
 }
 
 resource "keycloak_openid_client_default_scopes" "default_client_scopes" {
-	realm_id  = "${keycloak_realm.test.id}"
-	client_id = "${keycloak_openid_client.test_client.id}"
+  realm_id  = "${keycloak_realm.test.id}"
+  client_id = "${keycloak_openid_client.test_client.id}"
 
-	default_scopes = [
-		"profile",
-		"email",
-		"roles",
-		"web-origins",
-		"${keycloak_openid_client_scope.test_default_client_scope.name}",
-	]
+  default_scopes = [
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "${keycloak_openid_client_scope.test_default_client_scope.name}",
+  ]
 }
 
 resource "keycloak_openid_client_optional_scopes" "optional_client_scopes" {
-	realm_id  = "${keycloak_realm.test.id}"
-	client_id = "${keycloak_openid_client.test_client.id}"
+  realm_id  = "${keycloak_realm.test.id}"
+  client_id = "${keycloak_openid_client.test_client.id}"
 
-	optional_scopes = [
-		"address",
-		"phone",
-		"offline_access",
-		"${keycloak_openid_client_scope.test_optional_client_scope.name}",
-	]
+  optional_scopes = [
+    "address",
+    "phone",
+    "offline_access",
+    "${keycloak_openid_client_scope.test_optional_client_scope.name}",
+  ]
 }
 
 resource "keycloak_ldap_user_federation" "openldap" {
-	name     = "openldap"
-	realm_id = "${keycloak_realm.test.id}"
+  name     = "openldap"
+  realm_id = "${keycloak_realm.test.id}"
 
-	enabled        = true
-	import_enabled = false
+  enabled        = true
+  import_enabled = false
 
-	username_ldap_attribute = "cn"
-	rdn_ldap_attribute      = "cn"
-	uuid_ldap_attribute     = "entryDN"
+  username_ldap_attribute = "cn"
+  rdn_ldap_attribute      = "cn"
+  uuid_ldap_attribute     = "entryDN"
 
-	user_object_classes = [
-		"simpleSecurityObject",
-		"organizationalRole",
-	]
+  user_object_classes = [
+    "simpleSecurityObject",
+    "organizationalRole",
+  ]
 
-	connection_url  = "ldap://openldap"
-	users_dn        = "dc=example,dc=org"
-	bind_dn         = "cn=admin,dc=example,dc=org"
-	bind_credential = "admin"
+  connection_url  = "ldap://openldap"
+  users_dn        = "dc=example,dc=org"
+  bind_dn         = "cn=admin,dc=example,dc=org"
+  bind_credential = "admin"
 
-	connection_timeout = "5s"
-	read_timeout       = "10s"
+  connection_timeout = "5s"
+  read_timeout       = "10s"
 
-	cache_policy = "NO_CACHE"
+  cache_policy = "NO_CACHE"
 }
 
 resource "keycloak_ldap_user_attribute_mapper" "description_attr_mapper" {
-	name                    = "description-mapper"
-	realm_id                = "${keycloak_ldap_user_federation.openldap.realm_id}"
-	ldap_user_federation_id = "${keycloak_ldap_user_federation.openldap.id}"
+  name                    = "description-mapper"
+  realm_id                = "${keycloak_ldap_user_federation.openldap.realm_id}"
+  ldap_user_federation_id = "${keycloak_ldap_user_federation.openldap.id}"
 
-	user_model_attribute = "description"
-	ldap_attribute       = "description"
+  user_model_attribute = "description"
+  ldap_attribute       = "description"
 
-	always_read_value_from_ldap = false
+  always_read_value_from_ldap = false
 }
 
 resource "keycloak_ldap_group_mapper" "group_mapper" {
-	name                    = "group mapper"
-	realm_id                = "${keycloak_ldap_user_federation.openldap.realm_id}"
-	ldap_user_federation_id = "${keycloak_ldap_user_federation.openldap.id}"
+  name                    = "group mapper"
+  realm_id                = "${keycloak_ldap_user_federation.openldap.realm_id}"
+  ldap_user_federation_id = "${keycloak_ldap_user_federation.openldap.id}"
 
-	ldap_groups_dn            = "dc=example,dc=org"
-	group_name_ldap_attribute = "cn"
+  ldap_groups_dn            = "dc=example,dc=org"
+  group_name_ldap_attribute = "cn"
 
-	group_object_classes = [
-		"groupOfNames",
-	]
+  group_object_classes = [
+    "groupOfNames",
+  ]
 
-	membership_attribute_type      = "DN"
-	membership_ldap_attribute      = "member"
-	membership_user_ldap_attribute = "cn"
-	memberof_ldap_attribute        = "memberOf"
+  membership_attribute_type      = "DN"
+  membership_ldap_attribute      = "member"
+  membership_user_ldap_attribute = "cn"
+  memberof_ldap_attribute        = "memberOf"
 }
 
 resource "keycloak_ldap_msad_user_account_control_mapper" "msad_uac_mapper" {
-	name                    = "uac-mapper1"
-	realm_id                = "${keycloak_ldap_user_federation.openldap.realm_id}"
-	ldap_user_federation_id = "${keycloak_ldap_user_federation.openldap.id}"
+  name                    = "uac-mapper1"
+  realm_id                = "${keycloak_ldap_user_federation.openldap.realm_id}"
+  ldap_user_federation_id = "${keycloak_ldap_user_federation.openldap.id}"
 }
 
 resource "keycloak_ldap_full_name_mapper" "full_name_mapper" {
-	name                    = "full-name-mapper"
-	realm_id                = "${keycloak_ldap_user_federation.openldap.realm_id}"
-	ldap_user_federation_id = "${keycloak_ldap_user_federation.openldap.id}"
+  name                    = "full-name-mapper"
+  realm_id                = "${keycloak_ldap_user_federation.openldap.realm_id}"
+  ldap_user_federation_id = "${keycloak_ldap_user_federation.openldap.id}"
 
-	ldap_full_name_attribute = "cn"
-	read_only                = true
+  ldap_full_name_attribute = "cn"
+  read_only                = true
 }
 
 resource "keycloak_custom_user_federation" "custom" {
-	name        = "custom1"
-	realm_id    = "master"
-	provider_id = "custom"
+  name        = "custom1"
+  realm_id    = "master"
+  provider_id = "custom"
 
-	enabled = true
+  enabled = true
 }
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "map_user_attributes_client" {
-	name           = "tf-test-open-id-user-attribute-protocol-mapper-client"
-	realm_id       = "${keycloak_realm.test.id}"
-	client_id      = "${keycloak_openid_client.test_client.id}"
-	user_attribute = "description"
-	claim_name     = "description"
+  name           = "tf-test-open-id-user-attribute-protocol-mapper-client"
+  realm_id       = "${keycloak_realm.test.id}"
+  client_id      = "${keycloak_openid_client.test_client.id}"
+  user_attribute = "description"
+  claim_name     = "description"
 }
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "map_user_attributes_client_scope" {
-	name            = "tf-test-open-id-user-attribute-protocol-mapper-client-scope"
-	realm_id        = "${keycloak_realm.test.id}"
-	client_scope_id = "${keycloak_openid_client_scope.test_default_client_scope.id}"
-	user_attribute  = "foo2"
-	claim_name      = "bar2"
+  name            = "tf-test-open-id-user-attribute-protocol-mapper-client-scope"
+  realm_id        = "${keycloak_realm.test.id}"
+  client_scope_id = "${keycloak_openid_client_scope.test_default_client_scope.id}"
+  user_attribute  = "foo2"
+  claim_name      = "bar2"
 }
 
 resource "keycloak_openid_group_membership_protocol_mapper" "map_group_memberships_client" {
-	name       = "tf-test-open-id-group-membership-protocol-mapper-client"
-	realm_id   = "${keycloak_realm.test.id}"
-	client_id  = "${keycloak_openid_client.test_client.id}"
-	claim_name = "bar"
+  name       = "tf-test-open-id-group-membership-protocol-mapper-client"
+  realm_id   = "${keycloak_realm.test.id}"
+  client_id  = "${keycloak_openid_client.test_client.id}"
+  claim_name = "bar"
 }
 
 resource "keycloak_openid_group_membership_protocol_mapper" "map_group_memberships_client_scope" {
-	name            = "tf-test-open-id-group-membership-protocol-mapper-client-scope"
-	realm_id        = "${keycloak_realm.test.id}"
-	client_scope_id = "${keycloak_openid_client_scope.test_optional_client_scope.id}"
-	claim_name      = "bar2"
+  name            = "tf-test-open-id-group-membership-protocol-mapper-client-scope"
+  realm_id        = "${keycloak_realm.test.id}"
+  client_scope_id = "${keycloak_openid_client_scope.test_optional_client_scope.id}"
+  claim_name      = "bar2"
 }
 
 resource "keycloak_openid_full_name_protocol_mapper" "map_full_names_client" {
-	name      = "tf-test-open-id-full-name-protocol-mapper-client"
-	realm_id  = "${keycloak_realm.test.id}"
-	client_id = "${keycloak_openid_client.test_client.id}"
+  name      = "tf-test-open-id-full-name-protocol-mapper-client"
+  realm_id  = "${keycloak_realm.test.id}"
+  client_id = "${keycloak_openid_client.test_client.id}"
 }
 
 resource "keycloak_openid_full_name_protocol_mapper" "map_full_names_client_scope" {
-	name            = "tf-test-open-id-full-name-protocol-mapper-client-scope"
-	realm_id        = "${keycloak_realm.test.id}"
-	client_scope_id = "${keycloak_openid_client_scope.test_default_client_scope.id}"
+  name            = "tf-test-open-id-full-name-protocol-mapper-client-scope"
+  realm_id        = "${keycloak_realm.test.id}"
+  client_scope_id = "${keycloak_openid_client_scope.test_default_client_scope.id}"
 }
 
 resource "keycloak_openid_user_property_protocol_mapper" "map_user_properties_client" {
-	name          = "tf-test-open-id-user-property-protocol-mapper-client"
-	realm_id      = "${keycloak_realm.test.id}"
-	client_id     = "${keycloak_openid_client.test_client.id}"
-	user_property = "foo"
-	claim_name    = "bar"
+  name          = "tf-test-open-id-user-property-protocol-mapper-client"
+  realm_id      = "${keycloak_realm.test.id}"
+  client_id     = "${keycloak_openid_client.test_client.id}"
+  user_property = "foo"
+  claim_name    = "bar"
 }
 
 resource "keycloak_openid_user_property_protocol_mapper" "map_user_properties_client_scope" {
-	name            = "tf-test-open-id-user-property-protocol-mapper-client-scope"
-	realm_id        = "${keycloak_realm.test.id}"
-	client_scope_id = "${keycloak_openid_client_scope.test_optional_client_scope.id}"
-	user_property   = "foo2"
-	claim_name      = "bar2"
+  name            = "tf-test-open-id-user-property-protocol-mapper-client-scope"
+  realm_id        = "${keycloak_realm.test.id}"
+  client_scope_id = "${keycloak_openid_client_scope.test_optional_client_scope.id}"
+  user_property   = "foo2"
+  claim_name      = "bar2"
 }
 
 resource "keycloak_openid_hardcoded_claim_protocol_mapper" "hardcoded_claim_client" {
-	name      = "tf-test-open-id-hardcoded-claim-protocol-mapper-client"
-	realm_id  = "${keycloak_realm.test.id}"
-	client_id = "${keycloak_openid_client.test_client.id}"
+  name      = "tf-test-open-id-hardcoded-claim-protocol-mapper-client"
+  realm_id  = "${keycloak_realm.test.id}"
+  client_id = "${keycloak_openid_client.test_client.id}"
 
-	claim_name  = "foo"
-	claim_value = "bar"
+  claim_name  = "foo"
+  claim_value = "bar"
 }
 
 resource "keycloak_openid_hardcoded_claim_protocol_mapper" "hardcoded_claim_client_scope" {
-	name            = "tf-test-open-id-hardcoded-claim-protocol-mapper-client-scope"
-	realm_id        = "${keycloak_realm.test.id}"
-	client_scope_id = "${keycloak_openid_client_scope.test_default_client_scope.id}"
+  name            = "tf-test-open-id-hardcoded-claim-protocol-mapper-client-scope"
+  realm_id        = "${keycloak_realm.test.id}"
+  client_scope_id = "${keycloak_openid_client_scope.test_default_client_scope.id}"
 
-	claim_name  = "foo"
-	claim_value = "bar"
+  claim_name  = "foo"
+  claim_value = "bar"
 }
 
 resource "keycloak_openid_client" "bearer_only_client" {
-	client_id   = "test-bearer-only-client"
-	name        = "test-bearer-only-client"
-	realm_id    = "${keycloak_realm.test.id}"
-	description = "a test openid client using bearer-only"
+  client_id   = "test-bearer-only-client"
+  name        = "test-bearer-only-client"
+  realm_id    = "${keycloak_realm.test.id}"
+  description = "a test openid client using bearer-only"
 
-	access_type = "BEARER-ONLY"
+  access_type = "BEARER-ONLY"
 }
 
 resource "keycloak_openid_audience_protocol_mapper" "audience_client_scope" {
-	name            = "tf-test-openid-audience-protocol-mapper-client-scope"
-	realm_id        = "${keycloak_realm.test.id}"
-	client_scope_id = "${keycloak_openid_client_scope.test_default_client_scope.id}"
+  name            = "tf-test-openid-audience-protocol-mapper-client-scope"
+  realm_id        = "${keycloak_realm.test.id}"
+  client_scope_id = "${keycloak_openid_client_scope.test_default_client_scope.id}"
 
-	add_to_id_token     = true
-	add_to_access_token = false
+  add_to_id_token     = true
+  add_to_access_token = false
 
-	included_client_audience = "${keycloak_openid_client.bearer_only_client.client_id}"
+  included_client_audience = "${keycloak_openid_client.bearer_only_client.client_id}"
 }
 
 resource "keycloak_openid_audience_protocol_mapper" "audience_client" {
-	name      = "tf-test-openid-audience-protocol-mapper-client"
-	realm_id  = "${keycloak_realm.test.id}"
-	client_id = "${keycloak_openid_client.test_client.id}"
+  name      = "tf-test-openid-audience-protocol-mapper-client"
+  realm_id  = "${keycloak_realm.test.id}"
+  client_id = "${keycloak_openid_client.test_client.id}"
 
-	add_to_id_token     = false
-	add_to_access_token = true
+  add_to_id_token     = false
+  add_to_access_token = true
 
-	included_custom_audience = "foo"
+  included_custom_audience = "foo"
 }
 
 resource "keycloak_saml_client" "saml_client" {
-	realm_id  = "${keycloak_realm.test.id}"
-	client_id = "test-saml-client"
-	name      = "test-saml-client"
+  realm_id  = "${keycloak_realm.test.id}"
+  client_id = "test-saml-client"
+  name      = "test-saml-client"
 
-	sign_documents          = false
-	sign_assertions         = true
-	include_authn_statement = true
+  sign_documents          = false
+  sign_assertions         = true
+  include_authn_statement = true
 
-	signing_certificate = "${file("../provider/misc/saml-cert.pem")}"
-	signing_private_key = "${file("../provider/misc/saml-key.pem")}"
+  signing_certificate = "${file("../provider/misc/saml-cert.pem")}"
+  signing_private_key = "${file("../provider/misc/saml-key.pem")}"
 }
 
 resource "keycloak_saml_user_attribute_protocol_mapper" "saml_user_attribute_mapper" {
-	realm_id  = "${keycloak_realm.test.id}"
-	client_id = "${keycloak_saml_client.saml_client.id}"
-	name      = "test-saml-user-attribute-mapper"
+  realm_id  = "${keycloak_realm.test.id}"
+  client_id = "${keycloak_saml_client.saml_client.id}"
+  name      = "test-saml-user-attribute-mapper"
 
-	user_attribute             = "user-attribute"
-	friendly_name              = "friendly-name"
-	saml_attribute_name        = "saml-attribute-name"
-	saml_attribute_name_format = "Unspecified"
+  user_attribute             = "user-attribute"
+  friendly_name              = "friendly-name"
+  saml_attribute_name        = "saml-attribute-name"
+  saml_attribute_name_format = "Unspecified"
 }
 
 resource "keycloak_saml_user_property_protocol_mapper" "saml_user_property_mapper" {
-	realm_id  = "${keycloak_realm.test.id}"
-	client_id = "${keycloak_saml_client.saml_client.id}"
-	name      = "test-saml-user-property-mapper"
+  realm_id  = "${keycloak_realm.test.id}"
+  client_id = "${keycloak_saml_client.saml_client.id}"
+  name      = "test-saml-user-property-mapper"
 
-	user_property              = "email"
-	saml_attribute_name        = "email"
-	saml_attribute_name_format = "Unspecified"
+  user_property              = "email"
+  saml_attribute_name        = "email"
+  saml_attribute_name_format = "Unspecified"
 }
 
 resource keycloak_oidc_identity_provider oidc {
-	realm             = "${keycloak_realm.test.id}"
-	alias             = "oidc"
-	authorization_url = "https://example.com/auth"
-	token_url         = "https://example.com/token"
-	client_id         = "example_id"
-	client_secret     = "example_token"
+  realm             = "${keycloak_realm.test.id}"
+  alias             = "oidc"
+  authorization_url = "https://example.com/auth"
+  token_url         = "https://example.com/token"
+  client_id         = "example_id"
+  client_secret     = "example_token"
 }
 
 resource keycloak_oidc_identity_provider custom_oidc_idp {
-	realm             = "${keycloak_realm.test.id}"
-	provider_id		  = "customIdp"
-	alias             = "custom"
-	authorization_url = "https://example.com/auth"
-	token_url         = "https://example.com/token"
-	client_id         = "example_id"
-	client_secret     = "example_token"
-	extra_config = {
-		dummyConfig = "dummyValue"
-	}
+  realm             = "${keycloak_realm.test.id}"
+  provider_id       = "customIdp"
+  alias             = "custom"
+  authorization_url = "https://example.com/auth"
+  token_url         = "https://example.com/token"
+  client_id         = "example_id"
+  client_secret     = "example_token"
+  extra_config = {
+    dummyConfig = "dummyValue"
+  }
 }
 
 resource keycloak_attribute_importer_identity_provider_mapper oidc {
-	realm                   = "${keycloak_realm.test.id}"
-	name                    = "attributeImporter"
-	claim_name              = "upn"
-	identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
-	user_attribute          = "email"
+  realm                   = "${keycloak_realm.test.id}"
+  name                    = "attributeImporter"
+  claim_name              = "upn"
+  identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
+  user_attribute          = "email"
 }
 
 resource keycloak_attribute_to_role_identity_provider_mapper oidc {
-	realm                   = "${keycloak_realm.test.id}"
-	name                    = "attributeToRole"
-	claim_name              = "upn"
-	identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
-	claim_value             = "value"
-	role                    = "testRole"
+  realm                   = "${keycloak_realm.test.id}"
+  name                    = "attributeToRole"
+  claim_name              = "upn"
+  identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
+  claim_value             = "value"
+  role                    = "testRole"
 }
 
 resource keycloak_user_template_importer_identity_provider_mapper oidc {
-	realm                   = "${keycloak_realm.test.id}"
-	name                    = "userTemplate"
-	identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
-	template                = "$${ALIAS}/$${CLAIM.upn}"
+  realm                   = "${keycloak_realm.test.id}"
+  name                    = "userTemplate"
+  identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
+  template                = "$${ALIAS}/$${CLAIM.upn}"
 }
 
 resource keycloak_hardcoded_role_identity_provider_mapper oidc {
-	realm                   = "${keycloak_realm.test.id}"
-	name                    = "hardcodedRole"
-	identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
-	role                    = "testrole"
+  realm                   = "${keycloak_realm.test.id}"
+  name                    = "hardcodedRole"
+  identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
+  role                    = "testrole"
 }
 
 resource keycloak_hardcoded_attribute_identity_provider_mapper oidc {
-	realm                   = "${keycloak_realm.test.id}"
-	name                    = "hardcodedUserSessionAttribute"
-	identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
-	attribute_name          = "attribute"
-	attribute_value         = "value"
-	user_session            = true
+  realm                   = "${keycloak_realm.test.id}"
+  name                    = "hardcodedUserSessionAttribute"
+  identity_provider_alias = "${keycloak_oidc_identity_provider.oidc.alias}"
+  attribute_name          = "attribute"
+  attribute_value         = "value"
+  user_session            = true
 }
 
 resource keycloak_saml_identity_provider saml {
-	realm                      = "${keycloak_realm.test.id}"
-	alias                      = "saml"
-	single_sign_on_service_url = "https://example.com/auth"
+  realm                      = "${keycloak_realm.test.id}"
+  alias                      = "saml"
+  single_sign_on_service_url = "https://example.com/auth"
 }
 
 resource keycloak_attribute_importer_identity_provider_mapper saml {
-	realm                   = "${keycloak_realm.test.id}"
-	name                    = "Attribute: email"
-	attribute_name          = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
-	identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
-	user_attribute          = "email"
+  realm                   = "${keycloak_realm.test.id}"
+  name                    = "Attribute: email"
+  attribute_name          = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+  identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
+  user_attribute          = "email"
 }
 
 resource keycloak_attribute_to_role_identity_provider_mapper saml {
-	realm                   = "${keycloak_realm.test.id}"
-	name                    = "attributeToRole"
-	attribute_name          = "upn"
-	identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
-	attribute_value         = "value"
-	role                    = "testRole"
+  realm                   = "${keycloak_realm.test.id}"
+  name                    = "attributeToRole"
+  attribute_name          = "upn"
+  identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
+  attribute_value         = "value"
+  role                    = "testRole"
 }
 
 resource keycloak_user_template_importer_identity_provider_mapper saml {
-	realm                   = "${keycloak_realm.test.id}"
-	name                    = "userTemplate"
-	identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
-	template                = "$${ALIAS}/$${NAMEID}"
+  realm                   = "${keycloak_realm.test.id}"
+  name                    = "userTemplate"
+  identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
+  template                = "$${ALIAS}/$${NAMEID}"
 }
 
 resource keycloak_hardcoded_role_identity_provider_mapper saml {
-	realm                   = "${keycloak_realm.test.id}"
-	name                    = "hardcodedRole"
-	identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
-	role                    = "testrole"
+  realm                   = "${keycloak_realm.test.id}"
+  name                    = "hardcodedRole"
+  identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
+  role                    = "testrole"
 }
 
 resource keycloak_hardcoded_attribute_identity_provider_mapper saml {
-	realm                   = "${keycloak_realm.test.id}"
-	name                    = "hardcodedAttribute"
-	identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
-	attribute_name          = "attribute"
-	attribute_value         = "value"
-	user_session            = false
+  realm                   = "${keycloak_realm.test.id}"
+  name                    = "hardcodedAttribute"
+  identity_provider_alias = "${keycloak_saml_identity_provider.saml.alias}"
+  attribute_name          = "attribute"
+  attribute_value         = "value"
+  user_session            = false
 }
 
 data "keycloak_openid_client" "broker" {
-	realm_id  = "${keycloak_realm.test.id}"
-	client_id = "broker"
+  realm_id  = "${keycloak_realm.test.id}"
+  client_id = "broker"
 }
 
 data "keycloak_openid_client_authorization_policy" "default" {
-	realm_id           = "${keycloak_realm.test.id}"
-	resource_server_id = "${keycloak_openid_client.test_client_auth.resource_server_id}"
-	name               = "default"
+  realm_id           = "${keycloak_realm.test.id}"
+  resource_server_id = "${keycloak_openid_client.test_client_auth.resource_server_id}"
+  name               = "default"
 }
 
 resource "keycloak_openid_client" "test_client_auth" {
-	client_id   = "test-client-auth"
-	name        = "test-client-auth"
-	realm_id    = "${keycloak_realm.test.id}"
-	description = "a test openid client"
+  client_id   = "test-client-auth"
+  name        = "test-client-auth"
+  realm_id    = "${keycloak_realm.test.id}"
+  description = "a test openid client"
 
-	access_type                  = "CONFIDENTIAL"
-	direct_access_grants_enabled = true
-	implicit_flow_enabled        = true
-	service_accounts_enabled     = true
+  access_type                  = "CONFIDENTIAL"
+  direct_access_grants_enabled = true
+  implicit_flow_enabled        = true
+  service_accounts_enabled     = true
 
-	valid_redirect_uris = [
-		"http://localhost:5555/callback",
-	]
+  valid_redirect_uris = [
+    "http://localhost:5555/callback",
+  ]
 
-	authorization {
-		policy_enforcement_mode = "ENFORCING"
-	}
+  authorization {
+    policy_enforcement_mode = "ENFORCING"
+  }
 
-	client_secret = "secret"
+  client_secret = "secret"
 }
 
 resource "keycloak_openid_client_authorization_permission" "resource" {
-	resource_server_id = "${keycloak_openid_client.test_client_auth.resource_server_id}"
-	realm_id           = "${keycloak_realm.test.id}"
-	name               = "test"
-	policies           = [
-		"${data.keycloak_openid_client_authorization_policy.default.id}"]
-	resources          = [
-		"${keycloak_openid_client_authorization_resource.resource.id}"]
+  resource_server_id = "${keycloak_openid_client.test_client_auth.resource_server_id}"
+  realm_id           = "${keycloak_realm.test.id}"
+  name               = "test"
+  policies = [
+  "${data.keycloak_openid_client_authorization_policy.default.id}"]
+  resources = [
+  "${keycloak_openid_client_authorization_resource.resource.id}"]
 }
 
 resource "keycloak_openid_client_authorization_resource" "resource" {
-	resource_server_id = "${keycloak_openid_client.test_client_auth.resource_server_id}"
-	name               = "test-openid-client1"
-	realm_id           = "${keycloak_realm.test.id}"
+  resource_server_id = "${keycloak_openid_client.test_client_auth.resource_server_id}"
+  name               = "test-openid-client1"
+  realm_id           = "${keycloak_realm.test.id}"
 
-	uris = [
-		"/endpoint/*"
-	]
+  uris = [
+    "/endpoint/*"
+  ]
 
-	attributes = {
-		"asdads" = "asdasd"
-	}
+  attributes = {
+    "asdads" = "asdasd"
+  }
 }
 
 resource "keycloak_openid_client_authorization_scope" "resource" {
-	resource_server_id = "${keycloak_openid_client.test_client_auth.resource_server_id}"
-	name               = "test-openid-client1"
-	realm_id           = "${keycloak_realm.test.id}"
+  resource_server_id = "${keycloak_openid_client.test_client_auth.resource_server_id}"
+  name               = "test-openid-client1"
+  realm_id           = "${keycloak_realm.test.id}"
 }
 
 resource "keycloak_user" "resource" {
-	realm_id = "${keycloak_realm.test.id}"
-	username = "test"
+  realm_id = "${keycloak_realm.test.id}"
+  username = "test"
 
-	attributes = {
-		"key" = "value"
-	}
+  attributes = {
+    "key" = "value"
+  }
 }
 
 resource "keycloak_openid_client_service_account_role" "read_token" {
-	realm_id                = "${keycloak_realm.test.id}"
-	client_id               = "${data.keycloak_openid_client.broker.id}"
-	service_account_user_id = "${keycloak_openid_client.test_client_auth.service_account_user_id}"
-	role                    = "read-token"
+  realm_id                = "${keycloak_realm.test.id}"
+  client_id               = "${data.keycloak_openid_client.broker.id}"
+  service_account_user_id = "${keycloak_openid_client.test_client_auth.service_account_user_id}"
+  role                    = "read-token"
 }

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,3 @@ require (
 	github.com/hashicorp/terraform v0.12.1
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/hashicorp/terraform v0.12.1
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 )
+
+go 1.13

--- a/keycloak/group.go
+++ b/keycloak/group.go
@@ -145,3 +145,30 @@ func (keycloakClient *KeycloakClient) GetGroupMembers(realmId, groupId string) (
 
 	return users, nil
 }
+
+func defaultGroupURL(realmName, groupId string) string {
+	return fmt.Sprintf("/realms/%s/default-groups/%s", realmName, groupId)
+}
+
+// PutDefaultGroup will PUT a new group ID to the realm default groups. This is effectively
+// an "upsert".
+func (keycloakClient *KeycloakClient) PutDefaultGroup(realmName, groupId string) error {
+	url := defaultGroupURL(realmName, groupId)
+	return keycloakClient.put(url, nil)
+}
+
+// DeleteDefaultGroup deletes a group ID from the realm default groups.
+func (keycloakClient *KeycloakClient) DeleteDefaultGroup(realmName, groupId string) error {
+	url := defaultGroupURL(realmName, groupId)
+	return keycloakClient.delete(url, nil)
+}
+
+// GetDefaultGroups returns all the default groups for a realm.
+func (keycloakClient *KeycloakClient) GetDefaultGroups(realmName string) ([]Group, error) {
+	url := fmt.Sprintf("/realms/%s/default-groups", realmName)
+
+	var defaultGroups []Group
+	err := keycloakClient.get(url, &defaultGroups, nil)
+
+	return defaultGroups, err
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -17,6 +17,7 @@ func KeycloakProvider() *schema.Provider {
 			"keycloak_required_action":                                 resourceKeycloakRequiredAction(),
 			"keycloak_group":                                           resourceKeycloakGroup(),
 			"keycloak_group_memberships":                               resourceKeycloakGroupMemberships(),
+			"keycloak_default_groups":                                  resourceKeycloakDefaultGroups(),
 			"keycloak_user":                                            resourceKeycloakUser(),
 			"keycloak_openid_client":                                   resourceKeycloakOpenidClient(),
 			"keycloak_openid_client_scope":                             resourceKeycloakOpenidClientScope(),

--- a/provider/resource_keycloak_default_groups.go
+++ b/provider/resource_keycloak_default_groups.go
@@ -1,0 +1,122 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakDefaultGroups() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceKeycloakDefaultGroupsCreate,
+		Read:   resourceKeycloakDefaultGroupsRead,
+		Update: resourceKeycloakDefaultGroupsUpdate,
+		Delete: resourceKeycloakDefaultGroupsDelete,
+		Schema: map[string]*schema.Schema{
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"group_ids": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func defaultGroupId(realmId string) string {
+	return realmId + "/default-groups"
+}
+
+func resourceKeycloakDefaultGroupsCreate(data *schema.ResourceData, meta interface{}) error {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	groupIds := interfaceSliceToStringSlice(data.Get("group_ids").(*schema.Set).List())
+
+	for _, groupId := range groupIds {
+		err := keycloakClient.PutDefaultGroup(realmId, groupId)
+		if err != nil {
+			return err
+		}
+	}
+
+	data.SetId(defaultGroupId(realmId))
+
+	return nil
+}
+
+func resourceKeycloakDefaultGroupsRead(data *schema.ResourceData, meta interface{}) error {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+
+	groups, err := keycloakClient.GetDefaultGroups(realmId)
+	if err != nil {
+		return err
+	}
+
+	var groupIds []string
+	for _, group := range groups {
+		groupIds = append(groupIds, group.Id)
+	}
+
+	data.SetId(defaultGroupId(realmId))
+	data.Set("group_ids", groupIds)
+
+	return nil
+}
+
+func resourceKeycloakDefaultGroupsUpdate(data *schema.ResourceData, meta interface{}) error {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	newGroupIds := data.Get("group_ids").(*schema.Set)
+
+	originalGroups, err := keycloakClient.GetDefaultGroups(realmId)
+	if err != nil {
+		return err
+	}
+
+	for _, originalGroup := range originalGroups {
+		if newGroupIds.Contains(originalGroup.Id) {
+			newGroupIds.Remove(originalGroup.Id)
+		} else {
+			err := keycloakClient.DeleteDefaultGroup(realmId, originalGroup.Id)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// at this point newGroupIds should contain only users that need to be created
+	for _, group := range interfaceSliceToStringSlice(newGroupIds.List()) {
+		err := keycloakClient.PutDefaultGroup(realmId, group)
+		if err != nil {
+			return err
+		}
+	}
+
+	data.SetId(defaultGroupId(realmId))
+
+	return resourceKeycloakDefaultGroupsRead(data, meta)
+}
+
+func resourceKeycloakDefaultGroupsDelete(data *schema.ResourceData, meta interface{}) error {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	groupIds := interfaceSliceToStringSlice(data.Get("group_ids").(*schema.Set).List())
+
+	for _, groupId := range groupIds {
+		err := keycloakClient.DeleteDefaultGroup(realmId, groupId)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/provider/resource_keycloak_default_groups.go
+++ b/provider/resource_keycloak_default_groups.go
@@ -11,6 +11,9 @@ func resourceKeycloakDefaultGroups() *schema.Resource {
 		Read:   resourceKeycloakDefaultGroupsRead,
 		Update: resourceKeycloakDefaultGroupsUpdate,
 		Delete: resourceKeycloakDefaultGroupsDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceKeycloakDefaultGroupsImport,
+		},
 		Schema: map[string]*schema.Schema{
 			"realm_id": {
 				Type:     schema.TypeString,
@@ -119,4 +122,10 @@ func resourceKeycloakDefaultGroupsDelete(data *schema.ResourceData, meta interfa
 	}
 
 	return nil
+}
+
+func resourceKeycloakDefaultGroupsImport(data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	data.Set("realm_id", data.Id())
+	data.SetId(data.Id())
+	return []*schema.ResourceData{data}, nil
 }

--- a/provider/resource_keycloak_default_groups_test.go
+++ b/provider/resource_keycloak_default_groups_test.go
@@ -33,6 +33,28 @@ func TestAccKeycloakDefaultGroups_basic(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakDefaultGroups_import(t *testing.T) {
+	realmName := "terraform-" + acctest.RandString(10)
+	groupName := "terraform-group-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakDefaultGroups_basic(realmName, groupName),
+				Check:  testAccCheckGroupsAreDefault("keycloak_default_groups.group_default", []string{groupName}),
+			},
+			{
+				ResourceName:      "keycloak_default_groups.group_default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     realmName,
+			},
+		},
+	})
+}
+
 func TestAccKeycloakDefaultGroups_updateInPlace(t *testing.T) {
 	realmName := "terraform-" + acctest.RandString(10)
 

--- a/provider/resource_keycloak_default_groups_test.go
+++ b/provider/resource_keycloak_default_groups_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -218,14 +217,14 @@ resource "keycloak_group" "%s" {
 
 	var defaultGroupResources []string
 	for _, defaultGroup := range defaultGroups {
-		defaultGroupResources = append(defaultGroupResources, fmt.Sprintf(`"${keycloak_group.%s.id}"`, defaultGroup))
+		defaultGroupResources = append(defaultGroupResources, fmt.Sprintf(`${keycloak_group.%s.id}`, defaultGroup))
 	}
 
 	out += fmt.Sprintf(`
 resource "keycloak_default_groups" "group_default" {
 	realm_id = "${keycloak_realm.realm.id}"
-	group_ids = [%s]
-}`, strings.Join(defaultGroupResources, ","))
+	group_ids = %s
+}`, arrayOfStringsForTerraformResource(defaultGroupResources))
 
 	return out
 }

--- a/provider/resource_keycloak_default_groups_test.go
+++ b/provider/resource_keycloak_default_groups_test.go
@@ -1,0 +1,209 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
+)
+
+func TestAccKeycloakDefaultGroups_basic(t *testing.T) {
+	realmName := "terraform-" + acctest.RandString(10)
+	groupName := "terraform-group-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakDefaultGroups_basic(realmName, groupName),
+				Check:  testAccCheckGroupsAreDefault("keycloak_default_groups.group_default", []string{groupName}),
+			},
+			{
+				// we need a separate test for destroy instead of using CheckDestroy because this resource is implicitly
+				// destroyed at the end of each test via destroying users or groups they're tied to
+				Config: testKeycloakDefaultGroups_noDefaultGroups(realmName, groupName),
+				Check:  testAccNoDefaultGroups("keycloak_group.group", []string{groupName}),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakDefaultGroups_updateInPlace(t *testing.T) {
+	realmName := "terraform-" + acctest.RandString(10)
+
+	allGroupsForTest := []string{
+		"terraform-group-" + acctest.RandString(10),
+		"terraform-group-" + acctest.RandString(10),
+		"terraform-group-" + acctest.RandString(10),
+	}
+	indexOfRandomGroupToRemove := acctest.RandIntRange(0, len(allGroupsForTest)-1)
+	randomGroupToRemove := allGroupsForTest[indexOfRandomGroupToRemove]
+
+	var subsetOfGroups []string
+	for index, group := range allGroupsForTest {
+		if index != indexOfRandomGroupToRemove {
+			subsetOfGroups = append(subsetOfGroups, group)
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			// init
+			{
+				Config: testKeycloakDefaultGroups_multipleGroups(realmName, allGroupsForTest, allGroupsForTest),
+				Check:  testAccCheckGroupsAreDefault("keycloak_default_groups.group_default", allGroupsForTest),
+			},
+			// remove
+			{
+				Config: testKeycloakDefaultGroups_multipleGroups(realmName, allGroupsForTest, subsetOfGroups),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGroupsAreDefault("keycloak_default_groups.group_default", subsetOfGroups),
+					testAccCheckGroupsArentDefault("keycloak_default_groups.group_default", []string{randomGroupToRemove}),
+				),
+			},
+			// add
+			{
+				Config: testKeycloakDefaultGroups_multipleGroups(realmName, allGroupsForTest, allGroupsForTest),
+				Check:  testAccCheckGroupsAreDefault("keycloak_default_groups.group_default", allGroupsForTest),
+			},
+		},
+	})
+}
+
+func testAccCheckGroupsAreDefault(resourceName string, groupNames []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		stateGroups, err := testAccGetGroupsFromDefaultGroup(resourceName, s)
+		if err != nil {
+			return err
+		}
+
+		for _, groupName := range groupNames {
+			found := false
+
+			for _, stateGroup := range stateGroups {
+				if stateGroup.Name == groupName {
+					found = true
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("unable to find group %s", groupName)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGroupsArentDefault(resourceName string, groupNames []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		stateGroups, err := testAccGetGroupsFromDefaultGroup(resourceName, s)
+		if err != nil {
+			return err
+		}
+
+		for _, stateGroup := range stateGroups {
+			for _, groupName := range groupNames {
+				if groupName == stateGroup.Name {
+					return fmt.Errorf("didnt expect to find group %s", groupName)
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccNoDefaultGroups(resourceName string, groupNames []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		stateGroups, err := testAccGetGroupsFromDefaultGroup(resourceName, s)
+		if err != nil {
+			return err
+		}
+
+		if len(stateGroups) != 0 {
+			return fmt.Errorf("expected 0 stateGroups, got %d", len(stateGroups))
+		}
+
+		return nil
+	}
+}
+
+func testAccGetGroupsFromDefaultGroup(resourceName string, s *terraform.State) ([]keycloak.Group, error) {
+	keycloakClient := testAccProvider.Meta().(*keycloak.KeycloakClient)
+
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("resource not found: %s", resourceName)
+	}
+
+	realmId := rs.Primary.Attributes["realm_id"]
+
+	return keycloakClient.GetDefaultGroups(realmId)
+}
+
+func testKeycloakDefaultGroups_basic(realmName, groupName string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_group" "group" {
+	name     = "%s"
+	realm_id = "${keycloak_realm.realm.id}"
+}
+
+resource "keycloak_default_groups" "group_default" {
+	realm_id = "${keycloak_realm.realm.id}"
+	group_ids = ["${keycloak_group.group.id}"]
+}
+	`, realmName, groupName)
+}
+
+func testKeycloakDefaultGroups_noDefaultGroups(realmName, groupName string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_group" "group" {
+	name     = "%s"
+	realm_id = "${keycloak_realm.realm.id}"
+}`, realmName, groupName)
+}
+
+// this tf config provides a good way to test groups that exist within keycloak but aren't defaults
+func testKeycloakDefaultGroups_multipleGroups(realm string, groups []string, defaultGroups []string) string {
+	out := fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm = "%s"
+}`, realm)
+
+	for _, group := range groups {
+		out += fmt.Sprintf(`
+resource "keycloak_group" "%s" {
+	name     = "%s"
+	realm_id = "${keycloak_realm.realm.id}"
+}`, group, group)
+	}
+
+	var defaultGroupResources []string
+	for _, defaultGroup := range defaultGroups {
+		defaultGroupResources = append(defaultGroupResources, fmt.Sprintf(`"${keycloak_group.%s.id}"`, defaultGroup))
+	}
+
+	out += fmt.Sprintf(`
+resource "keycloak_default_groups" "group_default" {
+	realm_id = "${keycloak_realm.realm.id}"
+	group_ids = [%s]
+}`, strings.Join(defaultGroupResources, ","))
+
+	return out
+}

--- a/provider/resource_keycloak_group_memberships.go
+++ b/provider/resource_keycloak_group_memberships.go
@@ -104,7 +104,7 @@ func resourceKeycloakGroupMembershipsUpdate(data *schema.ResourceData, meta inte
 			// if the user exists in keycloak and not in tf state, they need to be removed from the group
 			err = keycloakClient.RemoveUserFromGroup(keycloakMember, groupId)
 			if err != nil {
-				return nil
+				return err
 			}
 		}
 	}

--- a/provider/resource_keycloak_group_memberships.go
+++ b/provider/resource_keycloak_group_memberships.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
 )

--- a/provider/test_utils.go
+++ b/provider/test_utils.go
@@ -2,14 +2,15 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 	"math/rand"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func randomBool() bool {

--- a/provider/utils.go
+++ b/provider/utils.go
@@ -2,10 +2,11 @@ package provider
 
 import (
 	"bytes"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
 )
 
 func splitLen(s string, n int) []string {


### PR DESCRIPTION
## Summary

This PR adds a new `keycloak_default_groups` resource which allows you to manage default groups for a realm.

Closes #144 
Closes #145 

## TODO

- [x] Validate that a group membership resource doesn't exist or figure out some other solution for that (or just document that using a default group and a group membership resource will lead to funky results), see https://github.com/mrparkers/terraform-provider-keycloak/issues/144#issuecomment-526634858
- [x] Add tests
- [x] Add ability to import default groups
- [x] Add documentation
- [x] Add an example