### PR TITLE
Updated examples at docs to remove "Interpolation-only expressions are deprecated" warnings

### DIFF
--- a/docs/data_sources/keycloak_group.md
+++ b/docs/data_sources/keycloak_group.md
@@ -12,21 +12,21 @@ resource "keycloak_realm" "realm" {
 }
 
 data "keycloak_role" "offline_access" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "offline_access"
 }
 
 data "keycloak_group" "group" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "group"
 }
 
 resource "keycloak_group_roles" "group_roles" {
-    realm_id = "${keycloak_realm.realm.id}"
-    group_id = "${data.keycloak_group.group.id}"
+    realm_id = keycloak_realm.realm.id
+    group_id = data.keycloak_group.group.id
 
     role_ids = [
-        "${data.keycloak_role.offline_access.id}"
+        data.keycloak_role.offline_access.id
     ]
 }
 ```

--- a/docs/data_sources/keycloak_realm.md
+++ b/docs/data_sources/keycloak_realm.md
@@ -13,7 +13,7 @@ data "keycloak_realm" "realm" {
 # use the data source
 
 resource "keycloak_role" "group" {
-    realm_id = "${data.keycloak_realm.realm.id}"
+    realm_id = data.keycloak_realm.realm.id
     name     = "group"
 }
 

--- a/docs/data_sources/keycloak_role.md
+++ b/docs/data_sources/keycloak_role.md
@@ -12,23 +12,23 @@ resource "keycloak_realm" "realm" {
 }
 
 data "keycloak_role" "offline_access" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "offline_access"
 }
 
 # use the data source
 
 resource "keycloak_group" "group" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "group"
 }
 
 resource "keycloak_group_roles" "group_roles" {
-    realm_id = "${keycloak_realm.realm.id}"
-    group_id = "${keycloak_group.group.id}"
+    realm_id = keycloak_realm.realm.id
+    group_id = keycloak_group.group.id
 
     role_ids = [
-        "${data.keycloak_role.offline_access.id}"
+        data.keycloak_role.offline_access.id
     ]
 }
 ```
@@ -41,7 +41,7 @@ The following arguments are supported:
 - `client_id` - (Optional) When specified, this role is assumed to be a
   client role belonging to the client with the provided ID
 - `name` - (Required) The name of the role
-  
+
 ### Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:

--- a/docs/data_sources/keycloak_saml_client_installation_provider.md
+++ b/docs/data_sources/keycloak_saml_client_installation_provider.md
@@ -5,7 +5,7 @@ of a SAML Client.
 
 ### Example Usage
 
-In the example below, we extract the SAML metadata IDPSSODescriptor 
+In the example below, we extract the SAML metadata IDPSSODescriptor
 to pass it to the AWS IAM SAML Provider.
 
 ```hcl
@@ -15,7 +15,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_saml_client" "saml_client" {
-    realm_id                = "${keycloak_realm.realm.id}"
+    realm_id                = keycloak_realm.realm.id
     client_id               = "test-saml-client"
     name                    = "test-saml-client"
 
@@ -28,8 +28,8 @@ resource "keycloak_saml_client" "saml_client" {
 }
 
 data "keycloak_saml_client_installation_provider" "saml_idp_descriptor" {
-  realm_id    = "${keycloak_realm.realm.id}"
-  client_id   = "${keycloak_saml_client.saml_client}"
+  realm_id    = keycloak_realm.realm.id
+  client_id   = keycloak_saml_client.saml_client
   provider_id = "saml-idp-descriptor"
 }
 

--- a/docs/resources/keycloak_authentication_execution.md
+++ b/docs/resources/keycloak_authentication_execution.md
@@ -11,13 +11,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_authentication_flow" "flow" {
-	realm_id = "${keycloak_realm.realm.id}"
+	realm_id = keycloak_realm.realm.id
 	alias    = "my-flow-alias"
 }
 
 resource "keycloak_authentication_execution" "execution" {
-	realm_id          = "${keycloak_realm.realm.id}"
-	parent_flow_alias = "${keycloak_authentication_flow.flow.alias}"
+	realm_id          = keycloak_realm.realm.id
+	parent_flow_alias = keycloak_authentication_flow.flow.alias
 	authenticator     = "identity-provider-redirector"
     requirement       = "REQUIRED"
 }

--- a/docs/resources/keycloak_authentication_execution_config.md
+++ b/docs/resources/keycloak_authentication_execution_config.md
@@ -11,19 +11,19 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_authentication_flow" "flow" {
-	realm_id = "${keycloak_realm.realm.id}"
+	realm_id = keycloak_realm.realm.id
 	alias    = "my-flow-alias"
 }
 
 resource "keycloak_authentication_execution" "execution" {
-	realm_id          = "${keycloak_realm.realm.id}"
-	parent_flow_alias = "${keycloak_authentication_flow.flow.alias}"
+	realm_id          = keycloak_realm.realm.id
+	parent_flow_alias = keycloak_authentication_flow.flow.alias
 	authenticator     = "identity-provider-redirector"
 }
 
 resource "keycloak_authentication_execution_config" "config" {
-	realm_id     = "${keycloak_realm.realm.id}"
-	execution_id = "${keycloak_authentication_execution.execution.id}"
+	realm_id     = keycloak_realm.realm.id
+	execution_id = keycloak_authentication_execution.execution.id
 	alias        = "my-config-alias"
 	config = {
 		defaultProvider = "my-config-default-idp"

--- a/docs/resources/keycloak_custom_user_federation.md
+++ b/docs/resources/keycloak_custom_user_federation.md
@@ -16,7 +16,7 @@ resource "keycloak_realm" "realm" {
 
 resource "keycloak_custom_user_federation" "custom_user_federation" {
     name        = "custom"
-    realm_id    = "${keycloak_realm.realm.id}"
+    realm_id    = keycloak_realm.realm.id
     provider_id = "custom"
 
     enabled     = true

--- a/docs/resources/keycloak_default_groups.md
+++ b/docs/resources/keycloak_default_groups.md
@@ -14,14 +14,14 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_group" "group" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "my-group"
 }
 
 resource "keycloak_default_groups" "default" {
-    realm_id  = "${keycloak_realm.realm.id}"
-    group_ids = ["${keycloak_group.group.id}"]
-} 
+    realm_id  = keycloak_realm.realm.id
+    group_ids = [keycloak_group.group.id]
+}
 ```
 
 ### Argument Reference

