### PR TITLE
feature: Allows ignoring insecure certificates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ The following provider attributes are supported:
 - `realm` (Optional) - The realm used by the provider for authentication. Defaults to environment variable `KEYCLOAK_REALM`, or `master` if the environment variable is not specified.
 - `initial_login` (Optional) - Optionally avoid Keycloak login during provider setup, for when Keycloak itself is being provisioned by terraform. Defaults to true, which is the original method.
 - `client_timeout` (Optional) - Sets the timeout of the client when addressing Keycloak, in seconds. Defaults to environment variable `KEYCLOAK_CLIENT_TIMEOUT`, or 5 is the environment variable is not specified.
+- `verify_tls` (Optional) - Allows ignoring insecure certificates when set to false. Defaults to true. Disabling security check is dangerous and should be avoided.
 
 #### Example (client credentials)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ The following provider attributes are supported:
 - `realm` (Optional) - The realm used by the provider for authentication. Defaults to environment variable `KEYCLOAK_REALM`, or `master` if the environment variable is not specified.
 - `initial_login` (Optional) - Optionally avoid Keycloak login during provider setup, for when Keycloak itself is being provisioned by terraform. Defaults to true, which is the original method.
 - `client_timeout` (Optional) - Sets the timeout of the client when addressing Keycloak, in seconds. Defaults to environment variable `KEYCLOAK_CLIENT_TIMEOUT`, or 5 is the environment variable is not specified.
-- `verify_tls` (Optional) - Allows ignoring insecure certificates when set to false. Defaults to true. Disabling security check is dangerous and should be avoided.
+- `tls_insecure_skip_verify` (Optional) - Allows ignoring insecure certificates when set to true. Defaults to false. Disabling security check is dangerous and should be avoided.
 
 #### Example (client credentials)
 

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -41,7 +41,7 @@ const (
 	tokenUrl = "%s/auth/realms/%s/protocol/openid-connect/token"
 )
 
-func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, password string, initialLogin bool, clientTimeout int, verifyTls bool) (*KeycloakClient, error) {
+func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, password string, initialLogin bool, clientTimeout int, tlsInsecureSkipVerify bool) (*KeycloakClient, error) {
 	cookieJar, err := cookiejar.New(&cookiejar.Options{
 		PublicSuffixList: publicsuffix.List,
 	})
@@ -50,7 +50,7 @@ func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, passwor
 		return nil, err
 	}
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyTls},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: tlsInsecureSkipVerify},
 		Proxy:           http.ProxyFromEnvironment,
 	}
 

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -2,6 +2,7 @@ package keycloak
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"golang.org/x/net/publicsuffix"
@@ -12,7 +13,6 @@ import (
 	"net/http/cookiejar"
 	"net/http/httputil"
 	"net/url"
-	"crypto/tls"
 	"strings"
 	"time"
 )
@@ -51,13 +51,13 @@ func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, passwor
 	}
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyTls},
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	httpClient := &http.Client{
-		Timeout: time.Second * time.Duration(clientTimeout),
+		Timeout:   time.Second * time.Duration(clientTimeout),
 		Transport: transport,
-		Jar:     cookieJar,
+		Jar:       cookieJar,
 	}
 	clientCredentials := &ClientCredentials{
 		ClientId:     clientId,

--- a/keycloak/keycloak_client_test.go
+++ b/keycloak/keycloak_client_test.go
@@ -51,7 +51,7 @@ func TestAccKeycloakApiClientRefresh(t *testing.T) {
 		t.Fatal("KEYCLOAK_CLIENT_TIMEOUT must be an integer")
 	}
 
-	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), true, clientTimeout)
+	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), true, clientTimeout, true)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/keycloak/keycloak_client_test.go
+++ b/keycloak/keycloak_client_test.go
@@ -51,7 +51,7 @@ func TestAccKeycloakApiClientRefresh(t *testing.T) {
 		t.Fatal("KEYCLOAK_CLIENT_TIMEOUT must be an integer")
 	}
 
-	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), true, clientTimeout, true)
+	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), true, clientTimeout, false)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -109,6 +109,12 @@ func KeycloakProvider() *schema.Provider {
 				Description: "Timeout (in seconds) of the Keycloak client",
 				DefaultFunc: schema.EnvDefaultFunc("KEYCLOAK_CLIENT_TIMEOUT", 5),
 			},
+			"verify_tls": {
+				Optional:    true,
+				Type:        schema.TypeBool,
+				Description: "Allows ignoring insecure certificates when set to false. Defaults to true. Disabling security check is dangerous and should be avoided.",
+				Default:     true,
+			},
 		},
 		ConfigureFunc: configureKeycloakProvider,
 	}
@@ -123,6 +129,7 @@ func configureKeycloakProvider(data *schema.ResourceData) (interface{}, error) {
 	realm := data.Get("realm").(string)
 	initialLogin := data.Get("initial_login").(bool)
 	clientTimeout := data.Get("client_timeout").(int)
+	verifyTls := data.Get("verify_tls").(bool)
 
-	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password, initialLogin, clientTimeout)
+	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password, initialLogin, clientTimeout, verifyTls)
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -109,11 +109,11 @@ func KeycloakProvider() *schema.Provider {
 				Description: "Timeout (in seconds) of the Keycloak client",
 				DefaultFunc: schema.EnvDefaultFunc("KEYCLOAK_CLIENT_TIMEOUT", 5),
 			},
-			"verify_tls": {
+			"tls_insecure_skip_verify": {
 				Optional:    true,
 				Type:        schema.TypeBool,
-				Description: "Allows ignoring insecure certificates when set to false. Defaults to true. Disabling security check is dangerous and should be avoided.",
-				Default:     true,
+				Description: "Allows ignoring insecure certificates when set to true. Defaults to false. Disabling security check is dangerous and should be avoided.",
+				Default:     false,
 			},
 		},
 		ConfigureFunc: configureKeycloakProvider,
@@ -129,7 +129,7 @@ func configureKeycloakProvider(data *schema.ResourceData) (interface{}, error) {
 	realm := data.Get("realm").(string)
 	initialLogin := data.Get("initial_login").(bool)
 	clientTimeout := data.Get("client_timeout").(int)
-	verifyTls := data.Get("verify_tls").(bool)
+	tlsInsecureSkipVerify := data.Get("tls_insecure_skip_verify").(bool)
 
-	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password, initialLogin, clientTimeout, verifyTls)
+	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password, initialLogin, clientTimeout, tlsInsecureSkipVerify)
 }


### PR DESCRIPTION
Hello,

Disabling security check is dangerous and should be avoided but in development, self signed certificates are quite frequent.

Usage:
```
provider "keycloak" {
    client_id     = "admin-cli"
    username      = "keycloak"
    password      = "password"
    url           = "http://localhost:8080"
    verify_tls    = false
}
```