### PR TITLE
Use cookiejar on Keycloak API requests

### DIFF
--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/net/publicsuffix"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httputil"
 	"net/url"
 	"strings"
@@ -39,8 +41,17 @@ const (
 )
 
 func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, password string, initialLogin bool, clientTimeout int) (*KeycloakClient, error) {
+	cookieJar, err := cookiejar.New(&cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
 	httpClient := &http.Client{
 		Timeout: time.Second * time.Duration(clientTimeout),
+		Jar:     cookieJar,
 	}
 	clientCredentials := &ClientCredentials{
 		ClientId:     clientId,


### PR DESCRIPTION
Most likely due to either configuration issues with our cache or a bug in Keycloak itself, we've been seeing 404s immediately after resource creation (mainly with client scope mappers). 
This causes the provider to immediately remove the newly-created resource from state, which makes subsequent applies either fail or duplicate resources. 

As a temporary workaround we enabled sticky sessions and changed the provider to persist and send cookies. While we'd like to figure this out and remove sticky sessions from our loadbalancer, it also seemed like it might be useful if the provider utilized sticky sessions if they were configured. 
