### PR TITLE
Fix input for keycloak_realm data source

### DIFF
--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -11,7 +11,7 @@ func dataSourceKeycloakRealm() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"realm": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Required: true,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
When trying out the new `keycloak_realm` data source, I received the the following error:

> Error: "realm": this field cannot be set

I have the suspicion this is a bug, this PR tries to fix that.