### PR TITLE
Fix attribute importer and user template mapper for Facebook/Google

### DIFF
--- a/keycloak/identity_provider_mapper.go
+++ b/keycloak/identity_provider_mapper.go
@@ -11,6 +11,7 @@ import (
 
 type IdentityProviderMapperConfig struct {
 	UserAttribute         string                 `json:"user.attribute,omitempty"`
+	UserAttributeName     string                 `json:"userAttribute,omitempty"`
 	Claim                 string                 `json:"claim,omitempty"`
 	ClaimValue            string                 `json:"claim.value,omitempty"`
 	HardcodedAttribute    string                 `json:"attribute,omitempty"`
@@ -19,6 +20,7 @@ type IdentityProviderMapperConfig struct {
 	AttributeFriendlyName string                 `json:"attribute.friendly.name,omitempty"`
 	Template              string                 `json:"template,omitempty"`
 	Role                  string                 `json:"role,omitempty"`
+	JsonField             string                 `json:"jsonField,omitEmpty"`
 	ExtraConfig           map[string]interface{} `json:"-"`
 }
 

--- a/provider/resource_keycloak_attribute_importer_identity_provider_mapper.go
+++ b/provider/resource_keycloak_attribute_importer_identity_provider_mapper.go
@@ -70,7 +70,12 @@ func getAttributeImporterIdentityProviderMapperFromData(data *schema.ResourceDat
 		if _, ok := data.GetOk("claim_name"); !ok {
 			return nil, fmt.Errorf(`provider.keycloak: keycloak_attribute_importer_identity_provider_mapper: %s: "claim_name": should be set for %s identity provider`, data.Get("name").(string), identityProvider.ProviderId)
 		}
+
 		rec.Config.Claim = data.Get("claim_name").(string)
+	} else if identityProvider.ProviderId == "facebook" || identityProvider.ProviderId == "google" {
+		rec.IdentityProviderMapper = fmt.Sprintf("%s-user-attribute-mapper", identityProvider.ProviderId)
+		rec.Config.JsonField = data.Get("claim_name").(string)
+		rec.Config.UserAttributeName = data.Get("user_attribute").(string)
 	} else {
 		return nil, fmt.Errorf(`provider.keycloak: keycloak_attribute_importer_identity_provider_mapper: %s: "%s" identity provider is not supported yet`, data.Get("name").(string), identityProvider.ProviderId)
 	}

--- a/provider/resource_keycloak_attribute_importer_identity_provider_mapper.go
+++ b/provider/resource_keycloak_attribute_importer_identity_provider_mapper.go
@@ -84,10 +84,16 @@ func getAttributeImporterIdentityProviderMapperFromData(data *schema.ResourceDat
 
 func setAttributeImporterIdentityProviderMapperData(data *schema.ResourceData, identityProviderMapper *keycloak.IdentityProviderMapper) error {
 	setIdentityProviderMapperData(data, identityProviderMapper)
+
+	claimName := identityProviderMapper.Config.Claim
+	if claimName == "" {
+		claimName = identityProviderMapper.Config.JsonField
+	}
+
 	data.Set("attribute_name", identityProviderMapper.Config.Attribute)
 	data.Set("user_attribute", identityProviderMapper.Config.UserAttribute)
 	data.Set("attribute_friendly_name", identityProviderMapper.Config.AttributeFriendlyName)
-	data.Set("claim_name", identityProviderMapper.Config.Claim)
+	data.Set("claim_name", claimName)
 	data.Set("extra_config", identityProviderMapper.Config.ExtraConfig)
 	return nil
 }

--- a/provider/resource_keycloak_user_template_importer_identity_provider_mapper.go
+++ b/provider/resource_keycloak_user_template_importer_identity_provider_mapper.go
@@ -36,7 +36,13 @@ func getUserTemplateImporterIdentityProviderMapperFromData(data *schema.Resource
 	if err != nil {
 		return nil, handleNotFoundError(err, data)
 	}
-	rec.IdentityProviderMapper = fmt.Sprintf("%s-username-idp-mapper", identityProvider.ProviderId)
+
+	if identityProvider.ProviderId == "facebook" || identityProvider.ProviderId == "google" {
+		rec.IdentityProviderMapper = "oidc-username-idp-mapper"
+	} else {
+		rec.IdentityProviderMapper = fmt.Sprintf("%s-username-idp-mapper", identityProvider.ProviderId)
+	}
+
 	rec.Config = &keycloak.IdentityProviderMapperConfig{
 		Template:    data.Get("template").(string),
 		ExtraConfig: extraConfig,


### PR DESCRIPTION
## `keycloak_attribute_importer_identity_provider_mapper`
This does not currently work for the Facebook and Google identity providers because of two reasons:

* The computed `IdentityProviderMapper` is `<provider id>-user-attribute-idp-mapper`, while it should be `<provider id>-user-attribute-mapper`.
* The config fields used are `userAttribute` and `jsonField`.

## `keycloak_user_template_importer_identity_provider_mapper`
This does not currently work for the Facebook and Google identity providers because of:

* The computed `IdentityProviderMapper` is `<provider id>-username-idp-mapper`, while it should be `oidc-username-idp-mapper`.

---

The more correct fix for all of these would be to hit `/{realm}/identity-provider/instances/{alias}/mapper-types` to get a list of available mapper types and config fields and to select the right one based on the category.

This short-cut makes it work till that work can be done. This if-else magic was already happening in the attribute importer resource.