### PR TITLE
Adds option to provide a CA root certificate for x509 validation

### DIFF
--- a/keycloak/keycloak_client_test.go
+++ b/keycloak/keycloak_client_test.go
@@ -51,7 +51,7 @@ func TestAccKeycloakApiClientRefresh(t *testing.T) {
 		t.Fatal("KEYCLOAK_CLIENT_TIMEOUT must be an integer")
 	}
 
-	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), true, clientTimeout)
+	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), true, clientTimeout, "")
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -106,6 +106,12 @@ func KeycloakProvider() *schema.Provider {
 				Description: "Timeout (in seconds) of the Keycloak client",
 				DefaultFunc: schema.EnvDefaultFunc("KEYCLOAK_CLIENT_TIMEOUT", 5),
 			},
+			"root_ca_certificate": {
+				Optional:    true,
+				Type:        schema.TypeString,
+				Description: "Allows x509 calls using an unknown CA certificate (for development purposes)",
+				Default:     "",
+			},
 		},
 		ConfigureFunc: configureKeycloakProvider,
 	}
@@ -120,6 +126,7 @@ func configureKeycloakProvider(data *schema.ResourceData) (interface{}, error) {
 	realm := data.Get("realm").(string)
 	initialLogin := data.Get("initial_login").(bool)
 	clientTimeout := data.Get("client_timeout").(int)
+	rootCaCertificate := data.Get("root_ca_certificate").(string)
 
-	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password, initialLogin, clientTimeout)
+	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password, initialLogin, clientTimeout, rootCaCertificate)
 }


### PR DESCRIPTION
Our current setup utilises staging certificates for our development environment. To prevent the client from x509 errors with respect to invalid root certificates, the new provider parameter allows the inclusion of a root CA certificate chain as a string. The client adds it to the http client if it is defined.

If there's anything that needs more work feel free to let me know, this is the first time I've fiddled with some Go code.