### PR TITLE
Allow identity_provider_mapper to be overriden for keycloak_user_template_importer_identity_provider_mapper

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -628,6 +628,19 @@ resource keycloak_user_template_importer_identity_provider_mapper oidc {
   }
 }
 
+resource keycloak_user_template_importer_identity_provider_mapper oidc {
+  realm                    = keycloak_realm.test.id
+  name                     = "userTemplate"
+  identity_provider_alias  = keycloak_oidc_identity_provider.oidc.alias
+  identity_provider_mapper = "oidc-username-idp-mapper"
+  template                 = "$${UUID}"
+
+  extra_config = {
+    syncMode = "IMPORT"
+    target = "LOCAL"
+  }
+}
+
 resource keycloak_hardcoded_role_identity_provider_mapper oidc {
   realm                   = keycloak_realm.test.id
   name                    = "hardcodedRole"


### PR DESCRIPTION
<img width="1097" alt="Screenshot 2021-02-05 at 13 26 59" src="https://user-images.githubusercontent.com/5777517/107028152-d4b05700-67b5-11eb-9fcc-709440799506.png">

Currently, `identity_provider_mapper` is computed as `[provider id]-username-idp-mapper`. This isn't always the case. Take for example the Facebook identity provider. The correct `identity_provider_mapper` is `oidc-username-idp-mapper`.

This PR adds an optional property to override the `identity_provider_mapper` attribute.

For completeness, this is the request the Keycloak admin console makes:

![image](https://user-images.githubusercontent.com/5777517/107028309-0cb79a00-67b6-11eb-9f76-05aad451c1d8.png)
