### PR TITLE
Add the decision strategy setting to the openid client

### DIFF
--- a/docs/resources/openid_client.md
+++ b/docs/resources/openid_client.md
@@ -70,6 +70,7 @@ is set to `true`.
 - `exclude_session_state_from_auth_response` - (Optional) When `true`, the parameter `session_state` will not be included in OpenID Connect Authentication Response.
 - `authorization` - (Optional) When this block is present, fine-grained authorization will be enabled for this client. The client's `access_type` must be `CONFIDENTIAL`, and `service_accounts_enabled` must be `true`. This block has the following arguments:
     - `policy_enforcement_mode` - (Required) Dictates how policies are enforced when evaluating authorization requests. Can be one of `ENFORCING`, `PERMISSIVE`, or `DISABLED`.
+    - `decision_strategy` - (Optional) Dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. Could be one of `AFFIRMATIVE`, `CONSENSUS`, or `UNANIMOUS`. Applies to permissions.
     - `allow_remote_resource_management` - (Optional) When `true`, resources can be managed remotely by the resource server. Defaults to `false`.
     - `keep_defaults` - (Optional) When `true`, defaults set by Keycloak will be respected. Defaults to `false`.
 

--- a/keycloak/openid_client.go
+++ b/keycloak/openid_client.go
@@ -20,6 +20,7 @@ type OpenidClientSecret struct {
 
 type OpenidClientAuthorizationSettings struct {
 	PolicyEnforcementMode         string `json:"policyEnforcementMode,omitempty"`
+	DecisionStrategy              string `json:"decisionStrategy,omitempty"`
 	AllowRemoteResourceManagement bool   `json:"allowRemoteResourceManagement,omitempty"`
 	KeepDefaults                  bool   `json:"-"`
 }

--- a/provider/data_source_keycloak_openid_client.go
+++ b/provider/data_source_keycloak_openid_client.go
@@ -108,6 +108,10 @@ func dataSourceKeycloakOpenidClient() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"decision_strategy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"allow_remote_resource_management": {
 							Type:     schema.TypeBool,
 							Computed: true,

--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -3,16 +3,18 @@ package provider
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
-	"strings"
 )
 
 var (
-	keycloakOpenidClientAccessTypes                        = []string{"CONFIDENTIAL", "PUBLIC", "BEARER-ONLY"}
-	keycloakOpenidClientAuthorizationPolicyEnforcementMode = []string{"ENFORCING", "PERMISSIVE", "DISABLED"}
-	keycloakOpenidClientPkceCodeChallengeMethod            = []string{"", "plain", "S256"}
+	keycloakOpenidClientAccessTypes                          = []string{"CONFIDENTIAL", "PUBLIC", "BEARER-ONLY"}
+	keycloakOpenidClientAuthorizationPolicyEnforcementMode   = []string{"ENFORCING", "PERMISSIVE", "DISABLED"}
+	keycloakOpenidClientResourcePermissionDecisionStrategies = []string{"UNANIMOUS", "AFFIRMATIVE", "CONSENSUS"}
+	keycloakOpenidClientPkceCodeChallengeMethod              = []string{"", "plain", "S256"}
 )
 
 func resourceKeycloakOpenidClient() *schema.Resource {
@@ -135,6 +137,12 @@ func resourceKeycloakOpenidClient() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringInSlice(keycloakOpenidClientAuthorizationPolicyEnforcementMode, false),
+						},
+						"decision_strategy": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(keycloakOpenidClientResourcePermissionDecisionStrategies, false),
+							Default:      "UNANIMOUS",
 						},
 						"allow_remote_resource_management": {
 							Type:     schema.TypeBool,
@@ -274,6 +282,7 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 		authorizationSettings := authorizationSettingsData.(map[string]interface{})
 		openidClient.AuthorizationSettings = &keycloak.OpenidClientAuthorizationSettings{
 			PolicyEnforcementMode:         authorizationSettings["policy_enforcement_mode"].(string),
+			DecisionStrategy:              authorizationSettings["decision_strategy"].(string),
 			AllowRemoteResourceManagement: authorizationSettings["allow_remote_resource_management"].(bool),
 			KeepDefaults:                  authorizationSettings["keep_defaults"].(bool),
 		}

--- a/provider/resource_keycloak_openid_client_authorization_permission.go
+++ b/provider/resource_keycloak_openid_client_authorization_permission.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	keycloakOpenidClientResourcePermissionDecisionStrategies = []string{"UNANIMOUS", "AFFIRMATIVE", "CONSENSUS"}
-	keycloakOpenidClientPermissionTypes                      = []string{"resource", "scope"}
+	keycloakOpenidClientPermissionTypes = []string{"resource", "scope"}
 )
 
 func resourceKeycloakOpenidClientAuthorizationPermission() *schema.Resource {


### PR DESCRIPTION
This merge request is intended to allow overriding the decision strategy at the client level. If not implemented, the client always defines "Unanimuous" as the Global decision strategy, which can prevent some use caes to be imeplemented.