--- a/docs/resources/keycloak_generic_client_protocol_mapper.md
+++ b/docs/resources/keycloak_generic_client_protocol_mapper.md
@@ -6,7 +6,7 @@ There are two uses cases for using this resource:
 * If you implemented a custom protocol mapper, this resource can be used to configure it
 * If the provider doesn't support a particular protocol mapper, this resource can be used instead.
 
-Due to the generic nature of this mapper, it is less user-friendly and more prone to configuration errors. 
+Due to the generic nature of this mapper, it is less user-friendly and more prone to configuration errors.
 Therefore, if possible, a specific mapper should be used.
 
 ### Example Usage
@@ -18,13 +18,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_saml_client" "saml_client" {
-  realm_id  = "${keycloak_realm.realm.id}"
+  realm_id  = keycloak_realm.realm.id
   client_id = "test-client"
 }
 
 resource "keycloak_generic_client_protocol_mapper" "saml_hardcode_attribute_mapper" {
-  realm_id        = "${keycloak_realm.realm.id}"
-  client_id       = "${keycloak_saml_client.saml_client.id}"
+  realm_id        = keycloak_realm.realm.id
+  client_id       = keycloak_saml_client.saml_client.id
   name            = "tes-mapper"
   protocol        = "saml"
   protocol_mapper = "saml-hardcode-attribute-mapper"

--- a/docs/resources/keycloak_group.md
+++ b/docs/resources/keycloak_group.md
@@ -20,19 +20,19 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_group" "parent_group" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "parent-group"
 }
 
 resource "keycloak_group" "child_group" {
-    realm_id  = "${keycloak_realm.realm.id}"
-    parent_id = "${keycloak_group.parent_group.id}"
+    realm_id  = keycloak_realm.realm.id
+    parent_id = keycloak_group.parent_group.id
     name      = "child-group"
 }
 
 resource "keycloak_group" "child_group_with_optional_attributes" {
-    realm_id  = "${keycloak_realm.realm.id}"
-    parent_id = "${keycloak_group.parent_group.id}"
+    realm_id  = keycloak_realm.realm.id
+    parent_id = keycloak_group.parent_group.id
     name      = "child-group-with-optional-attributes"
     attributes = {
 		"key1" = "value1"

--- a/docs/resources/keycloak_group_memberships.md
+++ b/docs/resources/keycloak_group_memberships.md
@@ -23,21 +23,21 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_group" "group" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "my-group"
 }
 
 resource "keycloak_user" "user" {
-	realm_id = "${keycloak_realm.realm.id}"
+	realm_id = keycloak_realm.realm.id
 	username = "my-user"
 }
 
 resource "keycloak_group_memberships" "group_members" {
-	realm_id = "${keycloak_realm.realm.id}"
-	group_id = "${keycloak_group.group.id}"
+	realm_id = keycloak_realm.realm.id
+	group_id = keycloak_group.group.id
 
 	members  = [
-		"${keycloak_user.user.username}"
+		keycloak_user.user.username
 	]
 }
 ```

--- a/docs/resources/keycloak_group_roles.md
+++ b/docs/resources/keycloak_group_roles.md
@@ -21,13 +21,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_role" "realm_role" {
-  realm_id    = "${keycloak_realm.realm.id}"
+  realm_id    = keycloak_realm.realm.id
   name        = "my-realm-role"
   description = "My Realm Role"
 }
 
 resource "keycloak_openid_client" "client" {
-  realm_id  = "${keycloak_realm.realm.id}"
+  realm_id  = keycloak_realm.realm.id
   client_id = "client"
   name      = "client"
 
@@ -37,24 +37,24 @@ resource "keycloak_openid_client" "client" {
 }
 
 resource "keycloak_role" "client_role" {
-  realm_id    = "${keycloak_realm.realm.id}"
-  client_id   = "${keycloak_client.client.id}"
+  realm_id    = keycloak_realm.realm.id
+  client_id   = keycloak_client.client.id
   name        = "my-client-role"
   description = "My Client Role"
 }
 
 resource "keycloak_group" "group" {
-  realm_id = "${keycloak_realm.realm.id}"
+  realm_id = keycloak_realm.realm.id
   name     = "my-group"
 }
 
 resource "keycloak_group_roles" "group_roles" {
-  realm_id = "${keycloak_realm.realm.id}"
-  group_id = "${keycloak_group.group.id}"
-  
+  realm_id = keycloak_realm.realm.id
+  group_id = keycloak_group.group.id
+
   role_ids = [
-    "${keycloak_role.realm_role.id}",
-    "${keycloak_role.client_role.id}",
+    keycloak_role.realm_role.id,
+    keycloak_role.client_role.id,
   ]
 }
 ```

--- a/docs/resources/keycloak_ldap_full_name_mapper.md
+++ b/docs/resources/keycloak_ldap_full_name_mapper.md
@@ -16,7 +16,7 @@ resource "keycloak_realm" "realm" {
 
 resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 	name                    = "openldap"
-	realm_id                = "${keycloak_realm.realm.id}"
+	realm_id                = keycloak_realm.realm.id
 
 	username_ldap_attribute = "cn"
 	rdn_ldap_attribute      = "cn"
@@ -32,8 +32,8 @@ resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 }
 
 resource "keycloak_ldap_full_name_mapper" "ldap_full_name_mapper" {
-	realm_id                 = "${keycloak_realm.realm.id}"
-	ldap_user_federation_id  = "${keycloak_ldap_user_federation.ldap_user_federation.id}"
+	realm_id                 = keycloak_realm.realm.id
+	ldap_user_federation_id  = keycloak_ldap_user_federation.ldap_user_federation.id
 	name                     = "full-name-mapper"
 	ldap_full_name_attribute = "cn"
 }

--- a/docs/resources/keycloak_ldap_group_mapper.md
+++ b/docs/resources/keycloak_ldap_group_mapper.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 
 resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 	name                    = "openldap"
-	realm_id                = "${keycloak_realm.realm.id}"
+	realm_id                = keycloak_realm.realm.id
 
 	username_ldap_attribute = "cn"
 	rdn_ldap_attribute      = "cn"
@@ -33,8 +33,8 @@ resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 }
 
 resource "keycloak_ldap_group_mapper" "ldap_group_mapper" {
-	realm_id                       = "${keycloak_realm.realm.id}"
-	ldap_user_federation_id        = "${keycloak_ldap_user_federation.ldap_user_federation.id}"
+	realm_id                       = keycloak_realm.realm.id
+	ldap_user_federation_id        = keycloak_ldap_user_federation.ldap_user_federation.id
 	name                           = "group-mapper"
 
 	ldap_groups_dn                 = "dc=example,dc=org"

--- a/docs/resources/keycloak_ldap_msad_lds_user_account_control_mapper.md
+++ b/docs/resources/keycloak_ldap_msad_lds_user_account_control_mapper.md
@@ -18,7 +18,7 @@ resource "keycloak_realm" "realm" {
 
 resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 	name                    = "ad"
-	realm_id                = "${keycloak_realm.realm.id}"
+	realm_id                = keycloak_realm.realm.id
 
 	username_ldap_attribute = "cn"
 	rdn_ldap_attribute      = "cn"
@@ -35,8 +35,8 @@ resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 }
 
 resource "keycloak_ldap_msad_lds_user_account_control_mapper" "msad_lds_user_account_control_mapper" {
-	realm_id                 = "${keycloak_realm.realm.id}"
-	ldap_user_federation_id  = "${keycloak_ldap_user_federation.ldap_user_federation.id}"
+	realm_id                 = keycloak_realm.realm.id
+	ldap_user_federation_id  = keycloak_ldap_user_federation.ldap_user_federation.id
 	name                     = "msad-lds-user-account-control-mapper"
 }
 ```

--- a/docs/resources/keycloak_ldap_msad_user_account_control_mapper.md
+++ b/docs/resources/keycloak_ldap_msad_user_account_control_mapper.md
@@ -18,7 +18,7 @@ resource "keycloak_realm" "realm" {
 
 resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 	name                    = "ad"
-	realm_id                = "${keycloak_realm.realm.id}"
+	realm_id                = keycloak_realm.realm.id
 
 	username_ldap_attribute = "cn"
 	rdn_ldap_attribute      = "cn"
@@ -35,8 +35,8 @@ resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 }
 
 resource "keycloak_ldap_msad_user_account_control_mapper" "msad_user_account_control_mapper" {
-	realm_id                 = "${keycloak_realm.realm.id}"
-	ldap_user_federation_id  = "${keycloak_ldap_user_federation.ldap_user_federation.id}"
+	realm_id                 = keycloak_realm.realm.id
+	ldap_user_federation_id  = keycloak_ldap_user_federation.ldap_user_federation.id
 	name                     = "msad-user-account-control-mapper"
 }
 ```

--- a/docs/resources/keycloak_ldap_user_attribute_mapper.md
+++ b/docs/resources/keycloak_ldap_user_attribute_mapper.md
@@ -16,7 +16,7 @@ resource "keycloak_realm" "realm" {
 
 resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 	name                    = "openldap"
-	realm_id                = "${keycloak_realm.realm.id}"
+	realm_id                = keycloak_realm.realm.id
 
 	username_ldap_attribute = "cn"
 	rdn_ldap_attribute      = "cn"
@@ -32,8 +32,8 @@ resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 }
 
 resource "keycloak_ldap_user_attribute_mapper" "ldap_user_attribute_mapper" {
-	realm_id                = "${keycloak_realm.realm.id}"
-	ldap_user_federation_id = "${keycloak_ldap_user_federation.ldap_user_federation.id}"
+	realm_id                = keycloak_realm.realm.id
+	ldap_user_federation_id = keycloak_ldap_user_federation.ldap_user_federation.id
 	name                    = "user-attribute-mapper"
 
 	user_model_attribute    = "foo"

--- a/docs/resources/keycloak_ldap_user_federation.md
+++ b/docs/resources/keycloak_ldap_user_federation.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 
 resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 	name                    = "openldap"
-	realm_id                = "${keycloak_realm.realm.id}"
+	realm_id                = keycloak_realm.realm.id
 
 	enabled                 = true
 

--- a/docs/resources/keycloak_oidc_identity_provider.md
+++ b/docs/resources/keycloak_oidc_identity_provider.md
@@ -22,7 +22,7 @@ resource "keycloak_oidc_identity_provider" "realm_identity_provider" {
   token_url         = "https://tokenurl.com"
 
   extra_config = {
-    "clientAuthMethod"                   = "client_secret_post"
+    "clientAuthMethod" = "client_secret_post"
   }
 }
 ```

--- a/docs/resources/keycloak_openid_audience_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_audience_protocol_mapper.md
@@ -16,7 +16,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client" "openid_client" {
-    realm_id            = "${keycloak_realm.realm.id}"
+    realm_id            = keycloak_realm.realm.id
     client_id           = "test-client"
 
     name                = "test client"
@@ -29,8 +29,8 @@ resource "keycloak_openid_client" "openid_client" {
 }
 
 resource "keycloak_openid_audience_protocol_mapper" "audience_mapper" {
-    realm_id                 = "${keycloak_realm.realm.id}"
-    client_id                = "${keycloak_openid_client.openid_client.id}"
+    realm_id                 = keycloak_realm.realm.id
+    client_id                = keycloak_openid_client.openid_client.id
     name                     = "audience-mapper"
 
     included_custom_audience = "foo"
@@ -46,13 +46,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 
 resource "keycloak_openid_audience_protocol_mapper" "audience_mapper" {
-    realm_id                 = "${keycloak_realm.realm.id}"
-    client_scope_id          = "${keycloak_openid_client_scope.client_scope.id}"
+    realm_id                 = keycloak_realm.realm.id
+    client_scope_id          = keycloak_openid_client_scope.client_scope.id
     name                     = "audience-mapper"
 
     included_custom_audience = "foo"

--- a/docs/resources/keycloak_openid_client.md
+++ b/docs/resources/keycloak_openid_client.md
@@ -15,7 +15,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client" "openid_client" {
-    realm_id            = "${keycloak_realm.realm.id}"
+    realm_id            = keycloak_realm.realm.id
     client_id           = "test-client"
 
     name                = "test client"

--- a/docs/resources/keycloak_openid_client_default_scopes.md
+++ b/docs/resources/keycloak_openid_client_default_scopes.md
@@ -25,27 +25,27 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client" "client" {
-    realm_id    = "${keycloak_realm.realm.id}"
+    realm_id    = keycloak_realm.realm.id
     client_id   = "test-client"
 
     access_type = "CONFIDENTIAL"
 }
 
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
-    realm_id       = "${keycloak_realm.realm.id}"
-    client_id      = "${keycloak_openid_client.client.id}"
+    realm_id       = keycloak_realm.realm.id
+    client_id      = keycloak_openid_client.client.id
 
     default_scopes = [
         "profile",
         "email",
         "roles",
         "web-origins",
-        "${keycloak_openid_client_scope.client_scope.name}"
+        keycloak_openid_client_scope.client_scope.name
     ]
 }
 

--- a/docs/resources/keycloak_openid_client_optional_scopes.md
+++ b/docs/resources/keycloak_openid_client_optional_scopes.md
@@ -26,26 +26,26 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client" "client" {
-    realm_id    = "${keycloak_realm.realm.id}"
+    realm_id    = keycloak_realm.realm.id
     client_id   = "test-client"
 
     access_type = "CONFIDENTIAL"
 }
 
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 
 resource "keycloak_openid_client_optional_scopes" "client_optional_scopes" {
-    realm_id       = "${keycloak_realm.realm.id}"
-    client_id      = "${keycloak_openid_client.client.id}"
+    realm_id       = keycloak_realm.realm.id
+    client_id      = keycloak_openid_client.client.id
 
     optional_scopes = [
         "address",
         "phone",
         "offline_access",
-        "${keycloak_openid_client_scope.client_scope.name}"
+        keycloak_openid_client_scope.client_scope.name
     ]
 }
 

--- a/docs/resources/keycloak_openid_client_scope.md
+++ b/docs/resources/keycloak_openid_client_scope.md
@@ -16,7 +16,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client_scope" "openid_client_scope" {
-    realm_id               = "${keycloak_realm.realm.id}"
+    realm_id               = keycloak_realm.realm.id
     name                   = "groups"
     description            = "When requested, this scope will map a user's group memberships to a claim"
     include_in_token_scope = true

--- a/docs/resources/keycloak_openid_full_name_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_full_name_protocol_mapper.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client" "openid_client" {
-    realm_id            = "${keycloak_realm.realm.id}"
+    realm_id            = keycloak_realm.realm.id
     client_id           = "test-client"
 
     name                = "test client"
@@ -30,8 +30,8 @@ resource "keycloak_openid_client" "openid_client" {
 }
 
 resource "keycloak_openid_full_name_protocol_mapper" "full_name_mapper" {
-    realm_id       = "${keycloak_realm.realm.id}"
-    client_id      = "${keycloak_openid_client.openid_client.id}"
+    realm_id       = keycloak_realm.realm.id
+    client_id      = keycloak_openid_client.openid_client.id
     name           = "full-name-mapper"
 }
 ```
@@ -45,13 +45,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 
 resource "keycloak_openid_full_name_protocol_mapper" "full_name_mapper" {
-    realm_id        = "${keycloak_realm.realm.id}"
-    client_scope_id = "${keycloak_openid_client_scope.client_scope.id}"
+    realm_id        = keycloak_realm.realm.id
+    client_scope_id = keycloak_openid_client_scope.client_scope.id
     name            = "full-name-mapper"
 }
 ```

--- a/docs/resources/keycloak_openid_group_membership_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_group_membership_protocol_mapper.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client" "openid_client" {
-    realm_id            = "${keycloak_realm.realm.id}"
+    realm_id            = keycloak_realm.realm.id
     client_id           = "test-client"
 
     name                = "test client"
@@ -30,8 +30,8 @@ resource "keycloak_openid_client" "openid_client" {
 }
 
 resource "keycloak_openid_group_membership_protocol_mapper" "group_membership_mapper" {
-    realm_id       = "${keycloak_realm.realm.id}"
-    client_id      = "${keycloak_openid_client.openid_client.id}"
+    realm_id       = keycloak_realm.realm.id
+    client_id      = keycloak_openid_client.openid_client.id
     name           = "group-membership-mapper"
 
     claim_name     = "groups"
@@ -47,13 +47,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 
 resource "keycloak_openid_group_membership_protocol_mapper" "group_membership_mapper" {
-    realm_id        = "${keycloak_realm.realm.id}"
-    client_scope_id = "${keycloak_openid_client_scope.client_scope.id}"
+    realm_id        = keycloak_realm.realm.id
+    client_scope_id = keycloak_openid_client_scope.client_scope.id
     name            = "group-membership-mapper"
 
     claim_name      = "groups"

--- a/docs/resources/keycloak_openid_hardcoded_claim_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_hardcoded_claim_protocol_mapper.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client" "openid_client" {
-    realm_id            = "${keycloak_realm.realm.id}"
+    realm_id            = keycloak_realm.realm.id
     client_id           = "test-client"
 
     name                = "test client"
@@ -30,8 +30,8 @@ resource "keycloak_openid_client" "openid_client" {
 }
 
 resource "keycloak_openid_hardcoded_claim_protocol_mapper" "hardcoded_claim_mapper" {
-    realm_id    = "${keycloak_realm.realm.id}"
-    client_id   = "${keycloak_openid_client.openid_client.id}"
+    realm_id    = keycloak_realm.realm.id
+    client_id   = keycloak_openid_client.openid_client.id
     name        = "hardcoded-claim-mapper"
 
     claim_name  = "foo"
@@ -48,13 +48,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 
 resource "keycloak_openid_hardcoded_claim_protocol_mapper" "hardcoded_claim_mapper" {
-    realm_id        = "${keycloak_realm.realm.id}"
-    client_scope_id = "${keycloak_openid_client_scope.client_scope.id}"
+    realm_id        = keycloak_realm.realm.id
+    client_scope_id = keycloak_openid_client_scope.client_scope.id
     name            = "hardcoded-claim-mapper"
 
     claim_name      = "foo"

--- a/docs/resources/keycloak_openid_hardcoded_role_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_hardcoded_role_protocol_mapper.md
@@ -17,12 +17,12 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_role" "role" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "my-role"
 }
 
 resource "keycloak_openid_client" "openid_client" {
-    realm_id            = "${keycloak_realm.realm.id}"
+    realm_id            = keycloak_realm.realm.id
     client_id           = "test-client"
 
     name                = "test client"
@@ -35,10 +35,10 @@ resource "keycloak_openid_client" "openid_client" {
 }
 
 resource "keycloak_openid_hardcoded_role_protocol_mapper" "hardcoded_role_mapper" {
-    realm_id  = "${keycloak_realm.realm.id}"
-    client_id = "${keycloak_openid_client.openid_client.id}"
+    realm_id  = keycloak_realm.realm.id
+    client_id = keycloak_openid_client.openid_client.id
     name      = "hardcoded-role-mapper"
-    role_id   = "${keycloak_role.role.id}"
+    role_id   = keycloak_role.role.id
 }
 ```
 
@@ -51,18 +51,18 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_role" "role" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "my-role"
 }
 
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 
 resource "keycloak_openid_hardcoded_role_protocol_mapper" "hardcoded_role_mapper" {
-    realm_id        = "${keycloak_realm.realm.id}"
-    client_scope_id = "${keycloak_openid_client_scope.client_scope.id}"
+    realm_id        = keycloak_realm.realm.id
+    client_scope_id = keycloak_openid_client_scope.client_scope.id
     name            = "hardcoded-role-mapper"
     role_id         = "${keycloak_role.role.id}"
 }

--- a/docs/resources/keycloak_openid_user_attribute_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_user_attribute_protocol_mapper.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client" "openid_client" {
-    realm_id            = "${keycloak_realm.realm.id}"
+    realm_id            = keycloak_realm.realm.id
     client_id           = "test-client"
 
     name                = "test client"
@@ -30,8 +30,8 @@ resource "keycloak_openid_client" "openid_client" {
 }
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "user_attribute_mapper" {
-    realm_id       = "${keycloak_realm.realm.id}"
-    client_id      = "${keycloak_openid_client.openid_client.id}"
+    realm_id       = keycloak_realm.realm.id
+    client_id      = keycloak_openid_client.openid_client.id
     name           = "test-mapper"
 
     user_attribute = "foo"
@@ -48,13 +48,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "user_attribute_mapper" {
-    realm_id        = "${keycloak_realm.realm.id}"
-    client_scope_id = "${keycloak_openid_client_scope.client_scope.id}"
+    realm_id        = keycloak_realm.realm.id
+    client_scope_id = keycloak_openid_client_scope.client_scope.id
     name            = "test-mapper"
 
     user_attribute  = "foo"

--- a/docs/resources/keycloak_openid_user_client_role_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_user_client_role_protocol_mapper.md
@@ -16,7 +16,7 @@ resource "keycloak_realm" "realm" {
     enabled = true
 }
 resource "keycloak_openid_client" "openid_client" {
-    realm_id            = "${keycloak_realm.realm.id}"
+    realm_id            = keycloak_realm.realm.id
     client_id           = "test-client"
     name                = "test client"
     enabled             = true
@@ -26,8 +26,8 @@ resource "keycloak_openid_client" "openid_client" {
     ]
 }
 resource "keycloak_openid_user_client_role_protocol_mapper" "user_client_role_mapper" {
-    realm_id    = "${keycloak_realm.realm.id}"
-    client_id   = "${keycloak_openid_client.openid_client.id}"
+    realm_id    = keycloak_realm.realm.id
+    client_id   = keycloak_openid_client.openid_client.id
     name        = "user-client-role-mapper"
     claim_name  = "foo"
 }
@@ -41,12 +41,12 @@ resource "keycloak_realm" "realm" {
     enabled = true
 }
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 resource "keycloak_openid_user_client_role_protocol_mapper" "user_client_role_mapper" {
-    realm_id        = "${keycloak_realm.realm.id}"
-    client_scope_id = "${keycloak_openid_client_scope.client_scope.id}"
+    realm_id        = keycloak_realm.realm.id
+    client_scope_id = keycloak_openid_client_scope.client_scope.id
     name            = "user-client-role-mapper"
     claim_name      = "foo"
 }
@@ -63,7 +63,7 @@ The following arguments are supported:
 - `claim_name` - (Required) The name of the claim to insert into a token.
 - `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `JSON`, `long`, `int`, or `boolean`. Defaults to `String`.
 - `multivalued` - (Optional) Indicates if attribute supports multiple values. If true, then the list of all values of this attribute will be set as claim. If false, then just first value will be set as claim. Defaults to `false`.
-- `client_id_for_role_mappings` - (Optional) The Client ID for role mappings. Just client roles of this client will be added to the token. If this is unset, client roles of all clients will be added to the token. 
+- `client_id_for_role_mappings` - (Optional) The Client ID for role mappings. Just client roles of this client will be added to the token. If this is unset, client roles of all clients will be added to the token.
 - `client_role_prefix` - (Optional) A prefix for each Client Role.
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.

--- a/docs/resources/keycloak_openid_user_property_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_user_property_protocol_mapper.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client" "openid_client" {
-    realm_id            = "${keycloak_realm.realm.id}"
+    realm_id            = keycloak_realm.realm.id
     client_id           = "test-client"
 
     name                = "test client"
@@ -30,8 +30,8 @@ resource "keycloak_openid_client" "openid_client" {
 }
 
 resource "keycloak_openid_user_property_protocol_mapper" "user_property_mapper" {
-    realm_id       = "${keycloak_realm.realm.id}"
-    client_id      = "${keycloak_openid_client.openid_client.id}"
+    realm_id       = keycloak_realm.realm.id
+    client_id      = keycloak_openid_client.openid_client.id
     name           = "test-mapper"
 
     user_property  = "email"
@@ -48,13 +48,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 
 resource "keycloak_openid_user_property_protocol_mapper" "user_property_mapper" {
-    realm_id        = "${keycloak_realm.realm.id}"
-    client_scope_id = "${keycloak_openid_client_scope.client_scope.id}"
+    realm_id        = keycloak_realm.realm.id
+    client_scope_id = keycloak_openid_client_scope.client_scope.id
     name            = "test-mapper"
 
     user_property   = "email"

--- a/docs/resources/keycloak_openid_user_realm_role_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_user_realm_role_protocol_mapper.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client" "openid_client" {
-    realm_id            = "${keycloak_realm.realm.id}"
+    realm_id            = keycloak_realm.realm.id
     client_id           = "test-client"
 
     name                = "test client"
@@ -30,8 +30,8 @@ resource "keycloak_openid_client" "openid_client" {
 }
 
 resource "keycloak_openid_user_realm_role_protocol_mapper" "user_realm_role_mapper" {
-    realm_id    = "${keycloak_realm.realm.id}"
-    client_id   = "${keycloak_openid_client.openid_client.id}"
+    realm_id    = keycloak_realm.realm.id
+    client_id   = keycloak_openid_client.openid_client.id
     name        = "user-realm-role-mapper"
 
     claim_name  = "foo"
@@ -47,13 +47,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 
 resource "keycloak_openid_user_realm_role_protocol_mapper" "user_realm_role_mapper" {
-    realm_id        = "${keycloak_realm.realm.id}"
-    client_scope_id = "${keycloak_openid_client_scope.client_scope.id}"
+    realm_id        = keycloak_realm.realm.id
+    client_scope_id = keycloak_openid_client_scope.client_scope.id
     name            = "user-realm-role-mapper"
 
     claim_name      = "foo"

--- a/docs/resources/keycloak_openid_user_session_note_protocol_mapper.md
+++ b/docs/resources/keycloak_openid_user_session_note_protocol_mapper.md
@@ -16,7 +16,7 @@ resource "keycloak_realm" "realm" {
     enabled = true
 }
 resource "keycloak_openid_client" "openid_client" {
-    realm_id            = "${keycloak_realm.realm.id}"
+    realm_id            = keycloak_realm.realm.id
     client_id           = "test-client"
     name                = "test client"
     enabled             = true
@@ -27,8 +27,8 @@ resource "keycloak_openid_client" "openid_client" {
 }
 resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_client" {
 	name               = "tf-test-open-id-user-session-note-protocol-mapper-client"
-	realm_id           = "${keycloak_realm.realm.id}"
-	client_id          = "${keycloak_openid_client.openid_client.id}"
+	realm_id           = keycloak_realm.realm.id
+	client_id          = keycloak_openid_client.openid_client.id
 	claim_name         = "foo"
 	claim_value_type   = "String"
 	session_note_label = "bar"
@@ -45,13 +45,13 @@ resource "keycloak_realm" "realm" {
     enabled = true
 }
 resource "keycloak_openid_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_client_scope" {
 	name               = "tf-test-open-id-user-session-note-protocol-mapper-client-scope"
-	realm_id           = "${keycloak_realm.realm.id}"
-	client_scope_id    = "${keycloak_openid_client_scope.client_scope.id}"
+	realm_id           = keycloak_realm.realm.id
+	client_scope_id    = keycloak_openid_client_scope.client_scope.id
 	claim_name         = "foo"
 	claim_value_type   = "String"
 	session_note_label = "bar"

--- a/docs/resources/keycloak_realm_events.md
+++ b/docs/resources/keycloak_realm_events.md
@@ -10,7 +10,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_realm_events" "realm_events" {
-  realm_id = "${keycloak_realm.realm.id}"
+  realm_id = keycloak_realm.realm.id
 
   events_enabled       = true
   events_expiration    = 3600

--- a/docs/resources/keycloak_role.md
+++ b/docs/resources/keycloak_role.md
@@ -14,7 +14,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_role" "realm_role" {
-    realm_id    = "${keycloak_realm.realm.id}"
+    realm_id    = keycloak_realm.realm.id
     name        = "my-realm-role"
     description = "My Realm Role"
 }
@@ -29,7 +29,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client" "client" {
-  realm_id  = "${keycloak_realm.realm.id}"
+  realm_id  = keycloak_realm.realm.id
   client_id = "client"
   name      = "client"
 
@@ -39,8 +39,8 @@ resource "keycloak_openid_client" "client" {
 }
 
 resource "keycloak_role" "client_role" {
-    realm_id    = "${keycloak_realm.realm.id}"
-    client_id   = "${keycloak_client.client.id}"
+    realm_id    = keycloak_realm.realm.id
+    client_id   = keycloak_client.client.id
     name        = "my-client-role"
     description = "My Client Role"
 }
@@ -57,29 +57,29 @@ resource "keycloak_realm" "realm" {
 # realm roles
 
 resource "keycloak_role" "create_role" {
-    realm_id    = "${keycloak_realm.realm.id}"
+    realm_id    = keycloak_realm.realm.id
     name        = "create"
 }
 
 resource "keycloak_role" "read_role" {
-    realm_id    = "${keycloak_realm.realm.id}"
+    realm_id    = keycloak_realm.realm.id
     name        = "read"
 }
 
 resource "keycloak_role" "update_role" {
-    realm_id    = "${keycloak_realm.realm.id}"
+    realm_id    = keycloak_realm.realm.id
     name        = "update"
 }
 
 resource "keycloak_role" "delete_role" {
-    realm_id    = "${keycloak_realm.realm.id}"
+    realm_id    = keycloak_realm.realm.id
     name        = "delete"
 }
 
 # client role
 
 resource "keycloak_openid_client" "client" {
-  realm_id  = "${keycloak_realm.realm.id}"
+  realm_id  = keycloak_realm.realm.id
   client_id = "client"
   name      = "client"
 
@@ -89,14 +89,14 @@ resource "keycloak_openid_client" "client" {
 }
 
 resource "keycloak_role" "client_role" {
-    realm_id    = "${keycloak_realm.realm.id}"
-    client_id   = "${keycloak_client.client.id}"
+    realm_id    = keycloak_realm.realm.id
+    client_id   = keycloak_client.client.id
     name        = "my-client-role"
     description = "My Client Role"
 }
 
 resource "keycloak_role" "admin_role" {
-    realm_id        = "${keycloak_realm.realm.id}"
+    realm_id        = keycloak_realm.realm.id
     name            = "admin"
     composite_roles = [
       "{keycloak_role.create_role.id}",

--- a/docs/resources/keycloak_saml_client.md
+++ b/docs/resources/keycloak_saml_client.md
@@ -15,7 +15,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_saml_client" "saml_client" {
-	realm_id                = "${keycloak_realm.realm.id}"
+	realm_id                = keycloak_realm.realm.id
 	client_id               = "test-saml-client"
 	name                    = "test-saml-client"
 

--- a/docs/resources/keycloak_saml_client_default_scopes.md
+++ b/docs/resources/keycloak_saml_client_default_scopes.md
@@ -25,7 +25,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_saml_client" "client" {
-	realm_id                = "${keycloak_realm.realm.id}"
+	realm_id                = keycloak_realm.realm.id
 	client_id               = "test-saml-client"
 	name                    = "test-saml-client"
 
@@ -38,17 +38,17 @@ resource "keycloak_saml_client" "client" {
 }
 
 resource "keycloak_saml_client_scope" "client_scope" {
-    realm_id = "${keycloak_realm.realm.id}"
+    realm_id = keycloak_realm.realm.id
     name     = "test-client-scope"
 }
 
 resource "keycloak_saml_client_default_scopes" "client_default_scopes" {
-    realm_id       = "${keycloak_realm.realm.id}"
-    client_id      = "${keycloak_saml_client.client.id}"
+    realm_id       = keycloak_realm.realm.id
+    client_id      = keycloak_saml_client.client.id
 
     default_scopes = [
         "role_list",
-        "${keycloak_saml_client_scope.client_scope.name}"
+        keycloak_saml_client_scope.client_scope.name
     ]
 }
 

--- a/docs/resources/keycloak_saml_client_scope.md
+++ b/docs/resources/keycloak_saml_client_scope.md
@@ -15,7 +15,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_saml_client_scope" "saml_client_scope" {
-    realm_id    = "${keycloak_realm.realm.id}"
+    realm_id    = keycloak_realm.realm.id
     name        = "groups"
     description = "This scope will map a user's group memberships to SAML assertion"
     gui_order   = 1

--- a/docs/resources/keycloak_saml_user_attribute_protocol_mapper.md
+++ b/docs/resources/keycloak_saml_user_attribute_protocol_mapper.md
@@ -17,14 +17,14 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_saml_client" "saml_client" {
-    realm_id  = "${keycloak_realm.test.id}"
+    realm_id  = keycloak_realm.test.id
     client_id = "test-saml-client"
     name      = "test-saml-client"
 }
 
 resource "keycloak_saml_user_attribute_protocol_mapper" "saml_user_attribute_mapper" {
-    realm_id                   = "${keycloak_realm.test.id}"
-    client_id                  = "${keycloak_saml_client.saml_client.id}"
+    realm_id                   = keycloak_realm.test.id
+    client_id                  = keycloak_saml_client.saml_client.id
     name                       = "displayname-user-attribute-mapper"
 
     user_attribute             = "displayName"

--- a/docs/resources/keycloak_saml_user_property_protocol_mapper.md
+++ b/docs/resources/keycloak_saml_user_property_protocol_mapper.md
@@ -17,14 +17,14 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_saml_client" "saml_client" {
-    realm_id  = "${keycloak_realm.test.id}"
+    realm_id  = keycloak_realm.test.id
     client_id = "test-saml-client"
     name      = "test-saml-client"
 }
 
 resource "keycloak_saml_user_property_protocol_mapper" "saml_user_property_mapper" {
-    realm_id                   = "${keycloak_realm.test.id}"
-    client_id                  = "${keycloak_saml_client.saml_client.id}"
+    realm_id                   = keycloak_realm.test.id
+    client_id                  = keycloak_saml_client.saml_client.id
     name                       = "email-user-property-mapper"
 
     user_property              = "email"

--- a/docs/resources/keycloak_user.md
+++ b/docs/resources/keycloak_user.md
@@ -15,7 +15,7 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_user" "user" {
-    realm_id   = "${keycloak_realm.realm.id}"
+    realm_id   = keycloak_realm.realm.id
     username   = "bob"
     enabled    = true
 
@@ -25,7 +25,7 @@ resource "keycloak_user" "user" {
 }
 
 resource "keycloak_user" "user_with_initial_password" {
-    realm_id   = "${keycloak_realm.realm.id}"
+    realm_id   = keycloak_realm.realm.id
     username   = "alice"
     enabled    = true
 

--- a/docs/resources/keycloak_user_roles.md
+++ b/docs/resources/keycloak_user_roles.md
@@ -21,13 +21,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_role" "realm_role" {
-  realm_id    = "${keycloak_realm.realm.id}"
+  realm_id    = keycloak_realm.realm.id
   name        = "my-realm-role"
   description = "My Realm Role"
 }
 
 resource "keycloak_openid_client" "client" {
-  realm_id  = "${keycloak_realm.realm.id}"
+  realm_id  = keycloak_realm.realm.id
   client_id = "client"
   name      = "client"
 
@@ -37,14 +37,14 @@ resource "keycloak_openid_client" "client" {
 }
 
 resource "keycloak_role" "client_role" {
-  realm_id    = "${keycloak_realm.realm.id}"
-  client_id   = "${keycloak_client.client.id}"
+  realm_id    = keycloak_realm.realm.id
+  client_id   = keycloak_client.client.id
   name        = "my-client-role"
   description = "My Client Role"
 }
 
 resource "keycloak_user" "user" {
-    realm_id   = "${keycloak_realm.realm.id}"
+    realm_id   = keycloak_realm.realm.id
     username   = "bob"
     enabled    = true
 
@@ -54,12 +54,12 @@ resource "keycloak_user" "user" {
 }
 
 resource "keycloak_user_roles" "user_roles" {
-  realm_id = "${keycloak_realm.realm.id}"
-  user_id = "${keycloak_user.user.id}"
+  realm_id = keycloak_realm.realm.id
+  user_id = keycloak_user.user.id
 
   role_ids = [
-    "${keycloak_role.realm_role.id}",
-    "${keycloak_role.client_role.id}",
+    keycloak_role.realm_role.id,
+    keycloak_role.client_role.id,
   ]
 }
 ```


### PR DESCRIPTION
Hello,

I updated the examples at `docs/resources` and `docs/data_sources` to remove the terraform `Warning: Interpolation-only expressions are deprecated`

At some examples the new syntax was already used and this PR updates the rest of the examples.