### PR TITLE
Add option to configure the Keycloak client timeout

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ The following provider attributes are supported:
 - `password` (Optional) - The password of the user used by the provider for authentication via the password grant. Defaults to environment variable `KEYCLOAK_PASSWORD`. This attribute is required when using the password grant, and cannot be set when using the client credentials grant.
 - `realm` (Optional) - The realm used by the provider for authentication. Defaults to environment variable `KEYCLOAK_REALM`, or `master` if the environment variable is not specified.
 - `initial_login` (Optional) - Optionally avoid Keycloak login during provider setup, for when Keycloak itself is being provisioned by terraform. Defaults to true, which is the original method.
+- `client_timeout` (Optional) - Sets the timeout of the client when addressing Keycloak, in seconds. Defaults to 5.
 
 #### Example (client credentials)
 

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -38,9 +38,9 @@ const (
 	tokenUrl = "%s/auth/realms/%s/protocol/openid-connect/token"
 )
 
-func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, password string, initialLogin bool) (*KeycloakClient, error) {
+func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, password string, initialLogin bool, clientTimeout int) (*KeycloakClient, error) {
 	httpClient := &http.Client{
-		Timeout: time.Second * 5,
+		Timeout: time.Second * time.Duration(clientTimeout),
 	}
 	clientCredentials := &ClientCredentials{
 		ClientId:     clientId,

--- a/keycloak/keycloak_client_test.go
+++ b/keycloak/keycloak_client_test.go
@@ -44,7 +44,7 @@ func TestAccKeycloakApiClientRefresh(t *testing.T) {
 		defer log.SetOutput(os.Stdout)
 	}
 
-	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), true)
+	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), true, 5)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -93,6 +93,12 @@ func KeycloakProvider() *schema.Provider {
 				Description: "Whether or not to login to Keycloak instance on provider initialization",
 				Default:     true,
 			},
+			"client_timeout": {
+				Optional:    true,
+				Type:        schema.TypeInt,
+				Description: "Timeout (in seconds) of the Keycloak client",
+				Default:     5,
+			},
 		},
 		ConfigureFunc: configureKeycloakProvider,
 	}
@@ -106,6 +112,7 @@ func configureKeycloakProvider(data *schema.ResourceData) (interface{}, error) {
 	password := data.Get("password").(string)
 	realm := data.Get("realm").(string)
 	initialLogin := data.Get("initial_login").(bool)
+	clientTimeout := data.Get("client_timeout").(int)
 
-	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password, initialLogin)
+	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password, initialLogin, clientTimeout)
 }


### PR DESCRIPTION
Our Keycloak instance is sometimes a bit slow to respond:

```
module.release_environment.keycloak_realm.realm: Creating...

Error: Post https://keycloak.is4.local/auth/admin/realms: net/http: request canceled (Client.Timeout exceeded while awaiting headers)

  on .terraform/modules/release_environment/main.tf line 5, in resource "keycloak_realm" "realm":
   5: resource "keycloak_realm" "realm" {
```

The request is cancelled, but the realm does get created, which leads to a conflict on subsequent `terraform apply` calls; and since the realm is not in the Terraform state, a `terraform destroy` does not solve the issue.

This PR allows for the Keycloak client timeout to be configurable, while keeping the default value of 5 seconds.