### PR TITLE
Fix data source keycloak_group with nested group

### DIFF
--- a/docs/data_sources/keycloak_group.md
+++ b/docs/data_sources/keycloak_group.md
@@ -36,7 +36,7 @@ resource "keycloak_group_roles" "group_roles" {
 The following arguments are supported:
 
 - `realm_id` - (Required) The realm this group exists within.
-- `name` - (Required) The name of the group
+- `name` - (Required) The name of the group. If there are multiple groups match `name`, it will return the first one it found.
 
 ### Attributes Reference
 


### PR DESCRIPTION
This is the PR for fixing https://github.com/mrparkers/terraform-provider-keycloak/issues/333

The fix is not "complete", when there are multiple groups that match the filter `name`, it will return the first group it found (right now using DFS). This would cause some unexpected behaviors, for example, the `data` returned would change if new groups added with have the same with the `data` group name, or in case there are multiple nested groups share the same name, there is no option to get the desired one:
```
/core
--/developers
/cloud
--/developers
```
Unless we introduce another indicator (eg. `path`), I think this is the best we can try.
Notes: I am not too familiar with Golang if you found something weird, just let me know, thanks :)