### PR TITLE
Allow JSON as a valid claim_value_type

### DIFF
--- a/docs/resources/keycloak_openid_hardcoded_claim_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_hardcoded_claim_protocol_mapper.md
@@ -72,7 +72,7 @@ The following arguments are supported:
 - `name` - (Required) The display name of this protocol mapper in the GUI.
 - `claim_name` - (Required) The name of the claim to insert into a token.
 - `claim_value` - (Required) The hardcoded value of the claim.
-- `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `long`, `int`, or `boolean`. Defaults to `String`.
+- `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `JSON`, `long`, `int`, or `boolean`. Defaults to `String`.
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.
 - `add_to_userinfo` - (Optional) Indicates if the property should be added as a claim to the UserInfo response body. Defaults to `true`.

--- a/docs/resources/keycloak_openid_user_attribute_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_user_attribute_protocol_mapper.md
@@ -72,7 +72,7 @@ The following arguments are supported:
 - `name` - (Required) The display name of this protocol mapper in the GUI.
 - `user_attribute` - (Required) The custom user attribute to map a claim for.
 - `claim_name` - (Required) The name of the claim to insert into a token.
-- `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `long`, `int`, or `boolean`. Defaults to `String`.
+- `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `JSON`, `long`, `int`, or `boolean`. Defaults to `String`.
 - `multivalued` - (Optional) Indicates whether this attribute is a single value or an array of values. Defaults to `false`.
 - `add_to_id_token` - (Optional) Indicates if the attribute should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the attribute should be added as a claim to the access token. Defaults to `true`.

--- a/docs/resources/keycloak_openid_user_property_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_user_property_protocol_mapper.md
@@ -72,7 +72,7 @@ The following arguments are supported:
 - `name` - (Required) The display name of this protocol mapper in the GUI.
 - `user_property` - (Required) The built in user property (such as email) to map a claim for.
 - `claim_name` - (Required) The name of the claim to insert into a token.
-- `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `long`, `int`, or `boolean`. Defaults to `String`.
+- `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `JSON`, `long`, `int`, or `boolean`. Defaults to `String`.
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.
 - `add_to_userinfo` - (Optional) Indicates if the property should be added as a claim to the UserInfo response body. Defaults to `true`.

--- a/docs/resources/keycloak_openid_user_realm_role_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_user_realm_role_protocol_mapper.md
@@ -69,7 +69,7 @@ The following arguments are supported:
 - `client_scope_id` - (Required if `client_id` is not specified) The client scope this protocol mapper is attached to.
 - `name` - (Required) The display name of this protocol mapper in the GUI.
 - `claim_name` - (Required) The name of the claim to insert into a token.
-- `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `long`, `int`, or `boolean`. Defaults to `String`.
+- `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `JSON`, `long`, `int`, or `boolean`. Defaults to `String`.
 - `multivalued` - (Optional) Indicates if attribute supports multiple values. If true, then the list of all values of this attribute will be set as claim. If false, then just first value will be set as claim. Defaults to `true`.
 - `realm_role_prefix` - (Optional) A prefix for each Realm Role.
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.

--- a/provider/resource_keycloak_openid_hardcoded_claim_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_hardcoded_claim_protocol_mapper.go
@@ -76,7 +76,7 @@ func resourceKeycloakOpenIdHardcodedClaimProtocolMapper() *schema.Resource {
 				Optional:     true,
 				Description:  "Claim type used when serializing tokens.",
 				Default:      "String",
-				ValidateFunc: validation.StringInSlice([]string{"String", "long", "int", "boolean"}, true),
+				ValidateFunc: validation.StringInSlice([]string{"JSON", "String", "long", "int", "boolean"}, true),
 			},
 		},
 	}

--- a/provider/resource_keycloak_openid_user_attribute_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_attribute_protocol_mapper.go
@@ -82,7 +82,7 @@ func resourceKeycloakOpenIdUserAttributeProtocolMapper() *schema.Resource {
 				Optional:     true,
 				Description:  "Claim type used when serializing tokens.",
 				Default:      "String",
-				ValidateFunc: validation.StringInSlice([]string{"String", "long", "int", "boolean"}, true),
+				ValidateFunc: validation.StringInSlice([]string{"JSON", "String", "long", "int", "boolean"}, true),
 			},
 		},
 	}

--- a/provider/resource_keycloak_openid_user_property_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_property_protocol_mapper.go
@@ -76,7 +76,7 @@ func resourceKeycloakOpenIdUserPropertyProtocolMapper() *schema.Resource {
 				Optional:     true,
 				Description:  "Claim type used when serializing tokens.",
 				Default:      "String",
-				ValidateFunc: validation.StringInSlice([]string{"String", "long", "int", "boolean"}, true),
+				ValidateFunc: validation.StringInSlice([]string{"JSON", "String", "long", "int", "boolean"}, true),
 			},
 		},
 	}

--- a/provider/resource_keycloak_openid_user_realm_role_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_realm_role_protocol_mapper.go
@@ -72,7 +72,7 @@ func resourceKeycloakOpenIdUserRealmRoleProtocolMapper() *schema.Resource {
 				Optional:     true,
 				Description:  "Claim type used when serializing tokens.",
 				Default:      "String",
-				ValidateFunc: validation.StringInSlice([]string{"String", "long", "int", "boolean"}, true),
+				ValidateFunc: validation.StringInSlice([]string{"JSON", "String", "long", "int", "boolean"}, true),
 			},
 			"multivalued": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
Fixes #255

I'm not sure if tests need expansion for this, couldn't find one testing the valid types.