### PR TITLE
Support social IdP attribute import

### DIFF
--- a/docs/resources/attribute_importer_identity_provider_mapper.md
+++ b/docs/resources/attribute_importer_identity_provider_mapper.md
@@ -58,7 +58,7 @@ The following arguments are supported:
 - `claim_name` - (Optional) For OIDC based providers, this is the name of the claim to use.
 - `extra_config` - (Optional) Key/value attributes to add to the identity provider mapper model that is persisted to Keycloak. This can be used to extend the base model with new Keycloak features.
 - `extra_config.jsonField` - (Optional) Social profile JSON field path for social identity providers.
-- `extra_config.attributeName` - (Optional) User attribute name for social identity providers.
+- `extra_config.userAttribute` - (Optional) User attribute name for social identity providers.
 
 ## Import
 

--- a/docs/resources/attribute_importer_identity_provider_mapper.md
+++ b/docs/resources/attribute_importer_identity_provider_mapper.md
@@ -57,6 +57,8 @@ The following arguments are supported:
 - `attribute_friendly_name` - (Optional) For SAML based providers, this is the friendly name of the attribute to search for in the assertion. Conflicts with `attribute_name`.
 - `claim_name` - (Optional) For OIDC based providers, this is the name of the claim to use.
 - `extra_config` - (Optional) Key/value attributes to add to the identity provider mapper model that is persisted to Keycloak. This can be used to extend the base model with new Keycloak features.
+- `extra_config.jsonField` - (Optional) Social profile JSON field path for social identity providers.
+- `extra_config.attributeName` - (Optional) User attribute name for social identity providers.
 
 ## Import
 

--- a/provider/resource_keycloak_attribute_importer_identity_provider_mapper.go
+++ b/provider/resource_keycloak_attribute_importer_identity_provider_mapper.go
@@ -71,10 +71,28 @@ func getAttributeImporterIdentityProviderMapperFromData(data *schema.ResourceDat
 			return nil, fmt.Errorf(`provider.keycloak: keycloak_attribute_importer_identity_provider_mapper: %s: "claim_name": should be set for %s identity provider`, data.Get("name").(string), identityProvider.ProviderId)
 		}
 		rec.Config.Claim = data.Get("claim_name").(string)
+
+	} else if isAttributeImportEnabledSocialProvider(identityProvider.ProviderId) {
+		rec.IdentityProviderMapper = fmt.Sprintf("%s-user-attribute-mapper", identityProvider.ProviderId)
+		if _, ok := rec.Config.ExtraConfig["jsonField"]; !ok {
+			return nil, fmt.Errorf(`provider.keycloak: keycloak_attribute_importer_identity_provider_mapper: %s: "extra_config.jsonField": should be set for %s identity provider`, data.Get("name").(string), identityProvider.ProviderId)
+		}
+		if _, ok := rec.Config.ExtraConfig["userAttribute"]; !ok {
+			return nil, fmt.Errorf(`provider.keycloak: keycloak_attribute_importer_identity_provider_mapper: %s: "extra_config.userAttribute": should be set for %s identity provider`, data.Get("name").(string), identityProvider.ProviderId)
+		}
 	} else {
 		return nil, fmt.Errorf(`provider.keycloak: keycloak_attribute_importer_identity_provider_mapper: %s: "%s" identity provider is not supported yet`, data.Get("name").(string), identityProvider.ProviderId)
 	}
 	return rec, nil
+}
+
+func isAttributeImportEnabledSocialProvider(providerIdOrAlias string) bool {
+	for _, supportedId := range []string{"facebook", "github", "google", "instagram", "linkedin", "microsoft", "paypal", "stackoverflow"} {
+		if providerIdOrAlias == supportedId {
+			return true
+		}
+	}
+	return false
 }
 
 func setAttributeImporterIdentityProviderMapperData(data *schema.ResourceData, identityProviderMapper *keycloak.IdentityProviderMapper) error {

--- a/provider/resource_keycloak_attribute_importer_identity_provider_mapper_test.go
+++ b/provider/resource_keycloak_attribute_importer_identity_provider_mapper_test.go
@@ -55,7 +55,7 @@ func TestAccKeycloakAttributeImporterIdentityProviderMapper_socialOidcProvider(t
 	t.Parallel()
 	for _, providerId := range []string{"facebook", "github", "google", "instagram", "linkedin", "microsoft", "paypal", "stackoverflow"} {
 		providerId := providerId
-		t.Run("", func(t *testing.T) {
+		t.Run(providerId, func(t *testing.T) {
 			t.Parallel()
 			mapperName := acctest.RandomWithPrefix("tf-acc")
 			alias := providerId


### PR DESCRIPTION
This PR allows the `keycloak_attribute_importer_identity_provider_mapper` resource to control mappers on the following social identity providers:
- facebook
- github
- google
- instagram
- linkedin
- microsoft
- paypal
- stackoverflow

It's broader than the scope defined in #471, but those are all the social identity providers where an "Attribute Importer" mapper can be configured. I tested the provider against the local instance of Keycloak and the mappers appear successfully for each of those social providers.

One of the things that are a bit less clean with this is that on social attribute importers, the field in the config is `attributeName` instead of `attribute.name`, so I documented how to leverage the `extra_config` fields to achieve such result. I would have liked to use the `attribute_name` and `claim` properties that are already in the struct, but that ended up messing things up more than anything. That being said, I'm pretty new to terraform providers, so any hint on how to improve this code and reuse the fields properly is more than welcome!

Fixes #471 