### PR TITLE
starting from keycloak 8.0.2: rootUrl and BaseUrl should be real urls

### DIFF
--- a/provider/resource_keycloak_openid_client_test.go
+++ b/provider/resource_keycloak_openid_client_test.go
@@ -188,7 +188,7 @@ func TestAccKeycloakOpenidClient_updateInPlace(t *testing.T) {
 		implicitFlowEnabled = !standardFlowEnabled
 	}
 
-	rootUrlBefore := "http://localhost:2222/"+ acctest.RandString(20)
+	rootUrlBefore := "http://localhost:2222/" + acctest.RandString(20)
 	openidClientBefore := &keycloak.OpenidClient{
 		RealmId:                   realm,
 		ClientId:                  clientId,

--- a/provider/resource_keycloak_openid_client_test.go
+++ b/provider/resource_keycloak_openid_client_test.go
@@ -188,7 +188,7 @@ func TestAccKeycloakOpenidClient_updateInPlace(t *testing.T) {
 		implicitFlowEnabled = !standardFlowEnabled
 	}
 
-	rootUrlBefore := acctest.RandString(20)
+	rootUrlBefore := "http://localhost:2222/"+ acctest.RandString(20)
 	openidClientBefore := &keycloak.OpenidClient{
 		RealmId:                   realm,
 		ClientId:                  clientId,
@@ -203,13 +203,13 @@ func TestAccKeycloakOpenidClient_updateInPlace(t *testing.T) {
 		ValidRedirectUris:         []string{acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10)},
 		WebOrigins:                []string{acctest.RandString(10), acctest.RandString(10), acctest.RandString(10)},
 		AdminUrl:                  acctest.RandString(20),
-		BaseUrl:                   acctest.RandString(20),
+		BaseUrl:                   "http://localhost:2222/" + acctest.RandString(20),
 		RootUrl:                   &rootUrlBefore,
 	}
 
 	standardFlowEnabled, implicitFlowEnabled = implicitFlowEnabled, standardFlowEnabled
 
-	rootUrlAfter := acctest.RandString(20)
+	rootUrlAfter := "http://localhost:2222/" + acctest.RandString(20)
 	openidClientAfter := &keycloak.OpenidClient{
 		RealmId:                   realm,
 		ClientId:                  clientId,
@@ -224,7 +224,7 @@ func TestAccKeycloakOpenidClient_updateInPlace(t *testing.T) {
 		ValidRedirectUris:         []string{acctest.RandString(10), acctest.RandString(10)},
 		WebOrigins:                []string{acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10)},
 		AdminUrl:                  acctest.RandString(20),
-		BaseUrl:                   acctest.RandString(20),
+		BaseUrl:                   "http://localhost:2222/" + acctest.RandString(20),
 		RootUrl:                   &rootUrlAfter,
 	}
 

--- a/provider/resource_keycloak_saml_client_test.go
+++ b/provider/resource_keycloak_saml_client_test.go
@@ -143,13 +143,13 @@ func TestAccKeycloakSamlClient_updateInPlace(t *testing.T) {
 
 		FrontChannelLogout: frontChannelLogout,
 
-		RootUrl: acctest.RandString(20),
+		RootUrl: "http://localhost:2222/" + acctest.RandString(20),
 		ValidRedirectUris: []string{
 			acctest.RandString(20),
 			acctest.RandString(20),
 			acctest.RandString(20),
 		},
-		BaseUrl:                 acctest.RandString(20),
+		BaseUrl:                 "http://localhost:2222/" + acctest.RandString(20),
 		MasterSamlProcessingUrl: acctest.RandString(20),
 
 		Attributes: &keycloak.SamlClientAttributes{
@@ -181,11 +181,11 @@ func TestAccKeycloakSamlClient_updateInPlace(t *testing.T) {
 
 		FrontChannelLogout: !frontChannelLogout,
 
-		RootUrl: acctest.RandString(20),
+		RootUrl: "http://localhost:2222/" + acctest.RandString(20),
 		ValidRedirectUris: []string{
 			acctest.RandString(20),
 		},
-		BaseUrl:                 acctest.RandString(20),
+		BaseUrl:                 "http://localhost:2222/" + acctest.RandString(20),
 		MasterSamlProcessingUrl: acctest.RandString(20),
 
 		Attributes: &keycloak.SamlClientAttributes{


### PR DESCRIPTION
As exposed in #294 the saml and oidc client update in place tests for keycloak version >= 8.0.2 where failing.
This is was because since 8.0.2 rootUrl and baseUrl need to be real urls.
I did not build any extra check in logic but just fixed the test to use real urls.