### PR TITLE
Add field session_note to user session protocol mapper. This field ne…

### DIFF
--- a/docs-old/resources/keycloak_openid_user_session_note_protocol_mapper.md
+++ b/docs-old/resources/keycloak_openid_user_session_note_protocol_mapper.md
@@ -31,6 +31,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	client_id          = keycloak_openid_client.openid_client.id
 	claim_name         = "foo"
 	claim_value_type   = "String"
+	session_note       = "bar"
 	session_note_label = "bar"
     add_to_id_token     = true
     add_to_access_token = false
@@ -54,6 +55,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	client_scope_id    = keycloak_openid_client_scope.client_scope.id
 	claim_name         = "foo"
 	claim_value_type   = "String"
+	session_note       = "bar"
 	session_note_label = "bar"
     add_to_id_token     = true
     add_to_access_token = false
@@ -70,6 +72,7 @@ The following arguments are supported:
 - `name` - (Required) The display name of this protocol mapper in the GUI.
 - `claim_name` - (Required) The name of the claim to insert into a token.
 - `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `JSON`, `long`, `int`, or `boolean`. Defaults to `String`.
+- `session_note` - (Optional) String value being the name of stored user session note within the UserSession.note map.
 - `session_note_label` - (Optional) String value being the name of stored user session note within the UserSessionModel.note map.
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.

--- a/docs-old/resources/keycloak_openid_user_session_note_protocol_mapper.md
+++ b/docs-old/resources/keycloak_openid_user_session_note_protocol_mapper.md
@@ -32,7 +32,6 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	claim_name         = "foo"
 	claim_value_type   = "String"
 	session_note       = "bar"
-	session_note_label = "bar"
     add_to_id_token     = true
     add_to_access_token = false
 }
@@ -56,7 +55,6 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	claim_name         = "foo"
 	claim_value_type   = "String"
 	session_note       = "bar"
-	session_note_label = "bar"
     add_to_id_token     = true
     add_to_access_token = false
 }
@@ -73,7 +71,6 @@ The following arguments are supported:
 - `claim_name` - (Required) The name of the claim to insert into a token.
 - `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `JSON`, `long`, `int`, or `boolean`. Defaults to `String`.
 - `session_note` - (Optional) String value being the name of stored user session note within the UserSession.note map.
-- `session_note_label` - (Optional) String value being the name of stored user session note within the UserSessionModel.note map.
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.
 

--- a/docs-old/resources/keycloak_openid_user_session_note_protocol_mapper.md
+++ b/docs-old/resources/keycloak_openid_user_session_note_protocol_mapper.md
@@ -70,7 +70,8 @@ The following arguments are supported:
 - `name` - (Required) The display name of this protocol mapper in the GUI.
 - `claim_name` - (Required) The name of the claim to insert into a token.
 - `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `JSON`, `long`, `int`, or `boolean`. Defaults to `String`.
-- `session_note` - (Optional) String value being the name of stored user session note within the UserSession.note map.
+- `session_note` - (Optional) String value being the name of stored user session note within the UserSessionModel.note map.
+- `session_note_label` - (Optional) **Deprecated** Use `session_note` instead.
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.
 

--- a/docs/resources/openid_user_session_note_protocol_mapper.md
+++ b/docs/resources/openid_user_session_note_protocol_mapper.md
@@ -39,7 +39,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 
   claim_name         = "foo"
   claim_value_type   = "String"
-  session_note_label = "bar"
+  session_note       = "bar"
 }
 ```
 
@@ -63,7 +63,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 
   claim_name         = "foo"
   claim_value_type   = "String"
-  session_note_label = "bar"
+  session_note       = "bar"
 }
 ```
 
@@ -75,7 +75,8 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 - `client_id` - (Optional) The client this protocol mapper should be attached to. Conflicts with `client_scope_id`. One of `client_id` or `client_scope_id` must be specified.
 - `client_scope_id` - (Optional) The client scope this protocol mapper should be attached to. Conflicts with `client_id`. One of `client_id` or `client_scope_id` must be specified.
 - `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `JSON`, `long`, `int`, or `boolean`. Defaults to `String`.
