### PR TITLE
fix: flaky tests

### DIFF
--- a/keycloak/role.go
+++ b/keycloak/role.go
@@ -2,6 +2,7 @@ package keycloak
 
 import (
 	"fmt"
+	"log"
 )
 
 type Role struct {
@@ -91,7 +92,14 @@ func (keycloakClient *KeycloakClient) UpdateRole(role *Role) error {
 }
 
 func (keycloakClient *KeycloakClient) DeleteRole(realmId, id string) error {
-	return keycloakClient.delete(fmt.Sprintf("/realms/%s/roles-by-id/%s", realmId, id), nil)
+	err := keycloakClient.delete(fmt.Sprintf("/realms/%s/roles-by-id/%s", realmId, id), nil)
+	if err != nil {
+		log.Printf("[DEBUG] Failed to delete role with id %s. Trying again...", id)
+
+		return keycloakClient.delete(fmt.Sprintf("/realms/%s/roles-by-id/%s", realmId, id), nil)
+	}
+
+	return nil
 }
 
 func (keycloakClient *KeycloakClient) AddCompositesToRole(role *Role, compositeRoles []*Role) error {

--- a/provider/resource_keycloak_ldap_user_federation_test.go
+++ b/provider/resource_keycloak_ldap_user_federation_test.go
@@ -128,10 +128,10 @@ func TestAccKeycloakLdapUserFederation_basicUpdateAll(t *testing.T) {
 	firstValidatePasswordPolicy := randomBool()
 	firstPagination := randomBool()
 
-	firstConnectionTimeout, _ := keycloak.GetDurationStringFromMilliseconds(strconv.Itoa(acctest.RandIntRange(1000, 3600000)))
-	secondConnectionTimeout, _ := keycloak.GetDurationStringFromMilliseconds(strconv.Itoa(acctest.RandIntRange(1000, 3600000)))
-	firstReadTimeout, _ := keycloak.GetDurationStringFromMilliseconds(strconv.Itoa(acctest.RandIntRange(1000, 3600000)))
-	secondReadTimeout, _ := keycloak.GetDurationStringFromMilliseconds(strconv.Itoa(acctest.RandIntRange(1000, 3600000)))
+	firstConnectionTimeout, _ := keycloak.GetDurationStringFromMilliseconds(strconv.Itoa(acctest.RandIntRange(1, 3600) * 1000))
+	secondConnectionTimeout, _ := keycloak.GetDurationStringFromMilliseconds(strconv.Itoa(acctest.RandIntRange(1, 3600) * 1000))
+	firstReadTimeout, _ := keycloak.GetDurationStringFromMilliseconds(strconv.Itoa(acctest.RandIntRange(1, 3600) * 1000))
+	secondReadTimeout, _ := keycloak.GetDurationStringFromMilliseconds(strconv.Itoa(acctest.RandIntRange(1, 3600) * 1000))
 
 	firstLdap := &keycloak.LdapUserFederation{
 		RealmId:                realmName,


### PR DESCRIPTION
- retry delete attempts for roles (these will occasionally error with a 500, but subsequent retries are successful)
- use whole numbers for duration string seconds to avoid rounding errors