### PR TITLE
support for deployed js policies

### DIFF
--- a/docs/resources/keycloak_realm.md
+++ b/docs/resources/keycloak_realm.md
@@ -73,6 +73,7 @@ The following arguments are supported:
 - `enabled` - (Optional) When false, users and clients will not be able to access this realm. Defaults to `true`.
 - `display_name` - (Optional) The display name for the realm that is shown when logging in to the admin console.
 - `display_name_html` - (Optional) The display name for the realm that is rendered as HTML on the screen when logging in to the admin console.
+- `user_managed_access` - (Optional) When true, users are allowed to manage their own resources. Defaults to `false`.
 
 ##### Login Settings
 
@@ -147,7 +148,7 @@ Internationalization support can be configured by using the `internationalizatio
 
 ##### Security Defenses Headers
 
-Header configuration support for browser security settings and brute force detection. It can be configured trough the`security_defenses` block using the `headers` and the `brute_force_detection` subblocks. 
+Header configuration support for browser security settings and brute force detection. It can be configured trough the`security_defenses` block using the `headers` and the `brute_force_detection` subblocks.
 
 The `headers` block supports the following attributes:
 

--- a/example/client_authorization_policys.tf
+++ b/example/client_authorization_policys.tf
@@ -100,7 +100,7 @@ resource keycloak_openid_client_js_policy test {
   name               = "client_js_policy_test"
   logic              = "POSITIVE"
   decision_strategy  = "UNANIMOUS"
-  code               = "test"
+  code               = "test"  # can be js code or a js file already deployed
   description        = "description"
 }
 

--- a/keycloak/openid_client_authorization_js_policy.go
+++ b/keycloak/openid_client_authorization_js_policy.go
@@ -3,6 +3,7 @@ package keycloak
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 type OpenidClientAuthorizationJSPolicy struct {
@@ -18,7 +19,13 @@ type OpenidClientAuthorizationJSPolicy struct {
 }
 
 func (keycloakClient *KeycloakClient) NewOpenidClientAuthorizationJSPolicy(policy *OpenidClientAuthorizationJSPolicy) error {
-	body, _, err := keycloakClient.post(fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/js", policy.RealmId, policy.ResourceServerId), policy)
+	var body []byte
+	var err error
+	if strings.HasSuffix(policy.Code, ".js") {
+		body, _, err = keycloakClient.post(fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/%s", policy.RealmId, policy.ResourceServerId, policy.Code), policy)
+	} else {
+		body, _, err = keycloakClient.post(fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/js", policy.RealmId, policy.ResourceServerId), policy)
+	}
 	if err != nil {
 		return err
 	}

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -21,11 +21,12 @@ type Keys struct {
 }
 
 type Realm struct {
-	Id              string `json:"id"`
-	Realm           string `json:"realm"`
-	Enabled         bool   `json:"enabled"`
-	DisplayName     string `json:"displayName"`
-	DisplayNameHtml string `json:"displayNameHtml"`
+	Id                string `json:"id"`
+	Realm             string `json:"realm"`
+	Enabled           bool   `json:"enabled"`
+	DisplayName       string `json:"displayName"`
+	DisplayNameHtml   string `json:"displayNameHtml"`
+	UserManagedAccess bool   `json:"userManagedAccessAllowed"`
 
 	// Login Config
 	RegistrationAllowed         bool   `json:"registrationAllowed"`

--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -26,9 +26,9 @@ func dataSourceKeycloakRealm() *schema.Resource {
 				Optional: true,
 			},
 			"user_managed_access": {
-            	Type:     schema.TypeBool,
-            	Computed: true,
-            },
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 
 			// Login Config
 

--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -25,6 +25,10 @@ func dataSourceKeycloakRealm() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"user_managed_access": {
+            	Type:     schema.TypeBool,
+            	Computed: true,
+            },
 
 			// Login Config
 

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -33,6 +33,11 @@ func resourceKeycloakRealm() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"user_managed_access": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 
 			// Login Config
 
@@ -450,11 +455,12 @@ func getRealmFromData(data *schema.ResourceData) (*keycloak.Realm, error) {
 	}
 
 	realm := &keycloak.Realm{
-		Id:              data.Get("realm").(string),
-		Realm:           data.Get("realm").(string),
-		Enabled:         data.Get("enabled").(bool),
-		DisplayName:     data.Get("display_name").(string),
-		DisplayNameHtml: data.Get("display_name_html").(string),
+		Id:                data.Get("realm").(string),
+		Realm:             data.Get("realm").(string),
+		Enabled:           data.Get("enabled").(bool),
+		DisplayName:       data.Get("display_name").(string),
+		DisplayNameHtml:   data.Get("display_name_html").(string),
+		UserManagedAccess: data.Get("user_managed_access").(bool),
 
 		// Login Config
 		RegistrationAllowed:         data.Get("registration_allowed").(bool),
@@ -728,6 +734,7 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm) {
 	data.Set("enabled", realm.Enabled)
 	data.Set("display_name", realm.DisplayName)
 	data.Set("display_name_html", realm.DisplayNameHtml)
+	data.Set("user_managed_access", realm.UserManagedAccess)
 
 	// Login Config
 	data.Set("registration_allowed", realm.RegistrationAllowed)


### PR DESCRIPTION
With this little change, it's possible to create js policies from already deployed policies. The field "code" of the resource "keycloak_openid_client_js_policy" can now be 2 things:
- javascript code, so that a brand new policy is created
- a javascript file already deployed, so that a new policy is created starting from this file.
This is recommended since in the last version of Keycloak uploading js code is disabled by default, but it's still possible for backwards compatibility.

Tested with Keycloak v9.0.3 and Terraform v0.12.24