-- `session_note_label` - (Optional) String value being the name of stored user session note within the UserSessionModel.note map.
+- `session_note` - (Optional) String value being the name of stored user session note within the UserSessionModel.note map.
+- `session_note_label` - (Optional) **Deprecated** Use `session_note` instead.
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -450,7 +450,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 
 	claim_name         = "foo"
 	claim_value_type   = "String"
-	session_note_label = "bar"
+	session_note       = "bar"
 
   add_to_id_token     = true
   add_to_access_token = false
@@ -463,7 +463,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 
 	claim_name         = "foo2"
 	claim_value_type   = "String"
-	session_note_label = "bar2"
+	session_note       = "bar2"
 
   add_to_id_token     = true
   add_to_access_token = false

--- a/keycloak/openid_user_session_note_protocol_mapper.go
+++ b/keycloak/openid_user_session_note_protocol_mapper.go
@@ -17,6 +17,7 @@ type OpenIdUserSessionNoteProtocolMapper struct {
 
 	ClaimName            string
 	ClaimValueType       string
+	UserSessionNote      string
 	UserSessionNoteLabel string
 }
 
@@ -31,6 +32,7 @@ func (mapper *OpenIdUserSessionNoteProtocolMapper) convertToGenericProtocolMappe
 			addToAccessTokenField:          strconv.FormatBool(mapper.AddToAccessToken),
 			claimNameField:                 mapper.ClaimName,
 			claimValueTypeField:            mapper.ClaimValueType,
+			userSessionNoteField:           mapper.UserSessionNote,
 			userSessionModelNoteLabelField: mapper.UserSessionNoteLabel,
 		},
 	}
@@ -59,6 +61,7 @@ func (protocolMapper *protocolMapper) convertToOpenIdUserSessionNoteProtocolMapp
 
 		ClaimName:            protocolMapper.Config[claimNameField],
 		ClaimValueType:       protocolMapper.Config[claimValueTypeField],
+		UserSessionNote:      protocolMapper.Config[userSessionNoteField],
 		UserSessionNoteLabel: protocolMapper.Config[userSessionModelNoteLabelField],
 	}, nil
 }

--- a/keycloak/openid_user_session_note_protocol_mapper.go
+++ b/keycloak/openid_user_session_note_protocol_mapper.go
@@ -18,7 +18,6 @@ type OpenIdUserSessionNoteProtocolMapper struct {
 	ClaimName            string
 	ClaimValueType       string
 	UserSessionNote      string
-	UserSessionNoteLabel string
 }
 
 func (mapper *OpenIdUserSessionNoteProtocolMapper) convertToGenericProtocolMapper() *protocolMapper {
@@ -33,7 +32,6 @@ func (mapper *OpenIdUserSessionNoteProtocolMapper) convertToGenericProtocolMappe
 			claimNameField:                 mapper.ClaimName,
 			claimValueTypeField:            mapper.ClaimValueType,
 			userSessionNoteField:           mapper.UserSessionNote,
-			userSessionModelNoteLabelField: mapper.UserSessionNoteLabel,
 		},
 	}
 }
@@ -62,7 +60,6 @@ func (protocolMapper *protocolMapper) convertToOpenIdUserSessionNoteProtocolMapp
 		ClaimName:            protocolMapper.Config[claimNameField],
 		ClaimValueType:       protocolMapper.Config[claimValueTypeField],
 		UserSessionNote:      protocolMapper.Config[userSessionNoteField],
-		UserSessionNoteLabel: protocolMapper.Config[userSessionModelNoteLabelField],
 	}, nil
 }
 

