### PR TITLE
support login theme parameter on openid client

### DIFF
--- a/docs/resources/keycloak_openid_client.md
+++ b/docs/resources/keycloak_openid_client.md
@@ -25,6 +25,8 @@ resource "keycloak_openid_client" "openid_client" {
     valid_redirect_uris = [
         "http://localhost:8080/openid-callback"
     ]
+
+    login_theme = "keycloak"
 }
 ```
 
@@ -64,6 +66,7 @@ is set to `true`.
 - `authentication_flow_binding_overrides` - (Optional) - Override realm authentication flow bindings
     - `browers_id` - (Optional) - Browser flow id, (flow needs to exist)
     - `direct_grant_id` - (Optional) - Direct grant flow id (flow needs to exist)
+- `login_theme` - (Optional) - Override realm login theme
 
 ### Attributes Reference
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -172,6 +172,8 @@ resource "keycloak_openid_client" "test_client" {
   client_secret = "secret"
 
   pkce_code_challenge_method = "plain"
+
+  login_theme = "keycloak"
 }
 
 resource "keycloak_openid_client_scope" "test_default_client_scope" {

--- a/keycloak/openid_client.go
+++ b/keycloak/openid_client.go
@@ -57,6 +57,7 @@ type OpenidClientAttributes struct {
 	PkceCodeChallengeMethod             string             `json:"pkce.code.challenge.method"`
 	ExcludeSessionStateFromAuthResponse KeycloakBoolQuoted `json:"exclude.session.state.from.auth.response"`
 	AccessTokenLifespan                 string             `json:"access.token.lifespan"`
+	LoginTheme                          string             `json:"login_theme"`
 }
 
 type OpenidAuthenticationFlowBindingOverrides struct {
@@ -88,6 +89,15 @@ func (keycloakClient *KeycloakClient) ValidateOpenidClient(client *OpenidClient)
 
 	if client.ServiceAccountsEnabled && client.PublicClient {
 		return fmt.Errorf("validation error: service accounts (client credentials flow) cannot be enabled on public clients")
+	}
+
+	serverInfo, err := keycloakClient.GetServerInfo()
+	if err != nil {
+		return err
+	}
+
+	if client.Attributes.LoginTheme != "" && !serverInfo.ThemeIsInstalled("login", client.Attributes.LoginTheme) {
+		return fmt.Errorf("validation error: theme \"%s\" does not exist on the server", client.Attributes.LoginTheme)
 	}
 
 	return nil

--- a/provider/data_source_keycloak_openid_client.go
+++ b/provider/data_source_keycloak_openid_client.go
@@ -121,6 +121,10 @@ func dataSourceKeycloakOpenidClient() *schema.Resource {
 					},
 				},
 			},
+			"login_theme": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -176,6 +176,10 @@ func resourceKeycloakOpenidClient() *schema.Resource {
 					},
 				},
 			},
+			"login_theme": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -232,6 +236,7 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 			PkceCodeChallengeMethod:             data.Get("pkce_code_challenge_method").(string),
 			ExcludeSessionStateFromAuthResponse: keycloak.KeycloakBoolQuoted(data.Get("exclude_session_state_from_auth_response").(bool)),
 			AccessTokenLifespan:                 data.Get("access_token_lifespan").(string),
+			LoginTheme:                          data.Get("login_theme").(string),
 		},
 		ValidRedirectUris: validRedirectUris,
 		WebOrigins:        webOrigins,
@@ -317,6 +322,7 @@ func setOpenidClientData(keycloakClient *keycloak.KeycloakClient, data *schema.R
 	data.Set("full_scope_allowed", client.FullScopeAllowed)
 	data.Set("consent_required", client.ConsentRequired)
 	data.Set("access_token_lifespan", client.Attributes.AccessTokenLifespan)
+	data.Set("login_theme", client.Attributes.LoginTheme)
 
 	if client.AuthorizationServicesEnabled {
 		data.Set("resource_server_id", client.Id)


### PR DESCRIPTION
Support login theme override on open client id. The logic check in server info if the theme exists.