### PR TITLE
add docs for 'config' parameter in resource 'keycloak_custom_user_federation'

### DIFF
--- a/docs/resources/keycloak_custom_user_federation.md
+++ b/docs/resources/keycloak_custom_user_federation.md
@@ -20,6 +20,11 @@ resource "keycloak_custom_user_federation" "custom_user_federation" {
     provider_id = "custom"
 
     enabled     = true
+
+    config = {
+        dummyString = "foobar"
+        dummyBool   = true
+    }
 }
 ```
 
@@ -34,6 +39,7 @@ The following arguments are supported:
 - `priority` - (Optional) Priority of this provider when looking up users. Lower values are first. Defaults to `0`.
 - `cache_policy` - (Optional) Can be one of `DEFAULT`, `EVICT_DAILY`, `EVICT_WEEKLY`, `MAX_LIFESPAN`, or `NO_CACHE`. Defaults to `DEFAULT`.
 - `parent_id` - (Optional) Must be set to the realms' `internal_id`  when it differs from the realm. This can happen when existing resources are imported into the state.
+- `config` - (Optional) The provider configuration handed over to your custom user federation provider.
 
 ### Import
 


### PR DESCRIPTION
It took me some time to realize that `keycloak_custom_user_federation` can already hand through provider configuration to the user federation provider. So I decided to add some docs in this pull request. 

I also extended the `Example Usage` to indicate that values in the config can contain various types such as strings and bools.