--- a/keycloak/openid_user_session_note_protocol_mapper.go
+++ b/keycloak/openid_user_session_note_protocol_mapper.go
@@ -15,9 +15,9 @@ type OpenIdUserSessionNoteProtocolMapper struct {
 	AddToIdToken     bool
 	AddToAccessToken bool
 
-	ClaimName            string
-	ClaimValueType       string
-	UserSessionNote      string
+	ClaimName       string
+	ClaimValueType  string
+	UserSessionNote string
 }
 
 func (mapper *OpenIdUserSessionNoteProtocolMapper) convertToGenericProtocolMapper() *protocolMapper {
@@ -27,11 +27,11 @@ func (mapper *OpenIdUserSessionNoteProtocolMapper) convertToGenericProtocolMappe
 		Protocol:       "openid-connect",
 		ProtocolMapper: "oidc-usersessionmodel-note-mapper",
 		Config: map[string]string{
-			addToIdTokenField:              strconv.FormatBool(mapper.AddToIdToken),
-			addToAccessTokenField:          strconv.FormatBool(mapper.AddToAccessToken),
-			claimNameField:                 mapper.ClaimName,
-			claimValueTypeField:            mapper.ClaimValueType,
-			userSessionNoteField:           mapper.UserSessionNote,
+			addToIdTokenField:     strconv.FormatBool(mapper.AddToIdToken),
+			addToAccessTokenField: strconv.FormatBool(mapper.AddToAccessToken),
+			claimNameField:        mapper.ClaimName,
+			claimValueTypeField:   mapper.ClaimValueType,
+			userSessionNoteField:  mapper.UserSessionNote,
 		},
 	}
 }
@@ -57,9 +57,9 @@ func (protocolMapper *protocolMapper) convertToOpenIdUserSessionNoteProtocolMapp
 		AddToIdToken:     addToIdToken,
 		AddToAccessToken: addToAccessToken,
 
-		ClaimName:            protocolMapper.Config[claimNameField],
-		ClaimValueType:       protocolMapper.Config[claimValueTypeField],
-		UserSessionNote:      protocolMapper.Config[userSessionNoteField],
+		ClaimName:       protocolMapper.Config[claimNameField],
+		ClaimValueType:  protocolMapper.Config[claimValueTypeField],
+		UserSessionNote: protocolMapper.Config[userSessionNoteField],
 	}, nil
 }
 

--- a/keycloak/protocol_mapper.go
+++ b/keycloak/protocol_mapper.go
@@ -30,6 +30,7 @@ var (
 	userRealmRoleMappingRolePrefixField  = "usermodel.realmRoleMapping.rolePrefix"
 	userClientRoleMappingClientIdField   = "usermodel.clientRoleMapping.clientId"
 	userClientRoleMappingRolePrefixField = "usermodel.clientRoleMapping.rolePrefix"
+	userSessionNoteField                 = "user.session.note"
 	userSessionModelNoteLabelField       = "userSession.modelNote.label"
 	aggregateAttributeValuesField        = "aggregate.attrs"
 )

--- a/keycloak/protocol_mapper.go
+++ b/keycloak/protocol_mapper.go
@@ -31,7 +31,6 @@ var (
 	userClientRoleMappingClientIdField   = "usermodel.clientRoleMapping.clientId"
 	userClientRoleMappingRolePrefixField = "usermodel.clientRoleMapping.rolePrefix"
 	userSessionNoteField                 = "user.session.note"
-	userSessionModelNoteLabelField       = "userSession.modelNote.label"
 	aggregateAttributeValuesField        = "aggregate.attrs"
 )
 

--- a/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
@@ -68,6 +68,11 @@ func resourceKeycloakOpenIdUserSessionNoteProtocolMapper() *schema.Resource {
 				Default:      "String",
 				ValidateFunc: validation.StringInSlice([]string{"JSON", "String", "long", "int", "boolean"}, true),
 			},
+			"session_note": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "String value being the name of stored user session note within the UserSessionModel.note map.",
+			},
 			"session_note_label": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -89,6 +94,7 @@ func mapFromDataToOpenIdUserSessionNoteProtocolMapper(data *schema.ResourceData)
 
 		ClaimName:            data.Get("claim_name").(string),
 		ClaimValueType:       data.Get("claim_value_type").(string),
