### PR TITLE
Upgrade to Keycloak v12.0.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ workflows:
           matrix:
             parameters:
               keycloak-version:
-                - '12.0.1'
+                - '12.0.4'
                 - '11.0.3'
                 - '10.0.2'
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This provider will officially support the latest three major versions of Keycloa
 
 The following versions are used when running acceptance tests in CI:
 
-- 12.0.1 (latest)
+- 12.0.4 (latest)
 - 11.0.3
 - 10.0.2
 

--- a/custom-user-federation-example/build.gradle
+++ b/custom-user-federation-example/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext.kotlinVersion = '1.3.31'
-	ext.keycloakVersion = '12.0.1'
+	ext.keycloakVersion = '12.0.4'
 	ext.shadowJarVersion = '4.0.2'
 
     repositories {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
     - 8389:389
   keycloak:
-    image:  jboss/keycloak:12.0.1
+    image:  jboss/keycloak:12.0.4
     command: -b 0.0.0.0 -Dkeycloak.profile.feature.upload_scripts=enabled -Dkeycloak.profile.feature.admin_fine_grained_authz=enabled -Dkeycloak.profile.feature.token_exchange=enabled
     depends_on:
     - postgres


### PR DESCRIPTION
New patch versions of Keycloak have been released, the latest is now `12.0.4`.