### PR TITLE
Add remember me timeout attributes to realm

### DIFF
--- a/docs-old/resources/keycloak_realm.md
+++ b/docs-old/resources/keycloak_realm.md
@@ -112,6 +112,8 @@ The attributes below should be specified as [Go duration strings](https://golang
 
 - `sso_session_idle_timeout` - (Optional) The amount of time a session can be idle before it expires.
 - `sso_session_max_lifespan` - (Optional) The maximum amount of time before a session expires regardless of activity.
+- `sso_session_idle_timeout_remember_me` - (Optional) The amount of time a "remember me" session can be idle before it expires.
+- `sso_session_max_lifespan_remember_me` - (Optional) The maximum amount of time before a "remember me" session expires regardless of activity.
 - `offline_session_idle_timeout` - (Optional) The amount of time an offline session can be idle before it expires.
 - `offline_session_max_lifespan` - (Optional) The maximum amount of time before an offline session expires regardless of activity.
 - `access_token_lifespan` - (Optional) The amount of time an access token can be used before it expires.

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -54,6 +54,8 @@ type Realm struct {
 	RefreshTokenMaxReuse                int    `json:"refreshTokenMaxReuse"`
 	SsoSessionIdleTimeout               int    `json:"ssoSessionIdleTimeout,omitempty"`
 	SsoSessionMaxLifespan               int    `json:"ssoSessionMaxLifespan,omitempty"`
+	SsoSessionIdleTimeoutRememberMe     int    `json:"ssoSessionIdleTimeoutRememberMe,omitempty"`
+	SsoSessionMaxLifespanRememberMe     int    `json:"ssoSessionMaxLifespanRememberMe,omitempty"`
 	OfflineSessionIdleTimeout           int    `json:"offlineSessionIdleTimeout,omitempty"`
 	OfflineSessionMaxLifespan           int    `json:"offlineSessionMaxLifespan,omitempty"`
 	AccessTokenLifespan                 int    `json:"accessTokenLifespan,omitempty"`

--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -176,7 +176,15 @@ func dataSourceKeycloakRealm() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"sso_session_idle_timeout_remember_me": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"sso_session_max_lifespan": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sso_session_max_lifespan_remember_me": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -198,7 +198,19 @@ func resourceKeycloakRealm() *schema.Resource {
 				Computed:         true,
 				DiffSuppressFunc: suppressDurationStringDiff,
 			},
+			"sso_session_idle_timeout_remember_me": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: suppressDurationStringDiff,
+			},
 			"sso_session_max_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: suppressDurationStringDiff,
+			},
+			"sso_session_max_lifespan_remember_me": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
@@ -572,6 +584,22 @@ func getRealmFromData(data *schema.ResourceData) (*keycloak.Realm, error) {
 		realm.SsoSessionMaxLifespan = ssoSessionMaxLifespanDurationString
 	}
 
