### PR TITLE
allow specification of parentId in customer_federation

### DIFF
--- a/docs/resources/keycloak_custom_user_federation.md
+++ b/docs/resources/keycloak_custom_user_federation.md
@@ -33,6 +33,7 @@ The following arguments are supported:
 - `enabled` - (Optional) When `false`, this provider will not be used when performing queries for users. Defaults to `true`.
 - `priority` - (Optional) Priority of this provider when looking up users. Lower values are first. Defaults to `0`.
 - `cache_policy` - (Optional) Can be one of `DEFAULT`, `EVICT_DAILY`, `EVICT_WEEKLY`, `MAX_LIFESPAN`, or `NO_CACHE`. Defaults to `DEFAULT`.
+- `parent_id` - (Optional) Must be set to the realms' `internal_id`  when it differs from the realm. This can happen when existing resources are imported into the state.
 
 ### Import
 


### PR DESCRIPTION
This is a follow up of PR #270  and Issue #216 
User Federations are internally represented by components. Those components are linked to its realm using the parent_id attribute which is the realms' id and not necessarily its name. Using solely this provider everything is fine because realm-name == realm-internald.
However, when existing realms are imported into the provider's state, the realm's internal_id can be different from the realm's name.
Since PR #270 we have the realms' internal id at hand. This PR extends the behavior of the userfederation resource, so it is possible to use the realm's internal id and not the realm name as `parent_id`. For this an additional attribute parent_id can be added to the respective resources if they need this feature. Unfortunately we need to specify both: realm name for the keycloak api calls and the parent_id to reference the realm's internal id.
This PR uses the realm name as parent_id if it is not specified so nothing should break here.

- [x] Code
- [x] Tests
- [x] Docs
- [x] Rebase & tidy up

Note: This should also be fixed similarly at least for the ldap user federation provider. if time permits I could have a look into that resource as well.