### PR TITLE
Add full_scope_allowed attribute to keycloak_openid_client resource

### DIFF
--- a/docs/resources/keycloak_openid_client.md
+++ b/docs/resources/keycloak_openid_client.md
@@ -54,6 +54,7 @@ wildcards in the form of an asterisk can be used here. This attribute must be se
 is set to `true`.
 - `web_origins` - (Optional) A list of allowed CORS origins. `+` can be used to permit all valid redirect URIs, and `*` can be used to permit all origins.
 - `pkce_code_challenge_method` - (Optional) The challenge method to use for Proof Key for Code Exchange. Can be either `plain` or `S256`.
+- `full_scope_allowed` - (Optional) - Allow to include all roles mappings in the access token.
 
 ### Attributes Reference
 

--- a/keycloak/openid_client.go
+++ b/keycloak/openid_client.go
@@ -43,6 +43,7 @@ type OpenidClient struct {
 	AuthorizationServicesEnabled bool                               `json:"authorizationServicesEnabled"`
 	ValidRedirectUris            []string                           `json:"redirectUris"`
 	WebOrigins                   []string                           `json:"webOrigins"`
+	FullScopeAllowed             bool                               `json:"fullScopeAllowed"`
 	Attributes                   OpenidClientAttributes             `json:"attributes"`
 	AuthorizationSettings        *OpenidClientAuthorizationSettings `json:"authorizationSettings,omitempty"`
 }

--- a/provider/data_source_keycloak_openid_client.go
+++ b/provider/data_source_keycloak_openid_client.go
@@ -92,6 +92,10 @@ func dataSourceKeycloakOpenidClient() *schema.Resource {
 					},
 				},
 			},
+			"full_scope_allowed": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/provider/data_source_keycloak_openid_client_test.go
+++ b/provider/data_source_keycloak_openid_client_test.go
@@ -32,6 +32,7 @@ func TestAccKeycloakDataSourceOpenidClient_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "service_account_user_id", resourceName, "service_account_user_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "service_accounts_enabled", resourceName, "service_accounts_enabled"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "resource_server_id", resourceName, "resource_server_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "full_scope_allowed", resourceName, "full_scope_allowed"),
 				),
 			},
 		},
@@ -66,6 +67,7 @@ resource keycloak_openid_client test {
   web_origins              = [
 		"http://localhost"
   ]
+  full_scope_allowed       = false
 }
 
 data keycloak_openid_client test {

--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -128,6 +128,11 @@ func resourceKeycloakOpenidClient() *schema.Resource {
 					},
 				},
 			},
+			"full_scope_allowed": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 	}
 }
@@ -160,6 +165,7 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 		ImplicitFlowEnabled:       data.Get("implicit_flow_enabled").(bool),
 		DirectAccessGrantsEnabled: data.Get("direct_access_grants_enabled").(bool),
 		ServiceAccountsEnabled:    data.Get("service_accounts_enabled").(bool),
+		FullScopeAllowed:          data.Get("full_scope_allowed").(bool),
 		Attributes: keycloak.OpenidClientAttributes{
 			PkceCodeChallengeMethod: data.Get("pkce_code_challenge_method").(string),
 		},
@@ -224,6 +230,7 @@ func setOpenidClientData(keycloakClient *keycloak.KeycloakClient, data *schema.R
 	data.Set("valid_redirect_uris", client.ValidRedirectUris)
 	data.Set("web_origins", client.WebOrigins)
 	data.Set("authorization_services_enabled", client.AuthorizationServicesEnabled)
+	data.Set("full_scope_allowed", client.FullScopeAllowed)
 
 	if client.AuthorizationServicesEnabled {
 		data.Set("resource_server_id", client.Id)


### PR DESCRIPTION
This PR adds full_scope_allowed attribute support to keycloak_openid_client resource and data source.