### PR TITLE
Added ldap_user_federation attribute trust_email

### DIFF
--- a/docs-old/resources/keycloak_ldap_user_federation.md
+++ b/docs-old/resources/keycloak_ldap_user_federation.md
@@ -69,6 +69,7 @@ The following arguments are supported:
     - `ONE_LEVEL`: Only search for users in the DN specified by `user_dn`.
     - `SUBTREE`: Search entire LDAP subtree.
 - `validate_password_policy` - (Optional) When `true`, Keycloak will validate passwords using the realm policy before updating it.
+- `trust_email` - (Optional) If enabled, email provided by this provider is not verified even if verification is enabled for the realm.
 - `use_truststore_spi` - (Optional) Can be one of `ALWAYS`, `ONLY_FOR_LDAPS`, or `NEVER`:
     - `ALWAYS` - Always use the truststore SPI for LDAP connections.
     - `NEVER` - Never use the truststore SPI for LDAP connections.

--- a/keycloak/ldap_user_federation.go
+++ b/keycloak/ldap_user_federation.go
@@ -31,6 +31,7 @@ type LdapUserFederation struct {
 	SearchScope            string // api expects "1" or "2", but that means "One Level" or "Subtree"
 
 	ValidatePasswordPolicy bool
+	TrustEmail             bool
 	UseTruststoreSpi       string // can be "ldapsOnly", "always", or "never"
 	ConnectionTimeout      string // duration string (ex: 1h30m)
 	ReadTimeout            string // duration string (ex: 1h30m)
@@ -99,6 +100,9 @@ func convertFromLdapUserFederationToComponent(ldap *LdapUserFederation) (*compon
 		},
 		"validatePasswordPolicy": {
 			strconv.FormatBool(ldap.ValidatePasswordPolicy),
+		},
+		"trustEmail": {
+			strconv.FormatBool(ldap.TrustEmail),
 		},
 		"pagination": {
 			strconv.FormatBool(ldap.Pagination),
@@ -240,6 +244,11 @@ func convertFromComponentToLdapUserFederation(component *component) (*LdapUserFe
 		return nil, err
 	}
 
+	trustEmail, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("trustEmail"))
+	if err != nil {
+		return nil, err
+	}
+
 	pagination, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("pagination"))
 	if err != nil {
 		return nil, err
@@ -295,6 +304,7 @@ func convertFromComponentToLdapUserFederation(component *component) (*LdapUserFe
 		SearchScope:            component.getConfig("searchScope"),
 
 		ValidatePasswordPolicy: validatePasswordPolicy,
+		TrustEmail:             trustEmail,
 		UseTruststoreSpi:       component.getConfig("useTruststoreSpi"),
 		Pagination:             pagination,
 

--- a/provider/resource_keycloak_ldap_user_federation.go
+++ b/provider/resource_keycloak_ldap_user_federation.go
@@ -144,6 +144,12 @@ func resourceKeycloakLdapUserFederation() *schema.Resource {
 				Default:     false,
 				Description: "When true, Keycloak will validate passwords using the realm policy before updating it.",
 			},
+			"trust_email": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If enabled, email provided by this provider is not verified even if verification is enabled for the realm.",
+			},
 			"use_truststore_spi": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -323,6 +329,7 @@ func getLdapUserFederationFromData(data *schema.ResourceData) *keycloak.LdapUser
 		SearchScope:            data.Get("search_scope").(string),
 
 		ValidatePasswordPolicy: data.Get("validate_password_policy").(bool),
+		TrustEmail:             data.Get("trust_email").(bool),
 		UseTruststoreSpi:       data.Get("use_truststore_spi").(string),
 		ConnectionTimeout:      data.Get("connection_timeout").(string),
 		ReadTimeout:            data.Get("read_timeout").(string),
@@ -393,6 +400,7 @@ func setLdapUserFederationData(data *schema.ResourceData, ldap *keycloak.LdapUse
 	data.Set("search_scope", ldap.SearchScope)
 
 	data.Set("validate_password_policy", ldap.ValidatePasswordPolicy)
+	data.Set("trust_email", ldap.TrustEmail)
 	data.Set("use_truststore_spi", ldap.UseTruststoreSpi)
 	data.Set("connection_timeout", ldap.ConnectionTimeout)
 	data.Set("read_timeout", ldap.ReadTimeout)

--- a/provider/resource_keycloak_ldap_user_federation_test.go
+++ b/provider/resource_keycloak_ldap_user_federation_test.go
@@ -226,6 +226,9 @@ func TestAccKeycloakLdapUserFederation_basicUpdateAll(t *testing.T) {
 	firstValidatePasswordPolicy := randomBool()
 	firstPagination := randomBool()
 
+	firstTrustEmail := randomBool()
+	secondTrustEmail := !firstTrustEmail
+
 	firstConnectionTimeout, _ := keycloak.GetDurationStringFromMilliseconds(strconv.Itoa(acctest.RandIntRange(1, 3600) * 1000))
 	secondConnectionTimeout, _ := keycloak.GetDurationStringFromMilliseconds(strconv.Itoa(acctest.RandIntRange(1, 3600) * 1000))
 	firstReadTimeout, _ := keycloak.GetDurationStringFromMilliseconds(strconv.Itoa(acctest.RandIntRange(1, 3600) * 1000))
@@ -247,6 +250,7 @@ func TestAccKeycloakLdapUserFederation_basicUpdateAll(t *testing.T) {
 		BindCredential:                       acctest.RandString(10),
 		SearchScope:                          randomStringInSlice([]string{"ONE_LEVEL", "SUBTREE"}),
 		ValidatePasswordPolicy:               firstValidatePasswordPolicy,
+		TrustEmail:                           firstTrustEmail,
 		UseTruststoreSpi:                     randomStringInSlice([]string{"ALWAYS", "ONLY_FOR_LDAPS", "NEVER"}),
 		ConnectionTimeout:                    firstConnectionTimeout,
 		ReadTimeout:                          firstReadTimeout,
@@ -282,6 +286,7 @@ func TestAccKeycloakLdapUserFederation_basicUpdateAll(t *testing.T) {
 		BindCredential:                       acctest.RandString(10),
 		SearchScope:                          randomStringInSlice([]string{"ONE_LEVEL", "SUBTREE"}),
 		ValidatePasswordPolicy:               !firstValidatePasswordPolicy,
+		TrustEmail:                           secondTrustEmail,
 		UseTruststoreSpi:                     randomStringInSlice([]string{"ALWAYS", "ONLY_FOR_LDAPS", "NEVER"}),
 		ConnectionTimeout:                    secondConnectionTimeout,
 		ReadTimeout:                          secondReadTimeout,
@@ -659,6 +664,7 @@ resource "keycloak_ldap_user_federation" "openldap" {
 	search_scope             = "%s"
 
 	validate_password_policy = %t
+	trust_email              = %t
 	use_truststore_spi       = "%s"
 	connection_timeout       = "%s"
 	read_timeout             = "%s"
@@ -683,7 +689,7 @@ resource "keycloak_ldap_user_federation" "openldap" {
 		eviction_minute      = %d
 	}
 }
-	`, testAccRealmUserFederation.Realm, ldap.Name, ldap.Enabled, ldap.UsernameLDAPAttribute, ldap.RdnLDAPAttribute, ldap.UuidLDAPAttribute, arrayOfStringsForTerraformResource(ldap.UserObjectClasses), ldap.ConnectionUrl, ldap.UsersDn, ldap.BindDn, ldap.BindCredential, ldap.SearchScope, ldap.ValidatePasswordPolicy, ldap.UseTruststoreSpi, ldap.ConnectionTimeout, ldap.ReadTimeout, ldap.Pagination, ldap.BatchSizeForSync, ldap.FullSyncPeriod, ldap.ChangedSyncPeriod, ldap.ServerPrincipal, ldap.UseKerberosForPasswordAuthentication, ldap.KeyTab, ldap.KerberosRealm, ldap.CachePolicy, ldap.MaxLifespan, *ldap.EvictionDay, *ldap.EvictionHour, *ldap.EvictionMinute)
+	`, testAccRealmUserFederation.Realm, ldap.Name, ldap.Enabled, ldap.UsernameLDAPAttribute, ldap.RdnLDAPAttribute, ldap.UuidLDAPAttribute, arrayOfStringsForTerraformResource(ldap.UserObjectClasses), ldap.ConnectionUrl, ldap.UsersDn, ldap.BindDn, ldap.BindCredential, ldap.SearchScope, ldap.ValidatePasswordPolicy, ldap.TrustEmail, ldap.UseTruststoreSpi, ldap.ConnectionTimeout, ldap.ReadTimeout, ldap.Pagination, ldap.BatchSizeForSync, ldap.FullSyncPeriod, ldap.ChangedSyncPeriod, ldap.ServerPrincipal, ldap.UseKerberosForPasswordAuthentication, ldap.KeyTab, ldap.KerberosRealm, ldap.CachePolicy, ldap.MaxLifespan, *ldap.EvictionDay, *ldap.EvictionHour, *ldap.EvictionMinute)
 }
 
 func testKeycloakLdapUserFederation_basicWithAttrValidation(attr, ldap, val string) string {


### PR DESCRIPTION
Something strange happened with Pull Request 251, one of my git-rebase actions seems to have closed it?

The problem with Keycloak 7.0.1 is that the GUI does not support the "trust_email" attribute in this version. It is not in the Admin Webinterface nor in the representation that is reported back in the API.

How do you usually cope with such attributes? Is there a good way to throw an error depending on the version? If you can give me an example, I could try to enhance the patch.


  

original Text from Pull Request 251:
---------------------------------------------------------------------
fixes #234

It's a simple boolean value, I copy & paste fixed it whereever I found ValidatePasswordPolicy/validate_password_policy.

Verified that it can in fact turn the setting on and off in Keycloak 8.0.1.