### PR TITLE
Bumping tests to 8.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
   test:
     docker:
       - image: circleci/golang:1.11.4
-      - image: jboss/keycloak:7.0.0
+      - image: jboss/keycloak:8.0.0
         environment:
           DB_VENDOR: H2
           KEYCLOAK_LOGLEVEL: DEBUG

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GO111MODULE=on go mod download && make build
 
 ## Supported Versions
 
-Currently, this provider is tested against Terraform v0.12.1 and Keycloak v7.0.0. I personally use this provider with Terraform v0.11.x and Keycloak 4.8.3.Final.
+Currently, this provider is tested against Terraform v0.12.1 and Keycloak v8.0.0. I personally use this provider with Terraform v0.11.x and Keycloak 4.8.3.Final.
 
 In the future, it would be nice to [run acceptance tests using different versions of Terraform / Keycloak](https://github.com/mrparkers/terraform-provider-keycloak/issues/111). Please feel free to submit a PR if you believe you can help with this.
 
@@ -30,10 +30,10 @@ For local development, you can spin up a local instance of Keycloak, backed by P
 Once the environment is ready, you can run the acceptance tests after setting the required environment variables:
 
 ```
-KEYCLOAK_CLIENT_ID=terraform \
-KEYCLOAK_CLIENT_SECRET=884e0f95-0f42-4a63-9b1f-94274655669e \
-KEYCLOAK_REALM=master \
-KEYCLOAK_URL="http://localhost:8080" \
+export KEYCLOAK_CLIENT_ID=terraform \
+export KEYCLOAK_CLIENT_SECRET=884e0f95-0f42-4a63-9b1f-94274655669e \
+export KEYCLOAK_REALM=master \
+export KEYCLOAK_URL="http://localhost:8080" \
 make testacc
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
     - 8389:389
   keycloak:
-    image: jboss/keycloak:7.0.0
+    image: jboss/keycloak:8.0.0
     depends_on:
     - postgres
     - openldap
@@ -29,8 +29,8 @@ services:
     - DB_PASSWORD=password
     - KEYCLOAK_USER=keycloak
     - KEYCLOAK_PASSWORD=password
-    - POSTGRES_PORT_5432_TCP_ADDR=postgres
-    - POSTGRES_PORT_5432_TCP_PORT=5432
+    - DB_ADDR=postgres
+    - DB_PORT=5432
     ports:
     - 8080:8080
     volumes:


### PR DESCRIPTION
We're upgrading Keycloak to 8.0.0 and wanted to make sure the provider would work.  Tests passed locally for us.