+		UserSessionNote:      data.Get("session_note").(string),
 		UserSessionNoteLabel: data.Get("session_note_label").(string),
 	}
 }
@@ -108,6 +114,7 @@ func mapFromOpenIdUserSessionNoteMapperToData(mapper *keycloak.OpenIdUserSession
 	data.Set("add_to_access_token", mapper.AddToAccessToken)
 	data.Set("claim_name", mapper.ClaimName)
 	data.Set("claim_value_type", mapper.ClaimValueType)
+	data.Set("session_note", mapper.UserSessionNote)
 	data.Set("session_note_label", mapper.UserSessionNoteLabel)
 }
 

--- a/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
@@ -68,16 +68,31 @@ func resourceKeycloakOpenIdUserSessionNoteProtocolMapper() *schema.Resource {
 				Default:      "String",
 				ValidateFunc: validation.StringInSlice([]string{"JSON", "String", "long", "int", "boolean"}, true),
 			},
+			"session_note_label": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Deprecated:    "use session_note instead",
+				ConflictsWith: []string{"session_note"},
+				Description:   "String value being the name of stored user session note within the UserSessionModel.note map.",
+			},
 			"session_note": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "String value being the name of stored user session note within the UserSessionModel.note map.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"session_note_label"},
+				Description:   "String value being the name of stored user session note within the UserSessionModel.note map.",
 			},
 		},
 	}
 }
 
 func mapFromDataToOpenIdUserSessionNoteProtocolMapper(data *schema.ResourceData) *keycloak.OpenIdUserSessionNoteProtocolMapper {
+	var sessionNote string
+	if s, ok := data.GetOk("session_note_label"); ok {
+		sessionNote = s.(string)
+	} else {
+		sessionNote = data.Get("session_note").(string)
+	}
+
 	return &keycloak.OpenIdUserSessionNoteProtocolMapper{
 		Id:               data.Id(),
 		Name:             data.Get("name").(string),
@@ -89,7 +104,7 @@ func mapFromDataToOpenIdUserSessionNoteProtocolMapper(data *schema.ResourceData)
 
 		ClaimName:       data.Get("claim_name").(string),
 		ClaimValueType:  data.Get("claim_value_type").(string),
-		UserSessionNote: data.Get("session_note").(string),
+		UserSessionNote: sessionNote,
 	}
 }
 
@@ -108,7 +123,12 @@ func mapFromOpenIdUserSessionNoteMapperToData(mapper *keycloak.OpenIdUserSession
 	data.Set("add_to_access_token", mapper.AddToAccessToken)
 	data.Set("claim_name", mapper.ClaimName)
 	data.Set("claim_value_type", mapper.ClaimValueType)
-	data.Set("session_note", mapper.UserSessionNote)
+
+	if _, ok := data.GetOk("session_note_label"); ok {
+		data.Set("session_note_label", mapper.UserSessionNote)
+	} else {
+		data.Set("session_note", mapper.UserSessionNote)
+	}
 }
 
 func resourceKeycloakOpenIdUserSessionNoteProtocolMapperCreate(data *schema.ResourceData, meta interface{}) error {

--- a/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
@@ -73,11 +73,6 @@ func resourceKeycloakOpenIdUserSessionNoteProtocolMapper() *schema.Resource {
 				Optional:    true,
 				Description: "String value being the name of stored user session note within the UserSessionModel.note map.",
 			},
-			"session_note_label": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "String value being the name of stored user session note within the UserSessionModel.note map.",
-			},
 		},
 	}
 }
@@ -95,7 +90,6 @@ func mapFromDataToOpenIdUserSessionNoteProtocolMapper(data *schema.ResourceData)
 		ClaimName:            data.Get("claim_name").(string),
 		ClaimValueType:       data.Get("claim_value_type").(string),
 		UserSessionNote:      data.Get("session_note").(string),
