### PR TITLE
fix: correctly parse aggregate.attrs value for keycloak_openid_user_attribute_protocol_mapper

### DIFF
--- a/keycloak/openid_user_attribute_protocol_mapper.go
+++ b/keycloak/openid_user_attribute_protocol_mapper.go
@@ -65,7 +65,7 @@ func (protocolMapper *protocolMapper) convertToOpenIdUserAttributeProtocolMapper
 		return nil, err
 	}
 
-	aggregateAttributeValues, err := strconv.ParseBool(protocolMapper.Config[aggregateAttributeValuesField])
+	aggregateAttributeValues, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[aggregateAttributeValuesField])
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #283 