### PR TITLE
Fixed handling of Default Client Scope for deleted clients (#226)

### DIFF
--- a/provider/resource_keycloak_openid_client_default_scopes.go
+++ b/provider/resource_keycloak_openid_client_default_scopes.go
@@ -61,7 +61,7 @@ func resourceKeycloakOpenidClientDefaultScopesRead(data *schema.ResourceData, me
 
 	clientScopes, err := keycloakClient.GetOpenidClientDefaultScopes(realmId, clientId)
 	if err != nil {
-		return err
+		return handleNotFoundError(err, data)
 	}
 
 	var defaultScopes []string


### PR DESCRIPTION
I had a client with a Default Client Scope. After I deleted the client, "terraform refresh" crashed.
This should be handled better.

Terraform actually refreshed the client long before it tried to refresh the Default Client Scope so it should be aware that it makes no sense to query for its Default Client Scopes.

That knowledge seems even not necessary if it defaults to just delete the current state of the Default Client Scope if the server answers with a HTTP 404 NOT FOUND.

I saw this behavour in resource_keycloak_group_membership.go where `handleNotFoundError()` was called in that situation.

Doing exactly so in resource_keycloak_openid_client_default_scope.go works fine for me with Keycloak 8.0.1.