-		UserSessionNoteLabel: data.Get("session_note_label").(string),
 	}
 }
 
@@ -115,7 +109,6 @@ func mapFromOpenIdUserSessionNoteMapperToData(mapper *keycloak.OpenIdUserSession
 	data.Set("claim_name", mapper.ClaimName)
 	data.Set("claim_value_type", mapper.ClaimValueType)
 	data.Set("session_note", mapper.UserSessionNote)
-	data.Set("session_note_label", mapper.UserSessionNoteLabel)
 }
 
 func resourceKeycloakOpenIdUserSessionNoteProtocolMapperCreate(data *schema.ResourceData, meta interface{}) error {

--- a/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
@@ -87,9 +87,9 @@ func mapFromDataToOpenIdUserSessionNoteProtocolMapper(data *schema.ResourceData)
 		AddToIdToken:     data.Get("add_to_id_token").(bool),
 		AddToAccessToken: data.Get("add_to_access_token").(bool),
 
-		ClaimName:            data.Get("claim_name").(string),
-		ClaimValueType:       data.Get("claim_value_type").(string),
-		UserSessionNote:      data.Get("session_note").(string),
+		ClaimName:       data.Get("claim_name").(string),
+		ClaimValueType:  data.Get("claim_value_type").(string),
+		UserSessionNote: data.Get("session_note").(string),
 	}
 }
 

--- a/provider/resource_keycloak_openid_user_session_note_protocol_mapper_test.go
+++ b/provider/resource_keycloak_openid_user_session_note_protocol_mapper_test.go
@@ -347,6 +347,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	client_id          = "${keycloak_openid_client.openid_client.id}"
 	claim_name         = "foo"
 	claim_value_type   = "String"
+	session_note       = "bar"
 	session_note_label = "bar"
 }`, realmName, clientId, mapperName)
 }
@@ -366,6 +367,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	client_scope_id    = "${keycloak_openid_client_scope.client_scope.id}"
 	claim_name         = "foo"
 	claim_value_type   = "String"
+	session_note       = "bar"
 	session_note_label = "bar"
 }`, realmName, clientScopeId, mapperName)
 }
@@ -405,6 +407,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	client_id          = "${keycloak_openid_client.openid_client.id}"
 	claim_name         = "foo"
 	claim_value_type   = "String"
+	session_note       = "bar"
 	session_note_label = "%s"
 }`, realmName, clientId, mapperName, labelName)
 }
@@ -425,6 +428,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	client_id          = "${keycloak_openid_client.openid_client.id}"
 	claim_name         = "foo"
 	claim_value_type   = "String"
+	session_note       = "bar"
 	session_note_label = "bar"
 }
 resource "keycloak_openid_client_scope" "client_scope" {
@@ -437,6 +441,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	client_scope_id    = "${keycloak_openid_client_scope.client_scope.id}"
 	claim_name         = "foo"
 	claim_value_type   = "String"
+	session_note       = "bar"
 	session_note_label = "bar"
 }`, realmName, clientId, mapperName, clientScopeId, mapperName)
 }
@@ -457,6 +462,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	client_id          = "${keycloak_openid_client.openid_client.id}"
 	claim_name         = "foo"
 	claim_value_type   = "%s"
