### PR TITLE
Validation of RegistrationEmailAsUsername attribute

### DIFF
--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -199,10 +199,6 @@ func (keycloakClient *KeycloakClient) DeleteRealm(name string) error {
 }
 
 func (keycloakClient *KeycloakClient) ValidateRealm(realm *Realm) error {
-	if realm.RegistrationAllowed == false && realm.RegistrationEmailAsUsername == true {
-		return fmt.Errorf("validation error: RegistrationEmailAsUsername cannot be true if RegistrationAllowed is false")
-	}
-
 	if realm.DuplicateEmailsAllowed == true && realm.RegistrationEmailAsUsername == true {
 		return fmt.Errorf("validation error: DuplicateEmailsAllowed cannot be true if RegistrationEmailAsUsername is true")
 	}

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -333,10 +333,6 @@ func TestAccKeycloakRealm_loginConfigValidation(t *testing.T) {
 		CheckDestroy:      testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config:      testKeycloakRealm_invalidRegistrationEmailAsUsernameWithoutRegistrationAllowed(realmName),
-				ExpectError: regexp.MustCompile("validation error: RegistrationEmailAsUsername cannot be true if RegistrationAllowed is false"),
-			},
-			{
 				Config:      testKeycloakRealm_invalidRegistrationEmailAsUsernameAndDuplicateEmailsAllowed(realmName),
 				ExpectError: regexp.MustCompile("validation error: DuplicateEmailsAllowed cannot be true if RegistrationEmailAsUsername is true"),
 			},
@@ -1225,17 +1221,6 @@ resource "keycloak_realm" "realm" {
 	ssl_required       			   = "%s"
 }
 	`, realm.Realm, realm.RegistrationAllowed, realm.RegistrationEmailAsUsername, realm.EditUsernameAllowed, realm.ResetPasswordAllowed, realm.RememberMe, realm.VerifyEmail, realm.LoginWithEmailAllowed, realm.DuplicateEmailsAllowed, realm.SslRequired)
-}
-
-func testKeycloakRealm_invalidRegistrationEmailAsUsernameWithoutRegistrationAllowed(realm string) string {
-	return fmt.Sprintf(`
-resource "keycloak_realm" "realm" {
-	realm                          = "%s"
-
-	registration_allowed           = false
-	registration_email_as_username = true
-}
-	`, realm)
 }
 
 func testKeycloakRealm_invalidRegistrationEmailAsUsernameAndDuplicateEmailsAllowed(realm string) string {


### PR DESCRIPTION
Background:
I want to have a realm, where `username` and `email` attributes have same value, registration is disabled and user is allowed to manage own email address. To achieve this configuration keycloak can be configured as follows

```
RegistrationAllowed=false
RegistrationEmailAsUsername=true
EditUsernameAllowed=false
```

As a result, keycloak's account management page will allow user to manage own email address (but not username), and username will be updated automatically by keycloak upon change.

This configuration is of course not very intuitive, because `RegistrationEmailAsUsername` attribute _should_ make sense only when registration is enabled, but in fact keycloak behaves just as described above. In order to achieve this from GUI, `RegistrationAllowed` can be temporary enabled / disabled, which will allow setting `RegistrationEmailAsUsername` to true. 

Current implementation of the provider does not allow setting `RegistrationEmailAsUsername` to true when `RegistrationAllowed` is false, resulting in `validation error: RegistrationEmailAsUsername cannot be true if RegistrationAllowed is false`. This change removes that condition.