### PR TITLE
Fix identity provider update and service account role management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.11.0 (October 14, 2019)
+
+FEATURES:
+
+* new resource: `keycloak_openid_user_realm_role_protocol_mapper` ([#159](https://github.com/mrparkers/terraform-provider-keycloak/pull/159))
+* new data source: `keycloak_realm` ([#160](https://github.com/mrparkers/terraform-provider-keycloak/pull/160))
+
+IMPROVEMENTS:
+
+* added `timeout` provider attribute ([#155](https://github.com/mrparkers/terraform-provider-keycloak/pull/155))
+* always export `serviceAccountId` for `keycloak_openid_client` resource ([#162](https://github.com/mrparkers/terraform-provider-keycloak/pull/162))
+
+BUG FIXES:
+
+* fix default value for `reset_credentials_flow` attribute in `keycloak_realm` resource ([#158](https://github.com/mrparkers/terraform-provider-keycloak/pull/158))
+
 ## 1.10.0 (September 6, 2019)
 
 note: this release contains a [bug](https://github.com/mrparkers/terraform-provider-keycloak/issues/156) in the `keycloak_realm` resource that incorrectly sets the default attribute for `reset_credentials_flow` to `"registration"`. Please ensure that you set this attribute manually to override the incorrect default until a future release fixes this issue.

--- a/keycloak/openid_client_service_account_role.go
+++ b/keycloak/openid_client_service_account_role.go
@@ -16,13 +16,8 @@ type OpenidClientServiceAccountRole struct {
 }
 
 func (keycloakClient *KeycloakClient) NewOpenidClientServiceAccountRole(serviceAccountRole *OpenidClientServiceAccountRole) error {
-	role, err := keycloakClient.GetRoleByName(serviceAccountRole.RealmId, serviceAccountRole.ContainerId, serviceAccountRole.Name)
-	if err != nil {
-		return err
-	}
-	serviceAccountRole.Id = role.Id
 	serviceAccountRoles := []OpenidClientServiceAccountRole{*serviceAccountRole}
-	_, _, err = keycloakClient.post(fmt.Sprintf("/realms/%s/users/%s/role-mappings/clients/%s", serviceAccountRole.RealmId, serviceAccountRole.ServiceAccountUserId, serviceAccountRole.ContainerId), serviceAccountRoles)
+	_, _, err := keycloakClient.post(fmt.Sprintf("/realms/%s/users/%s/role-mappings/clients/%s", serviceAccountRole.RealmId, serviceAccountRole.ServiceAccountUserId, serviceAccountRole.ContainerId), serviceAccountRoles)
 	if err != nil {
 		return err
 	}
@@ -57,6 +52,8 @@ func (keycloakClient *KeycloakClient) GetOpenidClientServiceAccountRole(realm, s
 	}
 	for _, serviceAccountRole := range serviceAccountRoles {
 		if serviceAccountRole.Id == roleId {
+			serviceAccountRole.RealmId = realm
+			serviceAccountRole.ServiceAccountUserId = serviceAccountUserId
 			return &serviceAccountRole, nil
 		}
 	}

--- a/provider/resource_keycloak_oidc_identity_provider.go
+++ b/provider/resource_keycloak_oidc_identity_provider.go
@@ -94,6 +94,8 @@ func resourceKeycloakOidcIdentityProvider() *schema.Resource {
 func getOidcIdentityProviderFromData(data *schema.ResourceData) (*keycloak.IdentityProvider, error) {
 	rec, _ := getIdentityProviderFromData(data)
 	rec.ProviderId = data.Get("provider_id").(string)
+	_, useJwksUrl := data.GetOk("jwks_url")
+	_, enableUserInfo := data.GetOk("user_info_url")
 
 	extraConfig := map[string]interface{}{}
 	if v, ok := data.GetOk("extra_config"); ok {
@@ -107,6 +109,7 @@ func getOidcIdentityProviderFromData(data *schema.ResourceData) (*keycloak.Ident
 		ValidateSignature:    keycloak.KeycloakBoolQuoted(data.Get("validate_signature").(bool)),
 		AuthorizationUrl:     data.Get("authorization_url").(string),
 		ClientId:             data.Get("client_id").(string),
+		ClientSecret:         data.Get("client_secret").(string),
 		HideOnLoginPage:      keycloak.KeycloakBoolQuoted(data.Get("hide_on_login_page").(bool)),
 		TokenUrl:             data.Get("token_url").(string),
 		LogoutUrl:            data.Get("logout_url").(string),
@@ -115,16 +118,8 @@ func getOidcIdentityProviderFromData(data *schema.ResourceData) (*keycloak.Ident
 		JwksUrl:              data.Get("jwks_url").(string),
 		UserInfoUrl:          data.Get("user_info_url").(string),
 		ExtraConfig:          extraConfig,
-	}
-	_, useJwksUrl := data.GetOk("jwks_url")
-	rec.Config.UseJwksUrl = keycloak.KeycloakBoolQuoted(useJwksUrl)
-	_, enableUserInfo := data.GetOk("user_info_url")
-	rec.Config.DisableUserInfo = keycloak.KeycloakBoolQuoted(!enableUserInfo)
-
-	if data.HasChange("client_secret") {
-		rec.Config.ClientSecret = data.Get("client_secret").(string)
-	} else {
-		rec.Config.ClientSecret = "**********"
+		UseJwksUrl:						keycloak.KeycloakBoolQuoted(useJwksUrl),
+		DisableUserInfo:      keycloak.KeycloakBoolQuoted(!enableUserInfo),
 	}
 
 	return rec, nil

--- a/provider/resource_keycloak_oidc_identity_provider.go
+++ b/provider/resource_keycloak_oidc_identity_provider.go
@@ -118,7 +118,7 @@ func getOidcIdentityProviderFromData(data *schema.ResourceData) (*keycloak.Ident
 		JwksUrl:              data.Get("jwks_url").(string),
 		UserInfoUrl:          data.Get("user_info_url").(string),
 		ExtraConfig:          extraConfig,
-		UseJwksUrl:						keycloak.KeycloakBoolQuoted(useJwksUrl),
+		UseJwksUrl:           keycloak.KeycloakBoolQuoted(useJwksUrl),
 		DisableUserInfo:      keycloak.KeycloakBoolQuoted(!enableUserInfo),
 	}
 

--- a/provider/resource_keycloak_oidc_identity_provider.go
+++ b/provider/resource_keycloak_oidc_identity_provider.go
@@ -123,6 +123,8 @@ func getOidcIdentityProviderFromData(data *schema.ResourceData) (*keycloak.Ident
 
 	if data.HasChange("client_secret") {
 		rec.Config.ClientSecret = data.Get("client_secret").(string)
+	} else {
+		rec.Confog.ClientSecret = "**********"
 	}
 
 	return rec, nil

--- a/provider/resource_keycloak_oidc_identity_provider.go
+++ b/provider/resource_keycloak_oidc_identity_provider.go
@@ -124,7 +124,7 @@ func getOidcIdentityProviderFromData(data *schema.ResourceData) (*keycloak.Ident
 	if data.HasChange("client_secret") {
 		rec.Config.ClientSecret = data.Get("client_secret").(string)
 	} else {
-		rec.Confog.ClientSecret = "**********"
+		rec.Config.ClientSecret = "**********"
 	}
 
 	return rec, nil

--- a/provider/resource_keycloak_openid_client_service_account_role.go
+++ b/provider/resource_keycloak_openid_client_service_account_role.go
@@ -50,8 +50,9 @@ func getOpenidClientServiceAccountRoleFromData(data *schema.ResourceData, keyclo
 	if err != nil {
 		if keycloak.ErrorIs404(err) {
 			role = &keycloak.Role{Id: ""}
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
 
 	return &keycloak.OpenidClientServiceAccountRole{

--- a/provider/resource_keycloak_openid_client_service_account_role.go
+++ b/provider/resource_keycloak_openid_client_service_account_role.go
@@ -48,11 +48,8 @@ func getOpenidClientServiceAccountRoleFromData(data *schema.ResourceData, keyclo
 
 	role, err := keycloakClient.GetRoleByName(realmId, containerId, roleName)
 	if err != nil {
-		switch e := err.(type) {
-		case *keycloak.ApiError:
-			if e.Code == 404 {
-				role = &keycloak.Role{Id: ""}
-			}
+		if keycloak.ErrorIs404(err) {
+			role = &keycloak.Role{Id: ""}
 		}
 		return nil, err
 	}

--- a/provider/resource_keycloak_openid_client_service_account_role.go
+++ b/provider/resource_keycloak_openid_client_service_account_role.go
@@ -48,7 +48,7 @@ func getOpenidClientServiceAccountRoleFromData(data *schema.ResourceData, keyclo
 
 	role, err := keycloakClient.GetRoleByName(realmId, containerId, roleName)
 	if err != nil {
-		if keycloak.ErrorIs404(err) {
+		if handleNotFoundError(err, data) == nil {
 			role = &keycloak.Role{Id: ""}
 		} else {
 			return nil, err
@@ -113,7 +113,10 @@ func resourceKeycloakOpenidClientServiceAccountRoleDelete(data *schema.ResourceD
 		return err
 	}
 
-	return keycloakClient.DeleteOpenidClientServiceAccountRole(serviceAccountRole.RealmId, serviceAccountRole.ServiceAccountUserId, serviceAccountRole.ContainerId, serviceAccountRole.Id)
+	err = keycloakClient.DeleteOpenidClientServiceAccountRole(serviceAccountRole.RealmId, serviceAccountRole.ServiceAccountUserId, serviceAccountRole.ContainerId, serviceAccountRole.Id)
+	if err != nil {
+		return handleNotFoundError(err, data)
+	}
 }
 
 func resourceKeycloakOpenidClientServiceAccountRoleImport(d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {

--- a/provider/resource_keycloak_openid_client_service_account_role.go
+++ b/provider/resource_keycloak_openid_client_service_account_role.go
@@ -41,25 +41,22 @@ func resourceKeycloakOpenidClientServiceAccountRole() *schema.Resource {
 }
 
 func getOpenidClientServiceAccountRoleFromData(data *schema.ResourceData, keycloakClient *keycloak.KeycloakClient) (*keycloak.OpenidClientServiceAccountRole, error) {
-
 	containerId := data.Get("client_id").(string)
 	roleName := data.Get("role").(string)
 	realmId := data.Get("realm_id").(string)
 	serviceAccountRoleId := data.Get("service_account_user_id").(string)
 
-	if realmId != "" && containerId != "" {
-		role, err := keycloakClient.GetRoleByName(realmId, containerId, roleName)
-		if err != nil {
-			return nil, err
-		}
-		return &keycloak.OpenidClientServiceAccountRole{
-			Id:                   role.Id,
-			ContainerId:          containerId,
-			Name:                 roleName,
-			RealmId:              realmId,
-			ServiceAccountUserId: serviceAccountRoleId,
-		}, nil
+	role, err := keycloakClient.GetRoleByName(realmId, containerId, roleName)
+	if err != nil {
+		return nil, err
 	}
+	return &keycloak.OpenidClientServiceAccountRole{
+		Id:                   role.Id,
+		ContainerId:          containerId,
+		Name:                 roleName,
+		RealmId:              realmId,
+		ServiceAccountUserId: serviceAccountRoleId,
+	}, nil
 
 	return nil, nil
 }
@@ -79,10 +76,6 @@ func resourceKeycloakOpenidClientServiceAccountRoleCreate(data *schema.ResourceD
 		return err
 	}
 
-	if serviceAccountRole == nil {
-		return fmt.Errorf("Target client doesn't exist")
-	}
-
 	err = keycloakClient.NewOpenidClientServiceAccountRole(serviceAccountRole)
 	if err != nil {
 		return err
@@ -97,10 +90,6 @@ func resourceKeycloakOpenidClientServiceAccountRoleRead(data *schema.ResourceDat
 	serviceAccountRole, err := getOpenidClientServiceAccountRoleFromData(data, keycloakClient)
 	if err != nil {
 		return err
-	}
-
-	if serviceAccountRole == nil {
-		return fmt.Errorf("Target client doesn't exist")
 	}
 
 	serviceAccountRole, err = keycloakClient.GetOpenidClientServiceAccountRole(serviceAccountRole.RealmId, serviceAccountRole.ServiceAccountUserId, serviceAccountRole.ContainerId, serviceAccountRole.Id)
@@ -121,11 +110,7 @@ func resourceKeycloakOpenidClientServiceAccountRoleDelete(data *schema.ResourceD
 		return err
 	}
 
-	if serviceAccountRole != nil {
-		return keycloakClient.DeleteOpenidClientServiceAccountRole(serviceAccountRole.RealmId, serviceAccountRole.ServiceAccountUserId, serviceAccountRole.ContainerId, serviceAccountRole.Id)
-	} else {
-		return nil
-	}
+	return keycloakClient.DeleteOpenidClientServiceAccountRole(serviceAccountRole.RealmId, serviceAccountRole.ServiceAccountUserId, serviceAccountRole.ContainerId, serviceAccountRole.Id)
 }
 
 func resourceKeycloakOpenidClientServiceAccountRoleImport(d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {

--- a/provider/resource_keycloak_openid_client_service_account_role.go
+++ b/provider/resource_keycloak_openid_client_service_account_role.go
@@ -48,7 +48,7 @@ func getOpenidClientServiceAccountRoleFromData(data *schema.ResourceData, keyclo
 
 	role, err := keycloakClient.GetRoleByName(realmId, containerId, roleName)
 	if err != nil {
-		if handleNotFoundError(err, data) == nil {
+		if keycloak.ErrorIs404(err) {
 			role = &keycloak.Role{Id: ""}
 		} else {
 			return nil, err

--- a/provider/resource_keycloak_openid_client_service_account_role.go
+++ b/provider/resource_keycloak_openid_client_service_account_role.go
@@ -57,8 +57,6 @@ func getOpenidClientServiceAccountRoleFromData(data *schema.ResourceData, keyclo
 		RealmId:              realmId,
 		ServiceAccountUserId: serviceAccountRoleId,
 	}, nil
-
-	return nil, nil
 }
 
 func setOpenidClientServiceAccountRoleData(data *schema.ResourceData, serviceAccountRole *keycloak.OpenidClientServiceAccountRole) {

--- a/provider/resource_keycloak_openid_client_service_account_role.go
+++ b/provider/resource_keycloak_openid_client_service_account_role.go
@@ -48,8 +48,16 @@ func getOpenidClientServiceAccountRoleFromData(data *schema.ResourceData, keyclo
 
 	role, err := keycloakClient.GetRoleByName(realmId, containerId, roleName)
 	if err != nil {
-		return nil, err
+		switch e := err.(type) {
+		case *keycloak.ApiError:
+			if e.Code == 404 {
+				role = &keycloak.Role{Id: ""}
+			}
+		default:
+			return nil, err
+		}
 	}
+
 	return &keycloak.OpenidClientServiceAccountRole{
 		Id:                   role.Id,
 		ContainerId:          containerId,

--- a/provider/resource_keycloak_openid_client_service_account_role.go
+++ b/provider/resource_keycloak_openid_client_service_account_role.go
@@ -40,18 +40,28 @@ func resourceKeycloakOpenidClientServiceAccountRole() *schema.Resource {
 	}
 }
 
-func getOpenidClientServiceAccountRoleFromData(data *schema.ResourceData) *keycloak.OpenidClientServiceAccountRole {
-	return &keycloak.OpenidClientServiceAccountRole{
-		Id:                   data.Id(),
-		ContainerId:          data.Get("client_id").(string),
-		Name:                 data.Get("role").(string),
-		RealmId:              data.Get("realm_id").(string),
-		ServiceAccountUserId: data.Get("service_account_user_id").(string),
+func getOpenidClientServiceAccountRoleFromData(data *schema.ResourceData, keycloakClient *keycloak.KeycloakClient) (*keycloak.OpenidClientServiceAccountRole, error) {
+
+	containerId := data.Get("client_id").(string)
+	roleName := data.Get("role").(string)
+	realmId := data.Get("realm_id").(string)
+	serviceAccountRoleId := data.Get("service_account_user_id").(string)
+
+	role, err := keycloakClient.GetRoleByName(realmId, containerId, roleName)
+	if err != nil {
+		return nil, err
 	}
+	return &keycloak.OpenidClientServiceAccountRole{
+		Id:                   role.Id,
+		ContainerId:          containerId,
+		Name:                 roleName,
+		RealmId:              realmId,
+		ServiceAccountUserId: serviceAccountRoleId,
+	}, nil
 }
 
 func setOpenidClientServiceAccountRoleData(data *schema.ResourceData, serviceAccountRole *keycloak.OpenidClientServiceAccountRole) {
-	data.SetId(serviceAccountRole.Id)
+	data.SetId(fmt.Sprintf("%s/%s", serviceAccountRole.ServiceAccountUserId, serviceAccountRole.Id))
 	data.Set("realm_id", serviceAccountRole.RealmId)
 	data.Set("client_id", serviceAccountRole.ContainerId)
 	data.Set("service_account_user_id", serviceAccountRole.ServiceAccountUserId)
@@ -60,8 +70,11 @@ func setOpenidClientServiceAccountRoleData(data *schema.ResourceData, serviceAcc
 
 func resourceKeycloakOpenidClientServiceAccountRoleCreate(data *schema.ResourceData, meta interface{}) error {
 	keycloakClient := meta.(*keycloak.KeycloakClient)
-	serviceAccountRole := getOpenidClientServiceAccountRoleFromData(data)
-	err := keycloakClient.NewOpenidClientServiceAccountRole(serviceAccountRole)
+	serviceAccountRole, err := getOpenidClientServiceAccountRoleFromData(data, keycloakClient)
+	if err != nil {
+		return err
+	}
+	err = keycloakClient.NewOpenidClientServiceAccountRole(serviceAccountRole)
 	if err != nil {
 		return err
 	}
@@ -72,12 +85,12 @@ func resourceKeycloakOpenidClientServiceAccountRoleCreate(data *schema.ResourceD
 func resourceKeycloakOpenidClientServiceAccountRoleRead(data *schema.ResourceData, meta interface{}) error {
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
-	realmId := data.Get("realm_id").(string)
-	serviceAccountUserId := data.Get("service_account_user_id").(string)
-	clientId := data.Get("client_id").(string)
-	id := data.Id()
+	serviceAccountRole, err := getOpenidClientServiceAccountRoleFromData(data, keycloakClient)
+	if err != nil {
+		return err
+	}
 
-	serviceAccountRole, err := keycloakClient.GetOpenidClientServiceAccountRole(realmId, serviceAccountUserId, clientId, id)
+	serviceAccountRole, err = keycloakClient.GetOpenidClientServiceAccountRole(serviceAccountRole.RealmId, serviceAccountRole.ServiceAccountUserId, serviceAccountRole.ContainerId, serviceAccountRole.Id)
 	if err != nil {
 		return handleNotFoundError(err, data)
 	}
@@ -90,23 +103,23 @@ func resourceKeycloakOpenidClientServiceAccountRoleRead(data *schema.ResourceDat
 func resourceKeycloakOpenidClientServiceAccountRoleDelete(data *schema.ResourceData, meta interface{}) error {
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
-	realmId := data.Get("realm_id").(string)
-	serviceAccountUserId := data.Get("service_account_user_id").(string)
-	clientId := data.Get("client_id").(string)
-	id := data.Id()
+	serviceAccountRole, err := getOpenidClientServiceAccountRoleFromData(data, keycloakClient)
+	if err != nil {
+		return err
+	}
 
-	return keycloakClient.DeleteOpenidClientServiceAccountRole(realmId, serviceAccountUserId, clientId, id)
+	return keycloakClient.DeleteOpenidClientServiceAccountRole(serviceAccountRole.RealmId, serviceAccountRole.ServiceAccountUserId, serviceAccountRole.ContainerId, serviceAccountRole.Id)
 }
 
 func resourceKeycloakOpenidClientServiceAccountRoleImport(d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 3 {
-		return nil, fmt.Errorf("Invalid import. Supported import formats: {{realmId}}/{{serviceAccountUserId}}/{{clientId}}/{{role}}")
+		return nil, fmt.Errorf("Invalid import. Supported import formats: {{realmId}}/{{serviceAccountUserId}}/{{clientId}}/{{roleId}}")
 	}
 	d.Set("realm_id", parts[0])
 	d.Set("service_account_user_id", parts[1])
 	d.Set("client_id", parts[2])
-	d.SetId(parts[3])
+	d.SetId(fmt.Sprintf("%s/%s", parts[1], parts[3]))
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/provider/resource_keycloak_openid_client_service_account_role.go
+++ b/provider/resource_keycloak_openid_client_service_account_role.go
@@ -117,6 +117,7 @@ func resourceKeycloakOpenidClientServiceAccountRoleDelete(data *schema.ResourceD
 	if err != nil {
 		return handleNotFoundError(err, data)
 	}
+	return nil
 }
 
 func resourceKeycloakOpenidClientServiceAccountRoleImport(d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {

--- a/provider/resource_keycloak_openid_client_service_account_role.go
+++ b/provider/resource_keycloak_openid_client_service_account_role.go
@@ -53,9 +53,8 @@ func getOpenidClientServiceAccountRoleFromData(data *schema.ResourceData, keyclo
 			if e.Code == 404 {
 				role = &keycloak.Role{Id: ""}
 			}
-		default:
-			return nil, err
 		}
+		return nil, err
 	}
 
 	return &keycloak.OpenidClientServiceAccountRole{

--- a/provider/resource_keycloak_openid_client_service_account_role_test.go
+++ b/provider/resource_keycloak_openid_client_service_account_role_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
+	"strings"
 	"testing"
 )
 
@@ -123,7 +124,7 @@ func testAccCheckKeycloakOpenidClientServiceAccountRoleDestroy() resource.TestCh
 			realmId := rs.Primary.Attributes["realm_id"]
 			serviceAccountUserId := rs.Primary.Attributes["service_account_user_id"]
 			clientId := rs.Primary.Attributes["client_id"]
-			id := rs.Primary.ID
+			id := strings.Split(rs.Primary.ID, "/")[1]
 
 			keycloakClient := testAccProvider.Meta().(*keycloak.KeycloakClient)
 
@@ -148,7 +149,7 @@ func getKeycloakOpenidClientServiceAccountRoleFromState(s *terraform.State, reso
 	realmId := rs.Primary.Attributes["realm_id"]
 	serviceAccountUserId := rs.Primary.Attributes["service_account_user_id"]
 	clientId := rs.Primary.Attributes["client_id"]
-	id := rs.Primary.ID
+	id := strings.Split(rs.Primary.ID, "/")[1]
 
 	serviceAccountRole, err := keycloakClient.GetOpenidClientServiceAccountRole(realmId, serviceAccountUserId, clientId, id)
 	if err != nil {


### PR DESCRIPTION
Hi @mrparkers 
Prepared a PR with fixes for 
 - OIDC identity provider: It doesn't keep a valid client_secret value during resource update
 - service account role: sometimes it doesn't save a full state and tries to recreate resource once again