### PR TITLE
Added condition for fetching roles having forward slash(/) in its name

### DIFF
--- a/keycloak/role.go
+++ b/keycloak/role.go
@@ -3,6 +3,7 @@ package keycloak
 import (
 	"fmt"
 	"log"
+	"strings"
 )
 
 type Role struct {
@@ -43,7 +44,9 @@ func (keycloakClient *KeycloakClient) CreateRole(role *Role) error {
 	}
 
 	var createdRole Role
-	err = keycloakClient.get(fmt.Sprintf("%s/%s", url, role.Name), &createdRole, nil)
+	var roleName = strings.Replace(role.Name, "/", "%2F", -2)
+
+	err = keycloakClient.get(fmt.Sprintf("%s/%s", url, roleName), &createdRole, nil)
 	if err != nil {
 		return err
 	}
@@ -55,7 +58,6 @@ func (keycloakClient *KeycloakClient) CreateRole(role *Role) error {
 
 func (keycloakClient *KeycloakClient) GetRole(realmId, id string) (*Role, error) {
 	var role Role
-
 	err := keycloakClient.get(fmt.Sprintf("/realms/%s/roles-by-id/%s", realmId, id), &role, nil)
 	if err != nil {
 		return nil, err
@@ -72,8 +74,9 @@ func (keycloakClient *KeycloakClient) GetRole(realmId, id string) (*Role, error)
 
 func (keycloakClient *KeycloakClient) GetRoleByName(realmId, clientId, name string) (*Role, error) {
 	var role Role
+	var roleName = strings.Replace(name, "/", "%2F", -2)
 
-	err := keycloakClient.get(fmt.Sprintf("%s/%s", roleByNameUrl(realmId, clientId), name), &role, nil)
+	err := keycloakClient.get(fmt.Sprintf("%s/%s", roleByNameUrl(realmId, clientId), roleName), &role, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/resource_keycloak_role_test.go
+++ b/provider/resource_keycloak_role_test.go
@@ -32,6 +32,29 @@ func TestAccKeycloakRole_basicRealm(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakRole_basicRealmForwardSlashRole(t *testing.T) {
+	realmName := "terraform-" + acctest.RandString(10)
+	roleName := "terraform-role-/-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckKeycloakRoleDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakRole_basicRealm(realmName, roleName),
+				Check:  testAccCheckKeycloakRoleExists("keycloak_role.role"),
+			},
+			{
+				ResourceName:        "keycloak_role.role",
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: realmName + "/",
+			},
+		},
+	})
+}
+
 func TestAccKeycloakRole_basicClient(t *testing.T) {
 	realmName := "terraform-" + acctest.RandString(10)
 	clientId := "terraform-client-" + acctest.RandString(10)


### PR DESCRIPTION
Issue: Terraform giving 404 error while fetching client roles having forward slash(/) in its name.

Resolution: Added Replace string where ever required

Example Resource Name: Test/123