### PR TITLE
Fix group import

### DIFF
--- a/keycloak/group.go
+++ b/keycloak/group.go
@@ -35,27 +35,27 @@ func (keycloakClient *KeycloakClient) groupParentId(group *Group) (string, error
 	}
 
 	var parentGroup Group
-	if findParentGroup(*group, groups, parentGroup) {
-		return parentGroup.Id, nil
+	if parentGroupId, found := findParentGroup(*group, groups, parentGroup); found {
+		return parentGroupId, nil
 	}
 
 	// maybe panic here?  this should never happen
 	return "", fmt.Errorf("unable to determine parent ID for group with path %s", group.Path)
 }
 
-func findParentGroup(group Group, ingroups []*Group, parentGroup Group) bool {
+func findParentGroup(group Group, ingroups []*Group, parentGroup Group) (string, bool) {
 	for _, grp := range ingroups {
 		if grp.Id == group.Id {
-			return true
+			return parentGroup.Id, true
 		}
 		if strings.HasPrefix(group.Path, grp.Path+"/") {
-			parentGroup = *grp
-			if findParentGroup(group, grp.SubGroups, parentGroup) {
-				return true
+
+			if parentGroupId, found := findParentGroup(group, grp.SubGroups, *grp); found {
+				return parentGroupId, found
 			}
 		}
 	}
-	return false
+	return "", false
 }
 
 func (keycloakClient *KeycloakClient) ValidateGroupMembers(usernames []interface{}) error {

--- a/provider/resource_keycloak_group_test.go
+++ b/provider/resource_keycloak_group_test.go
@@ -186,6 +186,24 @@ func runTestNestedGroup(t *testing.T, realmName, parentGroupName, firstChildGrou
 				),
 			},
 			{
+				ResourceName:        parentGroupResource,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: realmName + "/",
+			},
+			{
+				ResourceName:        firstChildGroupResource,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: realmName + "/",
+			},
+			{
+				ResourceName:        secondChildGroupResource,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: realmName + "/",
+			},
+			{
 				Config: testKeycloakGroup_nested(realmName, parentGroupName, firstChildGroupName, secondChildGroupName, parentGroupResource),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeycloakGroupExists(parentGroupResource),
@@ -196,6 +214,24 @@ func runTestNestedGroup(t *testing.T, realmName, parentGroupName, firstChildGrou
 					resource.TestCheckResourceAttrPair(firstChildGroupResource, "parent_id", parentGroupResource, "id"),
 					resource.TestCheckResourceAttrPair(secondChildGroupResource, "parent_id", parentGroupResource, "id"),
 				),
+			},
+			{
+				ResourceName:        parentGroupResource,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: realmName + "/",
+			},
+			{
+				ResourceName:        firstChildGroupResource,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: realmName + "/",
+			},
+			{
+				ResourceName:        secondChildGroupResource,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: realmName + "/",
 			},
 		},
 	})


### PR DESCRIPTION
After import a Group, the`ParentId`is not set in the tfstate. So on 'terraform plan` it show a delete+creation.
The `groupParentId(group *Group)` function always set the `parentId` with empty string (https://github.com/mrparkers/terraform-provider-keycloak/blob/master/keycloak/group.go#L25)

I propose to keep the `findParentGroup` recursion function, but instead of just return a boolean, return the `parentId` found.