### PR TITLE
GH-238 Added 'default_signature_algorithm' to Realm config

### DIFF
--- a/docs/resources/keycloak_realm.md
+++ b/docs/resources/keycloak_realm.md
@@ -104,6 +104,7 @@ If any of these attributes are not specified, they will default to Keycloak's de
 
 The following attributes can be found in the "Tokens" tab within the realm settings.
 
+- `default_signature_algorithm` - (Optional) Default algorithm used to sign tokens for the realm.
 - `revoke_refresh_token` - (Optional) If enabled a refresh token can only be used number of times specified in 'refresh_token_max_reuse' before they are revoked. If unspecified, refresh tokens can be reused.
 - `refresh_token_max_reuse` - (Optional) Maximum number of times a refresh token can be reused before they are revoked. If unspecified and 'revoke_refresh_token' is enabled the default value is 0 and refresh tokens can not be reused.
 

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -49,19 +49,20 @@ type Realm struct {
 	EmailTheme   string `json:"emailTheme,omitempty"`
 
 	// Tokens
-	RevokeRefreshToken                  bool `json:"revokeRefreshToken"`
-	RefreshTokenMaxReuse                int  `json:"refreshTokenMaxReuse"`
-	SsoSessionIdleTimeout               int  `json:"ssoSessionIdleTimeout,omitempty"`
-	SsoSessionMaxLifespan               int  `json:"ssoSessionMaxLifespan,omitempty"`
-	OfflineSessionIdleTimeout           int  `json:"offlineSessionIdleTimeout,omitempty"`
-	OfflineSessionMaxLifespan           int  `json:"offlineSessionMaxLifespan,omitempty"`
-	AccessTokenLifespan                 int  `json:"accessTokenLifespan,omitempty"`
-	AccessTokenLifespanForImplicitFlow  int  `json:"accessTokenLifespanForImplicitFlow,omitempty"`
-	AccessCodeLifespan                  int  `json:"accessCodeLifespan,omitempty"`
-	AccessCodeLifespanLogin             int  `json:"accessCodeLifespanLogin,omitempty"`
-	AccessCodeLifespanUserAction        int  `json:"accessCodeLifespanUserAction,omitempty"`
-	ActionTokenGeneratedByUserLifespan  int  `json:"actionTokenGeneratedByUserLifespan,omitempty"`
-	ActionTokenGeneratedByAdminLifespan int  `json:"actionTokenGeneratedByAdminLifespan,omitempty"`
+	DefaultSignatureAlgorithm           string `json:"defaultSignatureAlgorithm"`
+	RevokeRefreshToken                  bool   `json:"revokeRefreshToken"`
+	RefreshTokenMaxReuse                int    `json:"refreshTokenMaxReuse"`
+	SsoSessionIdleTimeout               int    `json:"ssoSessionIdleTimeout,omitempty"`
+	SsoSessionMaxLifespan               int    `json:"ssoSessionMaxLifespan,omitempty"`
+	OfflineSessionIdleTimeout           int    `json:"offlineSessionIdleTimeout,omitempty"`
+	OfflineSessionMaxLifespan           int    `json:"offlineSessionMaxLifespan,omitempty"`
+	AccessTokenLifespan                 int    `json:"accessTokenLifespan,omitempty"`
+	AccessTokenLifespanForImplicitFlow  int    `json:"accessTokenLifespanForImplicitFlow,omitempty"`
+	AccessCodeLifespan                  int    `json:"accessCodeLifespan,omitempty"`
+	AccessCodeLifespanLogin             int    `json:"accessCodeLifespanLogin,omitempty"`
+	AccessCodeLifespanUserAction        int    `json:"accessCodeLifespanUserAction,omitempty"`
+	ActionTokenGeneratedByUserLifespan  int    `json:"actionTokenGeneratedByUserLifespan,omitempty"`
+	ActionTokenGeneratedByAdminLifespan int    `json:"actionTokenGeneratedByAdminLifespan,omitempty"`
 
 	//internationalization
 	InternationalizationEnabled bool     `json:"internationalizationEnabled"`

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -181,6 +181,10 @@ func resourceKeycloakRealm() *schema.Resource {
 			},
 
 			// Tokens
+			"default_signature_algorithm": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"revoke_refresh_token": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -538,6 +542,11 @@ func getRealmFromData(data *schema.ResourceData) (*keycloak.Realm, error) {
 	}
 
 	// Tokens
+
+	if defaultSignatureAlgorithm, ok := data.GetOk("default_signature_algorithm"); ok {
+		realm.DefaultSignatureAlgorithm = defaultSignatureAlgorithm.(string)
+	}
+
 	if revokeRefreshToken, ok := data.GetOk("revoke_refresh_token"); ok {
 		realm.RevokeRefreshToken = revokeRefreshToken.(bool)
 	}
@@ -794,6 +803,7 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm) {
 	data.Set("email_theme", realm.EmailTheme)
 
 	// Tokens
+	data.Set("default_signature_algorithm", realm.DefaultSignatureAlgorithm)
 	data.Set("revoke_refresh_token", realm.RevokeRefreshToken)
 	data.Set("refresh_token_max_reuse", realm.RefreshTokenMaxReuse)
 	data.Set("sso_session_idle_timeout", getDurationStringFromSeconds(realm.SsoSessionIdleTimeout))

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -1238,6 +1238,7 @@ resource "keycloak_realm" "realm" {
 }
 
 func testKeycloakRealm_tokenSettings(realm string) string {
+	defaultSignatureAlgorithm := "RS256"
 	ssoSessionIdleTimeout := randomDurationString()
 	ssoSessionMaxLifespan := randomDurationString()
 	offlineSessionIdleTimeout := randomDurationString()
@@ -1256,6 +1257,7 @@ resource "keycloak_realm" "realm" {
 	enabled                                  = true
 	display_name                             = "%s"
 
+	default_signature_algorithm              = "%s"
 	sso_session_idle_timeout                 = "%s"
 	sso_session_max_lifespan                 = "%s"
 	offline_session_idle_timeout             = "%s"
@@ -1268,7 +1270,7 @@ resource "keycloak_realm" "realm" {
 	action_token_generated_by_user_lifespan  = "%s"
 	action_token_generated_by_admin_lifespan = "%s"
 }
-	`, realm, realm, ssoSessionIdleTimeout, ssoSessionMaxLifespan, offlineSessionIdleTimeout, offlineSessionMaxLifespan, accessTokenLifespan, accessTokenLifespanForImplicitFlow, accessCodeLifespan, accessCodeLifespanLogin, accessCodeLifespanUserAction, actionTokenGeneratedByUserLifespan, actionTokenGeneratedByAdminLifespan)
+	`, realm, realm, defaultSignatureAlgorithm, ssoSessionIdleTimeout, ssoSessionMaxLifespan, offlineSessionIdleTimeout, offlineSessionMaxLifespan, accessTokenLifespan, accessTokenLifespanForImplicitFlow, accessCodeLifespan, accessCodeLifespanLogin, accessCodeLifespanUserAction, actionTokenGeneratedByUserLifespan, actionTokenGeneratedByAdminLifespan)
 }
 
 func testKeycloakRealm_securityDefensesHeaders(realm, realmDisplayName, xFrameOptions string) string {


### PR DESCRIPTION
Please have a look. I verified that "RS256" appears in the Keycloak Web GUI and that "" resets it to the default of an empty HTML Select input element.