+	session_note       = "bar"
 	session_note_label = "bar"
 }`, realmName, mapperName, claimValueType)
 }

--- a/provider/resource_keycloak_openid_user_session_note_protocol_mapper_test.go
+++ b/provider/resource_keycloak_openid_user_session_note_protocol_mapper_test.go
@@ -115,13 +115,13 @@ func TestAccKeycloakOpenIdUserSessionNoteProtocolMapper_updateClaim(t *testing.T
 	})
 }
 
-func TestAccKeycloakOpenIdUserSessionNoteProtocolMapper_updateLabel(t *testing.T) {
+func TestAccKeycloakOpenIdUserSessionNoteProtocolMapper_updateNote(t *testing.T) {
 	realmName := "terraform-realm-" + acctest.RandString(10)
 	clientId := "terraform-client-" + acctest.RandString(10)
 	mapperName := "terraform-openid-connect-user-session-note-mapper-" + acctest.RandString(5)
 
-	labelName := "session-note-label-" + acctest.RandString(10)
-	updatedLabelName := "session-note-label-update-" + acctest.RandString(10)
+	noteName := "session-note-" + acctest.RandString(10)
+	updatedNoteName := "session-note-update-" + acctest.RandString(10)
 
 	resourceName := "keycloak_openid_user_session_note_protocol_mapper.user_session_note_mapper"
 
@@ -131,11 +131,11 @@ func TestAccKeycloakOpenIdUserSessionNoteProtocolMapper_updateLabel(t *testing.T
 		CheckDestroy:      testAccKeycloakOpenIdUserSessionNoteProtocolMapperDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakOpenIdUserSessionNoteProtocolMapper_label(realmName, clientId, mapperName, labelName),
+				Config: testKeycloakOpenIdUserSessionNoteProtocolMapper_note(realmName, clientId, mapperName, noteName),
 				Check:  testKeycloakOpenIdUserSessionNoteProtocolMapperExists(resourceName),
 			},
 			{
-				Config: testKeycloakOpenIdUserSessionNoteProtocolMapper_label(realmName, clientId, mapperName, updatedLabelName),
+				Config: testKeycloakOpenIdUserSessionNoteProtocolMapper_note(realmName, clientId, mapperName, updatedNoteName),
 				Check:  testKeycloakOpenIdUserSessionNoteProtocolMapperExists(resourceName),
 			},
 		},
@@ -348,7 +348,6 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	claim_name         = "foo"
 	claim_value_type   = "String"
 	session_note       = "bar"
-	session_note_label = "bar"
 }`, realmName, clientId, mapperName)
 }
 
@@ -368,7 +367,6 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	claim_name         = "foo"
 	claim_value_type   = "String"
 	session_note       = "bar"
-	session_note_label = "bar"
 }`, realmName, clientScopeId, mapperName)
 }
 
@@ -391,7 +389,7 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 }`, realmName, clientId, mapperName, claimName)
 }
 
-func testKeycloakOpenIdUserSessionNoteProtocolMapper_label(realmName, clientId, mapperName, labelName string) string {
+func testKeycloakOpenIdUserSessionNoteProtocolMapper_note(realmName, clientId, mapperName, noteName string) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
 	realm = "%s"
@@ -407,9 +405,8 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	client_id          = "${keycloak_openid_client.openid_client.id}"
 	claim_name         = "foo"
 	claim_value_type   = "String"
-	session_note       = "bar"
-	session_note_label = "%s"
-}`, realmName, clientId, mapperName, labelName)
+	session_note       = "%s"
+}`, realmName, clientId, mapperName, noteName)
 }
 
 func testKeycloakOpenIdUserSessionNoteProtocolMapper_import(realmName, clientId, clientScopeId, mapperName string) string {
@@ -429,7 +426,6 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	claim_name         = "foo"
 	claim_value_type   = "String"
 	session_note       = "bar"
-	session_note_label = "bar"
 }
 resource "keycloak_openid_client_scope" "client_scope" {
 	name     = "%s"
@@ -442,7 +438,6 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	claim_name         = "foo"
 	claim_value_type   = "String"
 	session_note       = "bar"
-	session_note_label = "bar"
 }`, realmName, clientId, mapperName, clientScopeId, mapperName)
 }
 
@@ -463,6 +458,5 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	claim_name         = "foo"
 	claim_value_type   = "%s"
 	session_note       = "bar"
-	session_note_label = "bar"
 }`, realmName, mapperName, claimValueType)
 }


### PR DESCRIPTION
Add field session_note to user session protocol mapper. This field needs to be written additionally to session_note_label if the protocol mapper is intended to work correctly, e.g. an Apache mod_auth_openidc client.