### PR TITLE
fix: revert patch on GetGenericClientProtocolMappers

### DIFF
--- a/keycloak/generic_client_protocol_mapper.go
+++ b/keycloak/generic_client_protocol_mapper.go
@@ -33,10 +33,10 @@ func (keycloakClient *KeycloakClient) NewGenericClientProtocolMapper(genericClie
 	return nil
 }
 
-func (keycloakClient *KeycloakClient) GetGenericClientProtocolMappers(realmId string, clientId string, clientScopeId string, mapperId string) (*OpenidClientWithGenericClientProtocolMappers, error) {
+func (keycloakClient *KeycloakClient) GetGenericClientProtocolMappers(realmId string, clientId string) (*OpenidClientWithGenericClientProtocolMappers, error) {
 	var openidClientWithGenericClientProtocolMappers OpenidClientWithGenericClientProtocolMappers
 
-	err := keycloakClient.get(individualProtocolMapperPath(realmId, clientId, clientScopeId, mapperId), &openidClientWithGenericClientProtocolMappers, nil)
+	err := keycloakClient.get(fmt.Sprintf("/realms/%s/clients/%s", realmId, clientId), &openidClientWithGenericClientProtocolMappers, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,6 @@ func (keycloakClient *KeycloakClient) GetGenericClientProtocolMappers(realmId st
 	for _, protocolMapper := range openidClientWithGenericClientProtocolMappers.ProtocolMappers {
 		protocolMapper.RealmId = realmId
 		protocolMapper.ClientId = clientId
-		protocolMapper.ClientScopeId = clientScopeId
 	}
 
 	return &openidClientWithGenericClientProtocolMappers, nil


### PR DESCRIPTION
Revert the patch on that function, as it changes its behaviour, and my terraform provider is not working anymore. I will support ClientScopes someday, but for the moment my code is not prepared for that, and it's not the good way to support it.