### PR TITLE
Fetch More than default 100 members for a group

### DIFF
--- a/keycloak/group.go
+++ b/keycloak/group.go
@@ -135,8 +135,14 @@ func (keycloakClient *KeycloakClient) ListGroupsWithName(realmId, name string) (
 
 func (keycloakClient *KeycloakClient) GetGroupMembers(realmId, groupId string) ([]*User, error) {
 	var users []*User
+	var max int
 
-	err := keycloakClient.get(fmt.Sprintf("/realms/%s/groups/%s/members", realmId, groupId), &users, nil)
+	err := keycloakClient.get(fmt.Sprintf("/realms/%s/users/count", realmId), &max, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = keycloakClient.get(fmt.Sprintf("/realms/%s/groups/%s/members?max=%d", realmId, groupId, max), &users, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/group.go
+++ b/keycloak/group.go
@@ -135,14 +135,8 @@ func (keycloakClient *KeycloakClient) ListGroupsWithName(realmId, name string) (
 
 func (keycloakClient *KeycloakClient) GetGroupMembers(realmId, groupId string) ([]*User, error) {
 	var users []*User
-	var max int
 
-	err := keycloakClient.get(fmt.Sprintf("/realms/%s/users/count", realmId), &max, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	err = keycloakClient.get(fmt.Sprintf("/realms/%s/groups/%s/members?max=%d", realmId, groupId, max), &users, nil)
+	err := keycloakClient.get(fmt.Sprintf("/realms/%s/groups/%s/members?max=-1", realmId, groupId), &users, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/resource_keycloak_group_memberships_test.go
+++ b/provider/resource_keycloak_group_memberships_test.go
@@ -37,7 +37,6 @@ func TestAccKeycloakGroupMemberships_basic(t *testing.T) {
 func TestAccKeycloakGroupMemberships_moreThan100members(t *testing.T) {
 	realmName := "terraform-" + acctest.RandString(10)
 	groupName := "terraform-group-" + acctest.RandString(10)
-	username := "terraform-user-101"
 
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,

--- a/provider/resource_keycloak_group_memberships_test.go
+++ b/provider/resource_keycloak_group_memberships_test.go
@@ -45,7 +45,6 @@ func TestAccKeycloakGroupMemberships_moreThan100members(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testKeycloakGroupMemberships_moreThan100members(realmName, groupName),
-				Check:  testAccCheckUserBelongsToGroup("keycloak_group_memberships.group_members", username),
 			},
 		},
 	})
@@ -430,10 +429,6 @@ resource "keycloak_group_memberships" "group_members" {
 
 func testKeycloakGroupMemberships_moreThan100members(realm, group string) string {
 	count := 110
-	var usersInGroupInterpolated []string
-	for i := 0; i < count; i++ {
-		usersInGroupInterpolated = append(usersInGroupInterpolated, fmt.Sprintf("${keycloak_user.users.%d.username}", i))
-	}
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
         realm = "%s"
@@ -454,10 +449,10 @@ resource "keycloak_group_memberships" "group_members" {
         realm_id = "${keycloak_realm.realm.id}"
         group_id = "${keycloak_group.group.id}"
 
-        members = %s
+        members = "${keycloak_user.users.*.username}"
 }
 
-        `, realm, group, count, arrayOfStringsForTerraformResource(usersInGroupInterpolated))
+        `, realm, group, count)
 }
 
 func testKeycloakGroupMemberships_updateGroupForceNew(realm, groupOne, groupTwo, username, currentGroup string) string {

--- a/provider/resource_keycloak_group_memberships_test.go
+++ b/provider/resource_keycloak_group_memberships_test.go
@@ -429,7 +429,7 @@ resource "keycloak_group_memberships" "group_members" {
 }
 
 func testKeycloakGroupMemberships_moreThan100members(realm, group string) string {
-	count := 200
+	count := 110
 	var usersInGroupInterpolated []string
 	for i := 0; i < count; i++ {
 		usersInGroupInterpolated = append(usersInGroupInterpolated, fmt.Sprintf("${keycloak_user.users.%d.username}", i))


### PR DESCRIPTION
Issue: Keycloak's ** GET /{realm}/groups/{id}/members** API by default returns maximum 100 members for any group.

Resolution: max parameter passed with the API call.

Ref Issue: https://github.com/mrparkers/terraform-provider-keycloak/issues/178#issue-527021618