### PR TITLE
Update CI tools and images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,8 @@ workflows:
   version: 2
   test:
     jobs:
-      - test
+      - test-7.0.1
+      - test-8.0.1
   release:
     jobs:
       - test:
@@ -20,16 +21,19 @@ workflows:
               only: /\d+\.\d+\.\d+(-rc.\d+)?/
             branches:
               ignore: /.*/
-jobs:
-  test:
-    docker:
-      - image: circleci/golang:1.13.5
-      - image: jboss/keycloak:8.0.1
-        environment:
-          DB_VENDOR: H2
-          KEYCLOAK_LOGLEVEL: DEBUG
-          KEYCLOAK_USER: keycloak
-          KEYCLOAK_PASSWORD: password
+
+defaults:
+  go_image: &go_image
+    - image: circleci/golang:1.13.5
+
+  keycloak_env: &keycloak_env
+    environment:
+      DB_VENDOR: H2
+      KEYCLOAK_LOGLEVEL: DEBUG
+      KEYCLOAK_USER: keycloak
+      KEYCLOAK_PASSWORD: password
+
+  testacc_job: &testacc_job
     working_directory: /go/src/github.com/mrparkers/terraform-provider-keycloak
     steps:
       - checkout
@@ -53,9 +57,25 @@ jobs:
       KEYCLOAK_URL: "http://localhost:8080"
       KEYCLOAK_REALM: "master"
       KEYCLOAK_TEST_PASSWORD_GRANT: "true"
+
+jobs:
+  test-7.0.1:
+    docker:
+      - <<: *go_image
+      - image: jboss/keycloak:7.0.1
+        <<: *keycloak_env
+    <<: *testacc_job
+
+  test-8.0.1:
+    docker:
+      - <<: *go_image
+      - image: jboss/keycloak:8.0.1
+        <<: *keycloak_env
+    <<: *testacc_job
+
   build-and-release:
     docker:
-      - image: circleci/golang:1.13.5
+      - <<: *go_image
     environment:
       GO111MODULE: "on"
     working_directory: /go/src/github.com/mrparkers/terraform-provider-keycloak
@@ -69,3 +89,4 @@ jobs:
           command: |
             ./scripts/build-release.sh
             ./scripts/publish-release.sh
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
   test:
     docker:
       - image: circleci/golang:1.11.4
-      - image: jboss/keycloak:8.0.0
+      - image: jboss/keycloak:8.0.1
         environment:
           DB_VENDOR: H2
           KEYCLOAK_LOGLEVEL: DEBUG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.11.4
+      - image: circleci/golang:1.13.5
       - image: jboss/keycloak:8.0.1
         environment:
           DB_VENDOR: H2
@@ -55,7 +55,7 @@ jobs:
       KEYCLOAK_TEST_PASSWORD_GRANT: "true"
   build-and-release:
     docker:
-      - image: circleci/golang:1.11.4
+      - image: circleci/golang:1.13.5
     environment:
       GO111MODULE: "on"
     working_directory: /go/src/github.com/mrparkers/terraform-provider-keycloak

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GO111MODULE=on go mod download && make build
 
 ## Supported Versions
 
-Currently, this provider is tested against Terraform v0.12.1 and Keycloak v8.0.0. I personally use this provider with Terraform v0.11.x and Keycloak 4.8.3.Final.
+Currently, this provider is tested against Terraform v0.12.1 and Keycloak v8.0.1. I personally use this provider with Terraform v0.11.x and Keycloak 4.8.3.Final.
 
 In the future, it would be nice to [run acceptance tests using different versions of Terraform / Keycloak](https://github.com/mrparkers/terraform-provider-keycloak/issues/111). Please feel free to submit a PR if you believe you can help with this.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
     - postgres:/var/lib/postgresql
   openldap:
-    image: osixia/openldap:1.2.2
+    image: osixia/openldap:1.3.0
     ports:
     - 8389:389
   keycloak:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     - POSTGRES_DB=keycloak
     - POSTGRES_USER=keycloak
     - POSTGRES_PASSWORD=password
-    image: postgres:9.6
+    image: postgres:12
     ports:
     - 5432:5432
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
     - 8389:389
   keycloak:
-    image: jboss/keycloak:8.0.0
+    image: jboss/keycloak:8.0.1
     depends_on:
     - postgres
     - openldap

--- a/keycloak/openid_audience_protocol_mapper.go
+++ b/keycloak/openid_audience_protocol_mapper.go
@@ -100,7 +100,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdAudienceProtocolMapper(mappe
 	}
 
 	if mapper.ClientId != "" && mapper.ClientScopeId != "" {
-		return fmt.Errorf("validataion error: ClientId and ClientScopeId cannot both be set")
+		return fmt.Errorf("validation error: ClientId and ClientScopeId cannot both be set")
 	}
 
 	if mapper.IncludedClientAudience == "" && mapper.IncludedCustomAudience == "" {
@@ -108,7 +108,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdAudienceProtocolMapper(mappe
 	}
 
 	if mapper.IncludedClientAudience != "" && mapper.IncludedCustomAudience != "" {
-		return fmt.Errorf("validataion error: IncludedClientAudience and IncludedCustomAudience cannot both be set")
+		return fmt.Errorf("validation error: IncludedClientAudience and IncludedCustomAudience cannot both be set")
 	}
 
 	protocolMappers, err := keycloakClient.listGenericProtocolMappers(mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)

--- a/provider/resource_keycloak_openid_audience_protocol_mapper_test.go
+++ b/provider/resource_keycloak_openid_audience_protocol_mapper_test.go
@@ -237,7 +237,7 @@ func TestAccKeycloakOpenIdAudienceProtocolMapper_validateClientConflictsWithClie
 		Steps: []resource.TestStep{
 			{
 				Config:      testKeycloakOpenIdAudienceProtocolMapper_validateClientConflictsWithClientScope(realmName, clientId, clientScopeId, mapperName),
-				ExpectError: regexp.MustCompile("validataion error: ClientId and ClientScopeId cannot both be set"),
+				ExpectError: regexp.MustCompile("validation error: ClientId and ClientScopeId cannot both be set"),
 			},
 		},
 	})
@@ -255,7 +255,7 @@ func TestAccKeycloakOpenIdAudienceProtocolMapper_validateClientAudienceConflicts
 		Steps: []resource.TestStep{
 			{
 				Config:      testKeycloakOpenIdAudienceProtocolMapper_validateClientAudienceConflictsWithCustomAudience(realmName, clientId, mapperName),
-				ExpectError: regexp.MustCompile("validataion error: IncludedClientAudience and IncludedCustomAudience cannot both be set"),
+				ExpectError: regexp.MustCompile("validation error: IncludedClientAudience and IncludedCustomAudience cannot both be set"),
 			},
 		},
 	})


### PR DESCRIPTION
This PR updates the tool versions used in CircleCI and local acceptance tests:

- Golang 1.11 -> 1.13
- KeyCloak 8.0.0 -> 8.0.1
- `osixia/openldap:1.2.2` -> `osixia/openldap:1.3.0`
- `postgres:9.6` -> `postgres:12`

Also fixes a small typo in an error message.

This PR intentionally leaves Terraform at version 0.12.1. I tried upgrading it to 0.12.18 but this breaks a lot of tests. Error messages look different, validation is different and it seems to trigger race conditions in KeyCloak... I suggest to do this upgrade in a separate PR.