### PR TITLE
Clarify realm id / name and expose realm id as new realm attribute

### DIFF
--- a/docs/resources/keycloak_realm.md
+++ b/docs/resources/keycloak_realm.md
@@ -174,6 +174,12 @@ The `brute_force_detection` block supports the following attributes:
 
 Map, can be used to add custom attributes to a realm. Or perhaps influence a certain attribute that is not supported in this terraform-provider
 
+### Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+- `internal_id` - When importing realms created outside of this terraform provider, they could use generated arbitrary IDs for the technical realm id. Realms created by this provider always use the realm's name for its technical id.
+
 ### Import
 
 Realms can be imported using their name:

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -21,7 +21,7 @@ type Keys struct {
 }
 
 type Realm struct {
-	Id                string `json:"id"`
+	Id                string `json:"id,omitempty"`
 	Realm             string `json:"realm"`
 	Enabled           bool   `json:"enabled"`
 	DisplayName       string `json:"displayName"`
@@ -124,10 +124,10 @@ func (keycloakClient *KeycloakClient) NewRealm(realm *Realm) error {
 	return err
 }
 
-func (keycloakClient *KeycloakClient) GetRealm(id string) (*Realm, error) {
+func (keycloakClient *KeycloakClient) GetRealm(name string) (*Realm, error) {
 	var realm Realm
 
-	err := keycloakClient.get(fmt.Sprintf("/realms/%s", id), &realm, nil)
+	err := keycloakClient.get(fmt.Sprintf("/realms/%s", name), &realm, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -145,10 +145,10 @@ func (keycloakClient *KeycloakClient) GetRealms() ([]*Realm, error) {
 	return realms, nil
 }
 
-func (keycloakClient *KeycloakClient) GetRealmKeys(id string) (*Keys, error) {
+func (keycloakClient *KeycloakClient) GetRealmKeys(name string) (*Keys, error) {
 	var keys Keys
 
-	err := keycloakClient.get(fmt.Sprintf("/realms/%s/keys", id), &keys, nil)
+	err := keycloakClient.get(fmt.Sprintf("/realms/%s/keys", name), &keys, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -157,14 +157,14 @@ func (keycloakClient *KeycloakClient) GetRealmKeys(id string) (*Keys, error) {
 }
 
 func (keycloakClient *KeycloakClient) UpdateRealm(realm *Realm) error {
-	return keycloakClient.put(fmt.Sprintf("/realms/%s", realm.Id), realm)
+	return keycloakClient.put(fmt.Sprintf("/realms/%s", realm.Realm), realm)
 }
 
-func (keycloakClient *KeycloakClient) DeleteRealm(id string) error {
-	err := keycloakClient.delete(fmt.Sprintf("/realms/%s", id), nil)
+func (keycloakClient *KeycloakClient) DeleteRealm(name string) error {
+	err := keycloakClient.delete(fmt.Sprintf("/realms/%s", name), nil)
 	if err != nil {
 		// For whatever reason, this fails sometimes with a 500 during acceptance tests. try again
-		return keycloakClient.delete(fmt.Sprintf("/realms/%s", id), nil)
+		return keycloakClient.delete(fmt.Sprintf("/realms/%s", name), nil)
 	}
 
 	return nil

--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -13,6 +13,10 @@ func dataSourceKeycloakRealm() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"internal_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"enabled": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -359,9 +363,9 @@ func dataSourceKeycloakRealm() *schema.Resource {
 func dataSourceKeycloakRealmRead(data *schema.ResourceData, meta interface{}) error {
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
-	realmId := data.Get("realm").(string)
+	realmName := data.Get("realm").(string)
 
-	realm, err := keycloakClient.GetRealm(realmId)
+	realm, err := keycloakClient.GetRealm(realmName)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -20,6 +20,10 @@ func resourceKeycloakRealm() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"internal_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -454,8 +458,14 @@ func getRealmFromData(data *schema.ResourceData) (*keycloak.Realm, error) {
 		defaultLocale = internationalizationSettings["default_locale"].(string)
 	}
 
+	realmId := data.Get("realm")
+	internalId := data.Get("internal_id")
+	if internalId != "" {
+		realmId = internalId
+	}
+
 	realm := &keycloak.Realm{
-		Id:                data.Get("realm").(string),
+		Id:                realmId.(string),
 		Realm:             data.Get("realm").(string),
 		Enabled:           data.Get("enabled").(bool),
 		DisplayName:       data.Get("display_name").(string),
@@ -731,6 +741,7 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm) {
 	data.SetId(realm.Realm)
 
 	data.Set("realm", realm.Realm)
+	data.Set("internal_id", realm.Id)
 	data.Set("enabled", realm.Enabled)
 	data.Set("display_name", realm.DisplayName)
 	data.Set("display_name_html", realm.DisplayNameHtml)


### PR DESCRIPTION
Coming from discussions here #216 my shot at clarifying usage of realm name and id.
Main points are:
* the requests to the API require the usage of the realm name, not the id. this is a rather cosmetic change in `keycloak/realm.go`
* in the realm resource, now the "real" realm id is exposed as "internal_id" attribute
* we retain the default behaviour of creating a realm with realmId == realmName so nothing breaks new/existing realms created by the provider
* This offers the possibility to import existing realms which have a realm id that differs from the realm's name. This is relevant for possible keycloak component which use the realm id for the parent_id attributes. Additional PR coming for the custom_user_federation if this PR gets through. I think, the ldap stuff is also affected by possible id and name mismatches (through the use of parent_id attributes)