### PR TITLE
Use the terraform-plugin-sdk user agent string with running tf version

### DIFF
--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"golang.org/x/net/publicsuffix"
-	"github.com/hashicorp/terraform-plugin-sdk/httpclient"
 )
 
 type KeycloakClient struct {
@@ -45,7 +44,7 @@ const (
 	tokenUrl = "%s/auth/realms/%s/protocol/openid-connect/token"
 )
 
-func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, password string, initialLogin bool, clientTimeout int, caCert string, tlsInsecureSkipVerify bool, terraformVersion string) (*KeycloakClient, error) {
+func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, password string, initialLogin bool, clientTimeout int, caCert string, tlsInsecureSkipVerify bool, userAgent string) (*KeycloakClient, error) {
 	cookieJar, err := cookiejar.New(&cookiejar.Options{
 		PublicSuffixList: publicsuffix.List,
 	})
@@ -87,15 +86,16 @@ func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, passwor
 		return nil, fmt.Errorf("must specify client id, username and password for password grant, or client id and secret for client credentials grant")
 	}
 
-	userAgent := httpclient.TerraformUserAgent(terraformVersion)
-
 	keycloakClient := KeycloakClient{
 		baseUrl:           baseUrl,
 		clientCredentials: clientCredentials,
 		httpClient:        httpClient,
 		initialLogin:      initialLogin,
 		realm:             realm,
-		userAgent:         userAgent,
+	}
+
+	if userAgent != "" {
+		keycloakClient.userAgent = userAgent
 	}
 
 	if keycloakClient.initialLogin {

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -92,10 +92,7 @@ func NewKeycloakClient(baseUrl, clientId, clientSecret, realm, username, passwor
 		httpClient:        httpClient,
 		initialLogin:      initialLogin,
 		realm:             realm,
-	}
-
-	if userAgent != "" {
-		keycloakClient.userAgent = userAgent
+		userAgent:         userAgent,
 	}
 
 	if keycloakClient.initialLogin {
@@ -116,7 +113,10 @@ func (keycloakClient *KeycloakClient) login() error {
 
 	accessTokenRequest, _ := http.NewRequest(http.MethodPost, accessTokenUrl, strings.NewReader(accessTokenData.Encode()))
 	accessTokenRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	accessTokenRequest.Header.Set("User-Agent", keycloakClient.userAgent)
+
+	if keycloakClient.userAgent != "" {
+		accessTokenRequest.Header.Set("User-Agent", keycloakClient.userAgent)
+	}
 
 	accessTokenResponse, err := keycloakClient.httpClient.Do(accessTokenRequest)
 	if err != nil {
@@ -151,7 +151,10 @@ func (keycloakClient *KeycloakClient) refresh() error {
 
 	refreshTokenRequest, _ := http.NewRequest(http.MethodPost, refreshTokenUrl, strings.NewReader(refreshTokenData.Encode()))
 	refreshTokenRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	refreshTokenRequest.Header.Set("User-Agent", keycloakClient.userAgent)
+
+	if keycloakClient.userAgent != "" {
+		refreshTokenRequest.Header.Set("User-Agent", keycloakClient.userAgent)
+	}
 
 	refreshTokenResponse, err := keycloakClient.httpClient.Do(refreshTokenRequest)
 	if err != nil {
@@ -210,7 +213,10 @@ func (keycloakClient *KeycloakClient) addRequestHeaders(request *http.Request) {
 
 	request.Header.Set("Authorization", fmt.Sprintf("%s %s", tokenType, accessToken))
 	request.Header.Set("Accept", "application/json")
-	request.Header.Set("User-Agent", keycloakClient.userAgent)
+
+	if keycloakClient.userAgent != "" {
+		request.Header.Set("User-Agent", keycloakClient.userAgent)
+	}
 
 	if request.Method == http.MethodPost || request.Method == http.MethodPut || request.Method == http.MethodDelete {
 		request.Header.Set("Content-type", "application/json")

--- a/keycloak/keycloak_client_test.go
+++ b/keycloak/keycloak_client_test.go
@@ -51,7 +51,7 @@ func TestAccKeycloakApiClientRefresh(t *testing.T) {
 		t.Fatal("KEYCLOAK_CLIENT_TIMEOUT must be an integer")
 	}
 
-	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), true, clientTimeout, "", false)
+	keycloakClient, err := NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), true, clientTimeout, "", false, "")
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/httpclient"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
 )
 
@@ -140,7 +141,6 @@ func KeycloakProvider() *schema.Provider {
 		},
 	}
 
-
 	provider.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
 		terraformVersion := provider.TerraformVersion
 		if terraformVersion == "" {
@@ -148,13 +148,16 @@ func KeycloakProvider() *schema.Provider {
 			// We can therefore assume that if it's missing it's 0.10 or 0.11
 			terraformVersion = "0.11+compatible"
 		}
-		return configureKeycloakProvider(d, terraformVersion)
+
+		userAgent := httpclient.TerraformUserAgent(terraformVersion)
+
+		return configureKeycloakProvider(d, userAgent)
 	}
 
 	return provider
 }
 
-func configureKeycloakProvider(data *schema.ResourceData, terraformVersion string) (interface{}, error) {
+func configureKeycloakProvider(data *schema.ResourceData, userAgent string) (interface{}, error) {
 	url := data.Get("url").(string)
 	clientId := data.Get("client_id").(string)
 	clientSecret := data.Get("client_secret").(string)
@@ -166,5 +169,5 @@ func configureKeycloakProvider(data *schema.ResourceData, terraformVersion strin
 	tlsInsecureSkipVerify := data.Get("tls_insecure_skip_verify").(bool)
 	rootCaCertificate := data.Get("root_ca_certificate").(string)
 
-	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password, initialLogin, clientTimeout, rootCaCertificate, tlsInsecureSkipVerify, terraformVersion)
+	return keycloak.NewKeycloakClient(url, clientId, clientSecret, realm, username, password, initialLogin, clientTimeout, rootCaCertificate, tlsInsecureSkipVerify, userAgent)
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/httpclient"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
 	"os"
@@ -25,7 +26,7 @@ func init() {
 		"keycloak": testAccProvider,
 	}
 
-	keycloakClient, _ = keycloak.NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), "", "", true, 5, "", false)
+	keycloakClient, _ = keycloak.NewKeycloakClient(os.Getenv("KEYCLOAK_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), "", "", true, 5, "", false, httpclient.TerraformUserAgent(testAccProvider.TerraformVersion))
 }
 
 func TestProvider(t *testing.T) {


### PR DESCRIPTION
Http requests now using the user-agent built by the terraform-plugin-sdk using the running terraform version string instead of the default Go user agent.

Before: `Go-http-client/1.1`
After: `HashiCorp Terraform/0.12.25 (+https://www.terraform.io) Terraform Plugin SDK/1.6.0`


Starting with Terraform version v.0.12 the running version Terraform can be obtained from the provider. However this field is not included in prior versions of Terraform and the running version cannot be discovered. As a way to support older versions, the version string of "0.11+compatible" is used. This was inspired by the way the aws provider plugin works, https://github.com/terraform-providers/terraform-provider-aws/commit/0e183c1c5919a6cc1727b829e7a6bf1968f8b265

Fix for issue #276.
 