### PR TITLE
Allow commas in keycloak_custom_user_federation config

### DIFF
--- a/provider/resource_keycloak_custom_user_federation.go
+++ b/provider/resource_keycloak_custom_user_federation.go
@@ -82,7 +82,7 @@ func getCustomUserFederationFromData(data *schema.ResourceData) *keycloak.Custom
 	config := map[string][]string{}
 	if v, ok := data.GetOk("config"); ok {
 		for key, value := range v.(map[string]interface{}) {
-			config[key] = strings.Split(value.(string), ",")
+			config[key] = []string{value.(string)}
 		}
 	}
 	parentId := ""
@@ -125,7 +125,7 @@ func setCustomUserFederationData(data *schema.ResourceData, custom *keycloak.Cus
 
 	config := make(map[string]interface{})
 	for k, v := range custom.Config {
-		config[k] = strings.Join(v, ",")
+		config[k] = v[0]
 	}
 
 	data.Set("config", config)

--- a/provider/resource_keycloak_custom_user_federation_test.go
+++ b/provider/resource_keycloak_custom_user_federation_test.go
@@ -55,6 +55,20 @@ func TestAccKeycloakCustomUserFederation_customConfig(t *testing.T) {
 			},
 		},
 	})
+
+	configValue = configValue + "," + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakCustomUserFederationDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakCustomUserFederation_customConfig(realmName, name, providerId, configValue),
+				Check:  testAccCheckKeycloakCustomUserFederationExistsWithCustomConfig("keycloak_custom_user_federation.custom", configValue),
+			},
+		},
+	})
 }
 
 func TestAccKeycloakCustomUserFederation_createAfterManualDestroy(t *testing.T) {

--- a/provider/resource_keycloak_custom_user_federation_test.go
+++ b/provider/resource_keycloak_custom_user_federation_test.go
@@ -66,7 +66,7 @@ func TestAccKeycloakCustomUserFederation_customConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckKeycloakCustomUserFederationDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakCustomUserFederation_customConfig(realmName, name, providerId, configValue),
+				Config: testKeycloakCustomUserFederation_customConfig(name, providerId, configValue),
 				Check:  testAccCheckKeycloakCustomUserFederationExistsWithCustomConfig("keycloak_custom_user_federation.custom", configValue),
 			},
 		},


### PR DESCRIPTION
Allow commas in keycloak_custom_user_federation config. Fixes #454 

User federation config is a MultivaluedMap. A multivalued map has a key and a list of values.

The correct terraform config would be:
```
config = {
key = ["value1", "value2"]
}
```

Changing the config structure to array of strings would break existing configurations therefore only the first value is set and taken into account.