### PR TITLE
Fixed issue of group datasource

### DIFF
--- a/docs/data_sources/keycloak_group.md
+++ b/docs/data_sources/keycloak_group.md
@@ -25,7 +25,7 @@ resource "keycloak_group_roles" "group_roles" {
     realm_id = "${keycloak_realm.realm.id}"
     group_id = "${data.keycloak_group.group.id}"
 
-    roles = [
+    role_ids = [
         "${data.keycloak_role.offline_access.id}"
     ]
 }

--- a/docs/data_sources/keycloak_role.md
+++ b/docs/data_sources/keycloak_role.md
@@ -27,7 +27,7 @@ resource "keycloak_group_roles" "group_roles" {
     realm_id = "${keycloak_realm.realm.id}"
     group_id = "${keycloak_group.group.id}"
 
-    roles = [
+    role_ids = [
         "${data.keycloak_role.offline_access.id}"
     ]
 }

--- a/keycloak/group.go
+++ b/keycloak/group.go
@@ -145,8 +145,8 @@ func (keycloakClient *KeycloakClient) GetGroupByName(realmId, name string) (*Gro
 
 	// The search may return more than 1 result even if there is a group exactly matching the search string
 	groupsPtr := make([]*Group, len(groups))
-	for i, group := range groups {
-		groupsPtr[i] = &group
+	for i := range groups {
+		groupsPtr[i] = &groups[i]
 	}
 	group := getGroupByDFS(name, groupsPtr)
 	if group != nil {

--- a/provider/data_source_keycloak_group_test.go
+++ b/provider/data_source_keycloak_group_test.go
@@ -101,11 +101,17 @@ resource "keycloak_group" "group" {
 	realm_id = "${keycloak_realm.realm.id}"
 }
 
+# we create another group with a similar name to make the data lookup more realistic
+resource "keycloak_group" "similar_group" {
+	name     = "%s_with_similar_name"
+	realm_id = "${keycloak_realm.realm.id}"
+}
+
 data "keycloak_group" "group" {
 	realm_id = "${keycloak_realm.realm.id}"
 	name     = "${keycloak_group.group.name}"
 }
-	`, realm, group)
+	`, realm, group, group)
 }
 
 func testDataSourceKeycloakGroup_nested(realm, group, groupNested string) string {


### PR DESCRIPTION
Fixed issue of group datasource that made terraform fail, when Keycloak returns more than one element on a group search by name. Courtesy of my colleagues Daniel Wortmann and Johannes König.