### PR TITLE
feat: Support PKCE on OIDC Clients

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
   test:
     docker:
       - image: circleci/golang:1.11.4
-      - image: jboss/keycloak:6.0.1
+      - image: jboss/keycloak:7.0.0
         environment:
           DB_VENDOR: H2
           KEYCLOAK_LOGLEVEL: DEBUG

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GO111MODULE=on go mod download && make build
 
 ## Supported Versions
 
-Currently, this provider is tested against Terraform v0.12.1 and Keycloak v6.0.1. I personally use this provider with Terraform v0.11.x and Keycloak 4.8.3.Final.
+Currently, this provider is tested against Terraform v0.12.1 and Keycloak v7.0.0. I personally use this provider with Terraform v0.11.x and Keycloak 4.8.3.Final.
 
 In the future, it would be nice to [run acceptance tests using different versions of Terraform / Keycloak](https://github.com/mrparkers/terraform-provider-keycloak/issues/111). Please feel free to submit a PR if you believe you can help with this.
 

--- a/custom-user-federation-example/build.gradle
+++ b/custom-user-federation-example/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext.kotlinVersion = '1.3.31'
-	ext.keycloakVersion = '6.0.1'
+	ext.keycloakVersion = '7.0.0'
 	ext.shadowJarVersion = '4.0.2'
 
     repositories {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
     - 8389:389
   keycloak:
-    image: jboss/keycloak:6.0.1
+    image: jboss/keycloak:7.0.0
     depends_on:
     - postgres
     - openldap

--- a/docs/resources/keycloak_openid_client.md
+++ b/docs/resources/keycloak_openid_client.md
@@ -53,6 +53,14 @@ should be treated with the same care as a password. If omitted, Keycloak will ge
 wildcards in the form of an asterisk can be used here. This attribute must be set if either `standard_flow_enabled` or `implicit_flow_enabled`
 is set to `true`.
 - `web_origins` - (Optional) A list of allowed CORS origins. `+` can be used to permit all valid redirect URIs, and `*` can be used to permit all origins.
+- `pkce_code_challenge_method` - (Optional) The challenge method to use for Proof Key for Code Exchange. Can be either `plain` or `S256`.
+
+### Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+- `service_account_user_id` - When service accounts are enabled for this client, this attribute is the unique ID for the Keycloak user that represents this service account.
+ 
 
 ### Import
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -40,10 +40,6 @@ resource "keycloak_realm" "test" {
     default_locale = "en"
   }
 
-  browser_security_headers {
-
-  }
-
   security_defenses {
     headers {
       x_frame_options                     = "DENY"
@@ -160,6 +156,8 @@ resource "keycloak_openid_client" "test_client" {
   ]
 
   client_secret = "secret"
+
+  pkce_code_challenge_method = "plain"
 }
 
 resource "keycloak_openid_client_scope" "test_default_client_scope" {

--- a/keycloak/openid_client.go
+++ b/keycloak/openid_client.go
@@ -43,7 +43,12 @@ type OpenidClient struct {
 	AuthorizationServicesEnabled bool                               `json:"authorizationServicesEnabled"`
 	ValidRedirectUris            []string                           `json:"redirectUris"`
 	WebOrigins                   []string                           `json:"webOrigins"`
+	Attributes                   OpenidClientAttributes             `json:"attributes"`
 	AuthorizationSettings        *OpenidClientAuthorizationSettings `json:"authorizationSettings,omitempty"`
+}
+
+type OpenidClientAttributes struct {
+	PkceCodeChallengeMethod string `json:"pkce.code.challenge.method"`
 }
 
 func (keycloakClient *KeycloakClient) GetOpenidClientServiceAccountUserId(realmId, clientId string) (*User, error) {

--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -12,6 +12,7 @@ import (
 var (
 	keycloakOpenidClientAccessTypes                        = []string{"CONFIDENTIAL", "PUBLIC", "BEARER-ONLY"}
 	keycloakOpenidClientAuthorizationPolicyEnforcementMode = []string{"ENFORCING", "PERMISSIVE", "DISABLED"}
+	keycloakOpenidClientPkceCodeChallengeMethod            = []string{"plain", "S256"}
 )
 
 func resourceKeycloakOpenidClient() *schema.Resource {
@@ -90,6 +91,11 @@ func resourceKeycloakOpenidClient() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"pkce_code_challenge_method": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(keycloakOpenidClientPkceCodeChallengeMethod, false),
+			},
 			"service_account_user_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -154,8 +160,11 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 		ImplicitFlowEnabled:       data.Get("implicit_flow_enabled").(bool),
 		DirectAccessGrantsEnabled: data.Get("direct_access_grants_enabled").(bool),
 		ServiceAccountsEnabled:    data.Get("service_accounts_enabled").(bool),
-		ValidRedirectUris:         validRedirectUris,
-		WebOrigins:                webOrigins,
+		Attributes: keycloak.OpenidClientAttributes{
+			PkceCodeChallengeMethod: data.Get("pkce_code_challenge_method").(string),
+		},
+		ValidRedirectUris: validRedirectUris,
+		WebOrigins:        webOrigins,
 	}
 
 	if !openidClient.ImplicitFlowEnabled && !openidClient.StandardFlowEnabled {


### PR DESCRIPTION
This PR adds support for the advanced OIDC client setting `Proof Key for Code Exchange Code Challenge Method` on Keycloak >= 7.0.0

The setting is also applied on Keycloak versions < 7.0.0, but is ignored on those versions. (At least on Keycloak 6.0.1)

Fixes #169