### PR TITLE
Fix invalid syntax error when importing keycloak_openid_user_attribute_protocol_mapper resource

### DIFF
--- a/keycloak/openid_user_attribute_protocol_mapper.go
+++ b/keycloak/openid_user_attribute_protocol_mapper.go
@@ -65,7 +65,8 @@ func (protocolMapper *protocolMapper) convertToOpenIdUserAttributeProtocolMapper
 		return nil, err
 	}
 
-	aggregateAttributeValues, err := strconv.ParseBool(protocolMapper.Config[aggregateAttributeValuesField])
+	// aggregateAttributeValues's default is "", this is an issue when importing an existing mapper
+	aggregateAttributeValues, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[aggregateAttributeValuesField])
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When we import keycloak_openid_user_attribute_protocol_mapper resource, it causes the following invalid syntax error because `aggregateAttributeValues` is "" like `multivalued`.

```
Error: strconv.ParseBool: parsing "": invalid syntax
```

To resolve this issue, we can use `parseBoolAndTreatEmptyStringAsFalse` instead of `strconv.ParseBool` like `multivalued`.