### PR TITLE
Documentation: fix password example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ provider "keycloak" {
 
 ```hcl
 provider "keycloak" {
-	client_id     = "terraform"
+	client_id     = "admin-cli"
 	username      = "keycloak"
 	password      = "password"
 	url           = "http://localhost:8080"


### PR DESCRIPTION
Password example should use 'admin-cli' as the client as mentioned above: https://github.com/mrparkers/terraform-provider-keycloak/blob/master/docs/index.md#provider-setup.

> client_id (Required) - The client_id for the client that was created in the "Keycloak Setup" section. Use the admin-cli client if you are using the password grant.