### PR TITLE
Add attributes management to keycloak_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v2.2.0 (January 23, 2021)
+
+FEATURES:
+
+- add new `keycloak_realm` attributes for handling default client scopes ([#464](https://github.com/mrparkers/terraform-provider-keycloak/pull/464))
+- new data source: `keycloak_saml_client` ([#468](https://github.com/mrparkers/terraform-provider-keycloak/pull/468))
+
+IMPROVEMENTS:
+
+- revised the configuration for the custom user federation example ([#425](https://github.com/mrparkers/terraform-provider-keycloak/pull/425))
+- increased the default http client timeout to 15 seconds ([#469](https://github.com/mrparkers/terraform-provider-keycloak/pull/469))
+
+BUG FIXES:
+
+- fix panic when using `keycloak_user` data source with invalid username ([#460](https://github.com/mrparkers/terraform-provider-keycloak/pull/460))
+- fix version handling with RedHat SSO ([#462](https://github.com/mrparkers/terraform-provider-keycloak/pull/462))
+
 ## v2.1.0 (January 10, 2021)
 
 FEATURES:

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -20,6 +20,9 @@ resource "keycloak_role" "realm_role" {
   realm_id    = keycloak_realm.realm.id
   name        = "my-realm-role"
   description = "My Realm Role"
+  attributes = {
+    key = "value"
+  }
 }
 ```
 
@@ -49,6 +52,9 @@ resource "keycloak_role" "client_role" {
   client_id   = keycloak_client.openid_client.id
   name        = "my-client-role"
   description = "My Client Role"
+  attributes = {
+    key = "value"
+  }
 }
 ```
 
@@ -65,21 +71,33 @@ resource "keycloak_realm" "realm" {
 resource "keycloak_role" "create_role" {
   realm_id = keycloak_realm.realm.id
   name     = "create"
+  attributes = {
+    key = "value"
+  }
 }
 
 resource "keycloak_role" "read_role" {
   realm_id = keycloak_realm.realm.id
   name     = "read"
+  attributes = {
+    key = "value"
+  }
 }
 
 resource "keycloak_role" "update_role" {
   realm_id = keycloak_realm.realm.id
   name     = "update"
+  attributes = {
+    key = "value"
+  }
 }
 
 resource "keycloak_role" "delete_role" {
   realm_id = keycloak_realm.realm.id
   name     = "delete"
+  attributes = {
+    key = "value"
+  }
 }
 
 # client role
@@ -102,6 +120,10 @@ resource "keycloak_role" "client_role" {
   client_id   = keycloak_client.openid_client.id
   name        = "my-client-role"
   description = "My Client Role"
+
+  attributes = {
+    key = "value"
+  }
 }
 
 resource "keycloak_role" "admin_role" {
@@ -114,6 +136,10 @@ resource "keycloak_role" "admin_role" {
     keycloak_role.delete_role.id,
     keycloak_role.client_role.id,
   ]
+
+   attributes = {
+    key = "value"
+  }
 }
 ```
 
@@ -124,6 +150,7 @@ resource "keycloak_role" "admin_role" {
 - `client_id` - (Optional) When specified, this role will be created as a client role attached to the client with the provided ID
 - `description` - (Optional) The description of the role
 - `composite_roles` - (Optional) When specified, this role will be a composite role, composed of all roles that have an ID present within this list.
+- `attributes` - (Optional) Attribute key/value pairs 
 
 
 ## Import

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/hashicorp/go-version"
 
 	"golang.org/x/net/publicsuffix"
 )

--- a/keycloak/role.go
+++ b/keycloak/role.go
@@ -16,6 +16,8 @@ type Role struct {
 	ClientRole  bool   `json:"clientRole"`
 	ContainerId string `json:"containerId"`
 	Composite   bool   `json:"composite"`
+	//extra attributes of a role
+	Attributes map[string]interface{} `json:"attributes"`
 }
 
 type UsersInRole struct {

--- a/provider/data_source_keycloak_role.go
+++ b/provider/data_source_keycloak_role.go
@@ -25,6 +25,16 @@ func dataSourceKeycloakRole() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"composite_roles": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+				Computed: true,
+			},
+			"attributes": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/provider/resource_keycloak_role.go
+++ b/provider/resource_keycloak_role.go
@@ -57,9 +57,7 @@ func mapFromDataToRole(data *schema.ResourceData) *keycloak.Role {
 	attributes := map[string]interface{}{}
 	if v, ok := data.GetOk("attributes"); ok {
 		for key, value := range v.(map[string]interface{}) {
-			var value_as_array [1]string
-			value_as_array[0] = value.(string)
-			attributes[key] = value_as_array
+			attributes[key] = [1]string{value.(string)}
 		}
 	}
 

--- a/provider/resource_keycloak_role.go
+++ b/provider/resource_keycloak_role.go
@@ -85,7 +85,6 @@ func mapFromRoleToData(data *schema.ResourceData, role *keycloak.Role) {
 	attributes := map[string]interface{}{}
 	if v, ok := data.GetOk("attributes"); ok {
 		for key := range v.(map[string]interface{}) {
-			// as := role.Attributes[key].([]interface{})
 			attributes[key] = role.Attributes[key].([]interface{})[0]
 		}
 	}
@@ -231,9 +230,7 @@ func resourceKeycloakRoleUpdate(data *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	mapFromRoleToData(data, role)
-
-	return nil
+	return resourceKeycloakRoleRead(data, meta)
 }
 
 func resourceKeycloakRoleDelete(data *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
This adds the attributes field to keycloak roles.

A couple of small tweaks popped in due to my linter and I slightly reworked the after the PUT update  in the role update function to return a call to read instead of processing  and updating directly.

This is a pretty simple addition, most of it was cribbed from how realm attributes were handled with minor changes to reflect realm.attributes and role.attributes not being the same type in the JSON.