### PR TITLE
Fix: Failing Keycloak start in local dev environment by revising the custom-user-federation extension config

### DIFF
--- a/custom-user-federation-example/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/custom-user-federation-example/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-deployment-structure>
+    <deployment>
+        <dependencies>
+            <module name="org.keycloak.keycloak-core" export="true" />
+            <module name="org.keycloak.keycloak-server-spi" export="true" />
+            <module name="org.keycloak.keycloak-server-spi-private" export="true" />
+            <module name="org.keycloak.keycloak-services" export="true" />
+            <module name="org.bouncycastle" export="true" />
+            <module name="com.google.guava" export="true" />
+            <module name="org.jboss.logging" export="true" />
+            <module name="org.apache.commons.io" export="true" />
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,13 @@ services:
     - DB_USER=keycloak
     - DB_DATABASE=keycloak
     - DB_PASSWORD=password
+# Enable for remote java debugging
+#    - PREPEND_JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8787
     ports:
     - 8080:8080
+# Enable for remote java debugging
+#    - 8787:8787
     volumes:
-    - ./custom-user-federation-example/build/libs:/opt/jboss/keycloak/providers/
+# Make the custom-user-federation-example extension available to Keycloak. The :z option is required and tells Docker that the volume content will be shared between containers.
+    - ./custom-user-federation-example/build/libs/custom-user-federation-example.jar:/opt/jboss/keycloak/standalone/deployments/custom-user-federation-example.jar:z
 


### PR DESCRIPTION
This fixes #424 by revising the classpath configuration of the custom-user-federation extension module.
We also use the supported `standalone/deployments` folder for extension deployment instead of the old `providers` directory.

