### PR TITLE
compile libraries into release

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 MAKEFLAGS += --silent
 
 build:
-	GO111MODULE=on go build -o terraform-provider-keycloak
+	CGO_ENABLED=0 GO111MODULE=on go build -o terraform-provider-keycloak
 
 build-example: build
 	mkdir -p example/.terraform/plugins/darwin_amd64


### PR DESCRIPTION
(Not sure if I also need to modify https://github.com/mrparkers/terraform-provider-keycloak/blob/master/.circleci/config.yml#L83 )

**why**
I am seeing the following error messages. After researching a few things, it seems that alpine linux based images, like hashicorp/terraform, do not properly fork and exec binaries that do not have their libraries compiled into the binary.
```bash
Error: Failed to instantiate provider "harbor" to obtain schema: fork/exec /home/jenkins/agent/workspace/test/.terraform/plugins/linux_amd64/terraform-provider-harbor_v0.0.7: no such file or directory
```

**info**
https://github.com/terraform-providers/terraform-provider-helm/issues/59
https://github.com/terraform-providers/terraform-provider-helm/pull/111

https://serverfault.com/a/963315
https://medium.com/@laiello/cgo-with-custom-terraform-providers-65135604fa8c
https://github.com/hashicorp/terraform/blob/master/Dockerfile