### PR TITLE
fix required group_id in resource keycloak_group_roles

### DIFF
--- a/provider/resource_keycloak_group_roles.go
+++ b/provider/resource_keycloak_group_roles.go
@@ -25,7 +25,7 @@ func resourceKeycloakGroupRoles() *schema.Resource {
 			},
 			"group_id": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
 			},
 			"role_ids": {


### PR DESCRIPTION
Hey,

Just noticed the argument `group_id` is errorneously marked as "optional", although… this could never work without a `group_id`, there's an error when executing terraform, and the [doc says `group_id` is required](https://mrparkers.github.io/terraform-provider-keycloak/resources/keycloak_group_roles/#argument-reference).