### PR TITLE
feat: add serviceAccountUserId even if service accounts are disabled

### DIFF
--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -222,6 +222,8 @@ func setOpenidClientData(keycloakClient *keycloak.KeycloakClient, data *schema.R
 
 	if client.ServiceAccountsEnabled {
 		data.Set("service_account_user_id", serviceAccountUserId)
+	} else {
+		data.Set("service_account_user_id", "")
 	}
 
 	// access type


### PR DESCRIPTION
Hi,

I have a module for open_id clients, and I need to set an output with the service_account_user_id to use it after to set a service_account_role on this open_id client. The service_account_user_id attribute only exists when the service_accounts_enabled attribute is set to "true".

In Terraform 0.11, we can't verify if an attribute exists, and in an output like

```
output "service_account_user_id" {
  value = "${keycloak_openid_client.openid_client.service_accounts_enabled == "true" ? keycloak_openid_client.openid_client.service_account_user_id : ""}"
}
```
the variables are evaluated before the conditional. I had to patch your provider to always get the attribute, even if service_accounts_enabled is set to "false"...

Regards,

Pierre
