### PR TITLE
Add client session idle and max timeouts for openid_client resource

### DIFF
--- a/docs/resources/openid_client.md
+++ b/docs/resources/openid_client.md
@@ -62,6 +62,10 @@ is set to `true`.
 - `pkce_code_challenge_method` - (Optional) The challenge method to use for Proof Key for Code Exchange. Can be either `plain` or `S256` or set to empty value ``.
 - `full_scope_allowed` - (Optional) Allow to include all roles mappings in the access token.
 - `access_token_lifespan` - (Optional) The amount of time in seconds before an access token expires. This will override the default for the realm.
+- `client_offline_session_idle_timeout` - (Optional) Time a client session is allowed to be idle before it expires. Tokens are invalidated when a client session is expired. If not set it uses the standard SSO Session Idle value.
+- `client_offline_session_max_lifespan` - (Optional) Max time before a client session is expired. Tokens are invalidated when a client session is expired. If not set, it uses the standard SSO Session Max value.
+- `client_session_idle_timeout` - (Optional) Time a client offline session is allowed to be idle before it expires. Offline tokens are invalidated when a client offline session is expired. If not set it uses the Offline Session Idle value.
+- `client_session_max_lifespan` - (Optional) Max time before a client offline session is expired. Offline tokens are invalidated when a client offline session is expired. If not set, it uses the Offline Session Max value.
 - `consent_required` - (Optional) When `true`, users have to consent to client access.
 - `authentication_flow_binding_overrides` - (Optional) Override realm authentication flow bindings
     - `browser_id` - (Optional) Browser flow id, (flow needs to exist)

--- a/keycloak/openid_client.go
+++ b/keycloak/openid_client.go
@@ -58,6 +58,10 @@ type OpenidClientAttributes struct {
 	ExcludeSessionStateFromAuthResponse KeycloakBoolQuoted `json:"exclude.session.state.from.auth.response"`
 	AccessTokenLifespan                 string             `json:"access.token.lifespan"`
 	LoginTheme                          string             `json:"login_theme"`
+	ClientOfflineSessionIdleTimeout     string             `json:"client.offline.session.idle.timeout,omitempty"`
+	ClientOfflineSessionMaxLifespan     string             `json:"client.offline.session.max.lifespan,omitempty"`
+	ClientSessionIdleTimeout            string             `json:"client.session.idle.timeout,omitempty"`
+	ClientSessionMaxLifespan            string             `json:"client.session.max.lifespan,omitempty"`
 }
 
 type OpenidAuthenticationFlowBindingOverrides struct {

--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -117,6 +117,22 @@ func resourceKeycloakOpenidClient() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"client_offline_session_idle_timeout": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"client_offline_session_max_lifespan": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"client_session_idle_timeout": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"client_session_max_lifespan": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"exclude_session_state_from_auth_response": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -238,6 +254,10 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 			ExcludeSessionStateFromAuthResponse: keycloak.KeycloakBoolQuoted(data.Get("exclude_session_state_from_auth_response").(bool)),
 			AccessTokenLifespan:                 data.Get("access_token_lifespan").(string),
 			LoginTheme:                          data.Get("login_theme").(string),
+			ClientOfflineSessionIdleTimeout:     data.Get("client_offline_session_idle_timeout").(string),
+			ClientOfflineSessionMaxLifespan:     data.Get("client_offline_session_max_lifespan").(string),
+			ClientSessionIdleTimeout:            data.Get("client_session_idle_timeout").(string),
+			ClientSessionMaxLifespan:            data.Get("client_session_max_lifespan").(string),
 		},
 		ValidRedirectUris: validRedirectUris,
 		WebOrigins:        webOrigins,


### PR DESCRIPTION
Add `client.offline.session.idle.timeout`, `client.offline.session.max.lifespan`, `client.session.idle.timeout` and `client.session.max.lifespan` openid client attributes.