With this in place Keycloak starts without problems via `make local`:
```
keycloak_1  | 10:49:16,520 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-6) WFLYUT0006: Undertow AJP listener ajp listening on 0.0.0.0:8009
keycloak_1  | 10:49:16,523 INFO  [org.jboss.modcluster] (ServerService Thread Pool -- 60) MODCLUSTER000001: Initializing mod_cluster version 1.4.1.Final
keycloak_1  | 10:49:16,527 INFO  [org.jboss.modcluster] (ServerService Thread Pool -- 60) MODCLUSTER000032: Listening to proxy advertisements on /224.0.1.105:23364
keycloak_1  | 10:49:16,595 INFO  [org.jboss.as.ejb3] (MSC service thread 1-3) WFLYEJB0493: EJB subsystem suspension complete
keycloak_1  | 10:49:16,632 INFO  [org.jboss.as.patching] (MSC service thread 1-7) WFLYPAT0050: Keycloak cumulative patch ID is: base, one-off patches include: none
keycloak_1  | 10:49:16,641 WARN  [org.jboss.as.domain.management.security] (MSC service thread 1-6) WFLYDM0111: Keystore /opt/jboss/keycloak/standalone/configuration/application.keystore not found, it will be auto generated on first use with a self signed certificate for host localhost
keycloak_1  | 10:49:16,644 INFO  [org.jboss.as.server.deployment.scanner] (MSC service thread 1-5) WFLYDS0013: Started FileSystemDeploymentService for directory /opt/jboss/keycloak/standalone/deployments
keycloak_1  | 10:49:16,650 INFO  [org.jboss.as.connector.subsystems.datasources] (MSC service thread 1-7) WFLYJCA0001: Bound data source [java:jboss/datasources/KeycloakDS]
keycloak_1  | 10:49:16,650 INFO  [org.jboss.as.connector.subsystems.datasources] (MSC service thread 1-8) WFLYJCA0001: Bound data source [java:jboss/datasources/ExampleDS]
keycloak_1  | 10:49:16,650 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-6) WFLYSRV0027: Starting deployment of "keycloak-server.war" (runtime-name: "keycloak-server.war")
keycloak_1  | 10:49:16,650 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-4) WFLYSRV0027: Starting deployment of "custom-user-federation-example.jar" (runtime-name: "custom-user-federation-example.jar")
keycloak_1  | 10:49:16,695 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-1) WFLYUT0006: Undertow HTTPS listener https listening on 0.0.0.0:8443
keycloak_1  | 10:49:18,112 WARN  [org.jboss.as.dependency.private] (MSC service thread 1-7) WFLYSRV0018: Deployment "deployment.custom-user-federation-example.jar" is using a private module ("org.keycloak.keycloak-server-spi-private") which may be changed or removed in future versions without notice.
keycloak_1  | 10:49:18,113 WARN  [org.jboss.as.dependency.private] (MSC service thread 1-7) WFLYSRV0018: Deployment "deployment.custom-user-federation-example.jar" is using a private module ("org.keycloak.keycloak-services") which may be changed or removed in future versions without notice.
keycloak_1  | 10:49:18,113 WARN  [org.jboss.as.dependency.private] (MSC service thread 1-7) WFLYSRV0018: Deployment "deployment.custom-user-federation-example.jar" is using a private module ("org.bouncycastle") which may be changed or removed in future versions without notice.
keycloak_1  | 10:49:18,114 WARN  [org.jboss.as.dependency.private] (MSC service thread 1-7) WFLYSRV0018: Deployment "deployment.custom-user-federation-example.jar" is using a private module ("com.google.guava") which may be changed or removed in future versions without notice.
keycloak_1  | 10:49:18,114 WARN  [org.jboss.as.dependency.private] (MSC service thread 1-7) WFLYSRV0018: Deployment "deployment.custom-user-federation-example.jar" is using a private module ("org.apache.commons.io") which may be changed or removed in future versions without notice.
keycloak_1  | 10:49:18,116 INFO  [org.keycloak.subsystem.server.extension.KeycloakProviderDeploymentProcessor] (MSC service thread 1-7) Deploying Keycloak provider: custom-user-federation-example.jar
keycloak_1  | 10:49:18,127 WARN  [org.jboss.weld.deployer] (MSC service thread 1-5) WFLYWELD0013: Deployment custom-user-federation-example.jar contains CDI annotations but no bean archive was found (no beans.xml or class with bean defining annotations was present).
keycloak_1  | 10:49:20,028 INFO  [org.jgroups.protocols.pbcast.GMS] (ServerService Thread Pool -- 60) febdf24633cd: no members discovered after 3002 ms: creating cluster as coordinator
keycloak_1  | 10:49:20,201 INFO  [org.infinispan.factories.GlobalComponentRegistry] (MSC service thread 1-5) ISPN000128: Infinispan version: Infinispan 'Infinity Minus ONE +2' 9.4.18.Final
keycloak_1  | 10:49:20,310 INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-8) ISPN000078: Starting JGroups channel ejb
keycloak_1  | 10:49:20,310 INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-5) ISPN000078: Starting JGroups channel ejb
keycloak_1  | 10:49:20,310 INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-4) ISPN000078: Starting JGroups channel ejb
keycloak_1  | 10:49:20,310 INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-6) ISPN000078: Starting JGroups channel ejb
keycloak_1  | 10:49:20,310 INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-7) ISPN000078: Starting JGroups channel ejb
keycloak_1  | 10:49:20,313 INFO  [org.infinispan.CLUSTER] (MSC service thread 1-8) ISPN000094: Received new cluster view for channel ejb: [febdf24633cd|0] (1) [febdf24633cd]
keycloak_1  | 10:49:20,313 INFO  [org.infinispan.CLUSTER] (MSC service thread 1-5) ISPN000094: Received new cluster view for channel ejb: [febdf24633cd|0] (1) [febdf24633cd]
keycloak_1  | 10:49:20,313 INFO  [org.infinispan.CLUSTER] (MSC service thread 1-7) ISPN000094: Received new cluster view for channel ejb: [febdf24633cd|0] (1) [febdf24633cd]
keycloak_1  | 10:49:20,313 INFO  [org.infinispan.CLUSTER] (MSC service thread 1-6) ISPN000094: Received new cluster view for channel ejb: [febdf24633cd|0] (1) [febdf24633cd]
keycloak_1  | 10:49:20,313 INFO  [org.infinispan.CLUSTER] (MSC service thread 1-4) ISPN000094: Received new cluster view for channel ejb: [febdf24633cd|0] (1) [febdf24633cd]
keycloak_1  | 10:49:20,315 INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-8) ISPN000079: Channel ejb local address is febdf24633cd, physical addresses are [172.30.0.4:55200]
keycloak_1  | 10:49:20,315 INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-7) ISPN000079: Channel ejb local address is febdf24633cd, physical addresses are [172.30.0.4:55200]
keycloak_1  | 10:49:20,315 INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-4) ISPN000079: Channel ejb local address is febdf24633cd, physical addresses are [172.30.0.4:55200]
keycloak_1  | 10:49:20,317 INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-5) ISPN000079: Channel ejb local address is febdf24633cd, physical addresses are [172.30.0.4:55200]
keycloak_1  | 10:49:20,317 INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-6) ISPN000079: Channel ejb local address is febdf24633cd, physical addresses are [172.30.0.4:55200]
keycloak_1  | 10:49:20,475 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 66) WFLYCLINF0002: Started authorization cache from keycloak container
keycloak_1  | 10:49:20,475 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 61) WFLYCLINF0002: Started users cache from keycloak container
keycloak_1  | 10:49:20,475 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 65) WFLYCLINF0002: Started realms cache from keycloak container
keycloak_1  | 10:49:20,475 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 68) WFLYCLINF0002: Started keys cache from keycloak container
keycloak_1  | 10:49:20,559 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 60) WFLYCLINF0002: Started work cache from keycloak container
keycloak_1  | 10:49:20,559 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 64) WFLYCLINF0002: Started sessions cache from keycloak container
keycloak_1  | 10:49:20,559 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 70) WFLYCLINF0002: Started authenticationSessions cache from keycloak container
keycloak_1  | 10:49:20,559 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 62) WFLYCLINF0002: Started offlineClientSessions cache from keycloak container
keycloak_1  | 10:49:20,559 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 69) WFLYCLINF0002: Started actionTokens cache from keycloak container
keycloak_1  | 10:49:20,559 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 72) WFLYCLINF0002: Started client-mappings cache from ejb container
keycloak_1  | 10:49:20,559 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 63) WFLYCLINF0002: Started offlineSessions cache from keycloak container
keycloak_1  | 10:49:20,559 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 67) WFLYCLINF0002: Started clientSessions cache from keycloak container
keycloak_1  | 10:49:20,559 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 71) WFLYCLINF0002: Started loginFailures cache from keycloak container
keycloak_1  | 10:49:20,617 WARN  [org.jboss.as.server.deployment] (MSC service thread 1-5) WFLYSRV0273: Excluded subsystem webservices via jboss-deployment-structure.xml does not exist.
keycloak_1  | 10:49:20,925 INFO  [org.keycloak.services] (ServerService Thread Pool -- 62) KC-SERVICES0001: Loading config from standalone.xml or domain.xml
keycloak_1  | 10:49:20,945 INFO  [org.keycloak.url.DefaultHostnameProviderFactory] (ServerService Thread Pool -- 62) Frontend: <request>, Admin: <frontend>, Backend: <request>
keycloak_1  | 10:49:20,989 INFO  [org.keycloak.common.Profile] (ServerService Thread Pool -- 62) Preview feature enabled: admin_fine_grained_authz
keycloak_1  | 10:49:20,989 INFO  [org.keycloak.common.Profile] (ServerService Thread Pool -- 62) Preview feature enabled: token_exchange
keycloak_1  | 10:49:20,989 WARN  [org.keycloak.common.Profile] (ServerService Thread Pool -- 62) Deprecated feature enabled: upload_scripts
keycloak_1  | 10:49:20,989 WARN  [org.keycloak.common.Profile] (ServerService Thread Pool -- 62) Preview feature enabled: scripts
keycloak_1  | 10:49:21,183 WARN  [org.keycloak.services] (ServerService Thread Pool -- 62) KC-SERVICES0047: customIdp (com.github.mrparkers.keycloak.CustomIdentityProviderFactory) is implementing the internal SPI identity_provider. This SPI is internal and may change without notice
keycloak_1  | 10:49:21,213 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 62) WFLYCLINF0002: Started realmRevisions cache from keycloak container
keycloak_1  | 10:49:21,218 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 62) WFLYCLINF0002: Started userRevisions cache from keycloak container
keycloak_1  | 10:49:21,226 INFO  [org.jboss.as.clustering.infinispan] (ServerService Thread Pool -- 62) WFLYCLINF0002: Started authorizationRevisions cache from keycloak container
keycloak_1  | 10:49:21,228 INFO  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ServerService Thread Pool -- 62) Node name: febdf24633cd, Site name: null
keycloak_1  | 10:49:22,423 INFO  [org.hibernate.jpa.internal.util.LogHelper] (ServerService Thread Pool -- 62) HHH000204: Processing PersistenceUnitInfo [
keycloak_1  | 	name: keycloak-default
keycloak_1  | 	...]
keycloak_1  | 10:49:22,458 INFO  [org.hibernate.Version] (ServerService Thread Pool -- 62) HHH000412: Hibernate Core {5.3.15.Final}
keycloak_1  | 10:49:22,459 INFO  [org.hibernate.cfg.Environment] (ServerService Thread Pool -- 62) HHH000206: hibernate.properties not found
keycloak_1  | 10:49:22,537 INFO  [org.hibernate.annotations.common.Version] (ServerService Thread Pool -- 62) HCANN000001: Hibernate Commons Annotations {5.0.5.Final}
keycloak_1  | 10:49:22,632 INFO  [org.hibernate.dialect.Dialect] (ServerService Thread Pool -- 62) HHH000400: Using dialect: org.hibernate.dialect.PostgreSQL95Dialect
keycloak_1  | 10:49:22,711 INFO  [org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl] (ServerService Thread Pool -- 62) HHH000424: Disabling contextual LOB creation as createClob() method threw error : java.lang.reflect.InvocationTargetException
keycloak_1  | 10:49:22,715 INFO  [org.hibernate.type.BasicTypeRegistry] (ServerService Thread Pool -- 62) HHH000270: Type registration [java.util.UUID] overrides previous : org.hibernate.type.UUIDBinaryType@3b91a969
keycloak_1  | 10:49:22,718 INFO  [org.hibernate.envers.boot.internal.EnversServiceImpl] (ServerService Thread Pool -- 62) Envers integration enabled? : true
keycloak_1  | 10:49:23,010 INFO  [org.hibernate.orm.beans] (ServerService Thread Pool -- 62) HHH10005002: No explicit CDI BeanManager reference was passed to Hibernate, but CDI is available on the Hibernate ClassLoader.
keycloak_1  | 10:49:23,048 INFO  [org.hibernate.validator.internal.util.Version] (ServerService Thread Pool -- 62) HV000001: Hibernate Validator 6.0.18.Final
keycloak_1  | 10:49:23,719 INFO  [org.hibernate.hql.internal.QueryTranslatorFactoryInitiator] (ServerService Thread Pool -- 62) HHH000397: Using ASTQueryTranslatorFactory
keycloak_1  | 10:49:24,197 INFO  [org.keycloak.services] (ServerService Thread Pool -- 62) KC-SERVICES0006: Importing users from '/opt/jboss/keycloak/standalone/configuration/keycloak-add-user.json'
keycloak_1  | 10:49:24,297 WARN  [org.keycloak.services] (ServerService Thread Pool -- 62) KC-SERVICES0104: Not creating user keycloak. It already exists.
keycloak_1  | 10:49:24,324 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 62) RESTEASY002225: Deploying javax.ws.rs.core.Application: class org.keycloak.services.resources.KeycloakApplication
keycloak_1  | 10:49:24,325 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 62) RESTEASY002205: Adding provider class org.keycloak.services.filters.KeycloakSecurityHeadersFilter from Application class org.keycloak.services.resources.KeycloakApplication
keycloak_1  | 10:49:24,325 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 62) RESTEASY002200: Adding class resource org.keycloak.services.resources.ThemeResource from Application class org.keycloak.services.resources.KeycloakApplication
keycloak_1  | 10:49:24,326 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 62) RESTEASY002200: Adding class resource org.keycloak.services.resources.JsResource from Application class org.keycloak.services.resources.KeycloakApplication
keycloak_1  | 10:49:24,326 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 62) RESTEASY002205: Adding provider class org.keycloak.services.error.KeycloakErrorHandler from Application class org.keycloak.services.resources.KeycloakApplication
keycloak_1  | 10:49:24,326 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 62) RESTEASY002205: Adding provider class org.keycloak.services.filters.KeycloakTransactionCommitter from Application class org.keycloak.services.resources.KeycloakApplication
keycloak_1  | 10:49:24,326 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 62) RESTEASY002210: Adding provider singleton org.keycloak.services.util.ObjectMapperResolver from Application class org.keycloak.services.resources.KeycloakApplication
keycloak_1  | 10:49:24,326 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 62) RESTEASY002220: Adding singleton resource org.keycloak.services.resources.WelcomeResource from Application class org.keycloak.services.resources.KeycloakApplication
keycloak_1  | 10:49:24,326 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 62) RESTEASY002220: Adding singleton resource org.keycloak.services.resources.RealmsResource from Application class org.keycloak.services.resources.KeycloakApplication
keycloak_1  | 10:49:24,326 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 62) RESTEASY002220: Adding singleton resource org.keycloak.services.resources.RobotsResource from Application class org.keycloak.services.resources.KeycloakApplication
keycloak_1  | 10:49:24,326 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 62) RESTEASY002220: Adding singleton resource org.keycloak.services.resources.admin.AdminRoot from Application class org.keycloak.services.resources.KeycloakApplication
keycloak_1  | 10:49:24,372 INFO  [org.wildfly.extension.undertow] (ServerService Thread Pool -- 62) WFLYUT0021: Registered web context: '/auth' for server 'default-server'
keycloak_1  | 10:49:24,437 INFO  [org.jboss.as.server] (ServerService Thread Pool -- 35) WFLYSRV0010: Deployed "custom-user-federation-example.jar" (runtime-name : "custom-user-federation-example.jar")
keycloak_1  | 10:49:24,437 INFO  [org.jboss.as.server] (ServerService Thread Pool -- 46) WFLYSRV0010: Deployed "keycloak-server.war" (runtime-name : "keycloak-server.war")
keycloak_1  | 10:49:24,463 INFO  [org.jboss.as.server] (Controller Boot Thread) WFLYSRV0212: Resuming server
keycloak_1  | 10:49:24,465 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0060: Http management interface listening on http://127.0.0.1:9990/management
keycloak_1  | 10:49:24,465 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0051: Admin console listening on http://127.0.0.1:9990
keycloak_1  | 10:49:24,466 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: Keycloak 10.0.2 (WildFly Core 11.1.1.Final) started in 9994ms - Started 734 of 1040 services (711 services are lazy, passive or on-demand)
```