+	if ssoSessionIdleTimeoutRememberMe := data.Get("sso_session_idle_timeout_remember_me").(string); ssoSessionIdleTimeoutRememberMe != "" {
+		ssoSessionIdleTimeoutRememberMeDurationString, err := getSecondsFromDurationString(ssoSessionIdleTimeoutRememberMe)
+		if err != nil {
+			return nil, err
+		}
+		realm.SsoSessionIdleTimeoutRememberMe = ssoSessionIdleTimeoutRememberMeDurationString
+	}
+
+	if ssoSessionMaxLifespanRememberMe := data.Get("sso_session_max_lifespan_remember_me").(string); ssoSessionMaxLifespanRememberMe != "" {
+		ssoSessionMaxLifespanRememberMeDurationString, err := getSecondsFromDurationString(ssoSessionMaxLifespanRememberMe)
+		if err != nil {
+			return nil, err
+		}
+		realm.SsoSessionMaxLifespanRememberMe = ssoSessionMaxLifespanRememberMeDurationString
+	}
+
 	if offlineSessionIdleTimeout := data.Get("offline_session_idle_timeout").(string); offlineSessionIdleTimeout != "" {
 		offlineSessionIdleTimeoutDurationString, err := getSecondsFromDurationString(offlineSessionIdleTimeout)
 		if err != nil {
@@ -809,6 +837,8 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm) {
 	data.Set("refresh_token_max_reuse", realm.RefreshTokenMaxReuse)
 	data.Set("sso_session_idle_timeout", getDurationStringFromSeconds(realm.SsoSessionIdleTimeout))
 	data.Set("sso_session_max_lifespan", getDurationStringFromSeconds(realm.SsoSessionMaxLifespan))
+	data.Set("sso_session_idle_timeout_remember_me", getDurationStringFromSeconds(realm.SsoSessionIdleTimeoutRememberMe))
+	data.Set("sso_session_max_lifespan_remember_me", getDurationStringFromSeconds(realm.SsoSessionMaxLifespanRememberMe))
 	data.Set("offline_session_idle_timeout", getDurationStringFromSeconds(realm.OfflineSessionIdleTimeout))
 	data.Set("offline_session_max_lifespan", getDurationStringFromSeconds(realm.OfflineSessionMaxLifespan))
 	data.Set("access_token_lifespan", getDurationStringFromSeconds(realm.AccessTokenLifespan))

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -1240,6 +1240,8 @@ func testKeycloakRealm_tokenSettings(realm string) string {
 	defaultSignatureAlgorithm := "RS256"
 	ssoSessionIdleTimeout := randomDurationString()
 	ssoSessionMaxLifespan := randomDurationString()
+	ssoSessionIdleTimeoutRememberMe := randomDurationString()
+	ssoSessionMaxLifespanRememberMe := randomDurationString()
 	offlineSessionIdleTimeout := randomDurationString()
 	offlineSessionMaxLifespan := randomDurationString()
 	accessTokenLifespan := randomDurationString()
@@ -1259,6 +1261,8 @@ resource "keycloak_realm" "realm" {
 	default_signature_algorithm              = "%s"
 	sso_session_idle_timeout                 = "%s"
 	sso_session_max_lifespan                 = "%s"
+	sso_session_idle_timeout_remember_me     = "%s"
+	sso_session_max_lifespan_remember_me     = "%s"
 	offline_session_idle_timeout             = "%s"
 	offline_session_max_lifespan             = "%s"
 	access_token_lifespan                    = "%s"
@@ -1269,7 +1273,7 @@ resource "keycloak_realm" "realm" {
 	action_token_generated_by_user_lifespan  = "%s"
 	action_token_generated_by_admin_lifespan = "%s"
 }
-	`, realm, realm, defaultSignatureAlgorithm, ssoSessionIdleTimeout, ssoSessionMaxLifespan, offlineSessionIdleTimeout, offlineSessionMaxLifespan, accessTokenLifespan, accessTokenLifespanForImplicitFlow, accessCodeLifespan, accessCodeLifespanLogin, accessCodeLifespanUserAction, actionTokenGeneratedByUserLifespan, actionTokenGeneratedByAdminLifespan)
+	`, realm, realm, defaultSignatureAlgorithm, ssoSessionIdleTimeout, ssoSessionMaxLifespan, ssoSessionIdleTimeoutRememberMe, ssoSessionMaxLifespanRememberMe, offlineSessionIdleTimeout, offlineSessionMaxLifespan, accessTokenLifespan, accessTokenLifespanForImplicitFlow, accessCodeLifespan, accessCodeLifespanLogin, accessCodeLifespanUserAction, actionTokenGeneratedByUserLifespan, actionTokenGeneratedByAdminLifespan)
 }
 
 func testKeycloakRealm_securityDefensesHeaders(realm, realmDisplayName, xFrameOptions string) string {


### PR DESCRIPTION
When the remember me box is clicked, two additional session timeout attributes come into play. This adds support for setting them.