### PR TITLE
Fix marshalling of `false` value in KeycloakBoolQuoted

### DIFF
--- a/keycloak/util.go
+++ b/keycloak/util.go
@@ -11,11 +11,7 @@ type KeycloakBoolQuoted bool
 
 func (c KeycloakBoolQuoted) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
-	if c == false {
-		buf.WriteString(`""`)
-	} else {
-		buf.WriteString(strconv.Quote(strconv.FormatBool(bool(c))))
-	}
+	buf.WriteString(strconv.Quote(strconv.FormatBool(bool(c))))
 	return buf.Bytes(), nil
 }
 


### PR DESCRIPTION
Resolves #492

`false` is currently marshalled to `""` (empty string). This is incorrect: `""` represents the default value for an attribute which hasn't been explicitly set.

`""` could be interpreted by Keycloak as either `true` or `false` depending on what the default value is in Keycloak for the attribute considered. For example, in client scopes, both attributes `include.in.token.scope` and `display.on.consent.screen` are evaluated to `true` (ON) when their value is `""`.

As a result, `""` and `"false"` are not equivalent and `"false"` must be used explicitly to accurately turn off Keycloak attributes and not rely on default Keycloak behaviours.

For the same reason, the assumption made when unmarshalling is incorrect as well, though this has a lesser negative effect: https://github.com/mrparkers/terraform-provider-keycloak/blob/master/keycloak/util.go#L24-L25