### PR TITLE
keycloak_saml_identity_provider: support entity_id as required field

### DIFF
--- a/docs-old/resources/keycloak_saml_identity_provider.md
+++ b/docs-old/resources/keycloak_saml_identity_provider.md
@@ -10,6 +10,7 @@ SAML (Security Assertion Markup Language) identity providers allows to authentic
 resource "keycloak_saml_identity_provider" "realm_identity_provider" {
   realm = "my-realm"
   alias = "my-idp"
+  entity_id = "https://domain.com/entity_id"
   single_sign_on_service_url = "https://domain.com/adfs/ls/"
   single_logout_service_url = "https://domain.com/adfs/ls/?wa=wsignout1.0"
   backchannel_supported = true
@@ -41,7 +42,8 @@ The following arguments are supported:
 
 #### SAML Configuration
 
-- `single_sign_on_service_url` - (Optional) The Url that must be used to send authentication requests (SAML AuthnRequest).
+- `entity_id` - (Required) The Entity ID that will be used to uniquely identify this SAML Service Provider.
+- `single_sign_on_service_url` - (Required) The Url that must be used to send authentication requests (SAML AuthnRequest).
 - `single_logout_service_url` - (Optional) The Url that must be used to send logout requests.
 - `backchannel_supported` - (Optional) Does the external IDP support back-channel logout ?.
 - `name_id_policy_format` - (Optional) Specifies the URI reference corresponding to a name identifier format. Defaults to empty.

--- a/docs/resources/saml_identity_provider.md
+++ b/docs/resources/saml_identity_provider.md
@@ -20,6 +20,7 @@ resource "keycloak_saml_identity_provider" "realm_saml_identity_provider" {
   realm = keycloak_realm.realm.id
   alias = "my-saml-idp"
 
+  entity_id                  = "https://domain.com/entity_id"
   single_sign_on_service_url = "https://domain.com/adfs/ls/"
   single_logout_service_url  = "https://domain.com/adfs/ls/?wa=wsignout1.0"
 
@@ -47,7 +48,8 @@ resource "keycloak_saml_identity_provider" "realm_saml_identity_provider" {
 - `first_broker_login_flow_alias` - (Optional) Alias of authentication flow, which is triggered after first login with this identity provider. Term 'First Login' means that there is not yet existing Keycloak account linked with the authenticated identity provider account. Defaults to `first broker login`.
 - `post_broker_login_flow_alias` - (Optional) Alias of authentication flow, which is triggered after each login with this identity provider. Useful if you want additional verification of each user authenticated with this identity provider (for example OTP). Leave this empty if you don't want any additional authenticators to be triggered after login with this identity provider. Also note, that authenticator implementations must assume that user is already set in ClientSession as identity provider already set it. Defaults to empty.
 - `authenticate_by_default` - (Optional) Authenticate users by default. Defaults to `false`.
-- `single_sign_on_service_url` - (Optional) The Url that must be used to send authentication requests (SAML AuthnRequest).
+- `entity_id` - (Required) The Entity ID that will be used to uniquely identify this SAML Service Provider.
+- `single_sign_on_service_url` - (Required) The Url that must be used to send authentication requests (SAML AuthnRequest).
 - `single_logout_service_url` - (Optional) The Url that must be used to send logout requests.
 - `backchannel_supported` - (Optional) Does the external IDP support back-channel logout ?.
 - `name_id_policy_format` - (Optional) Specifies the URI reference corresponding to a name identifier format. Defaults to empty.

--- a/example/main.tf
+++ b/example/main.tf
@@ -677,6 +677,7 @@ resource keycloak_hardcoded_attribute_identity_provider_mapper oidc {
 resource keycloak_saml_identity_provider saml {
   realm                      = keycloak_realm.test.id
   alias                      = "saml"
+  entity_id                  = "https://example.com/entity_id"
   single_sign_on_service_url = "https://example.com/auth"
 }
 

--- a/keycloak/identity_provider.go
+++ b/keycloak/identity_provider.go
@@ -20,6 +20,7 @@ type IdentityProviderConfig struct {
 	UserInfoUrl                      string                 `json:"userInfoUrl,omitempty"`
 	HideOnLoginPage                  KeycloakBoolQuoted     `json:"hideOnLoginPage"`
 	NameIDPolicyFormat               string                 `json:"nameIDPolicyFormat,omitempty"`
+	EntityId                         string                 `json:"entityId,omitempty"`
 	SingleLogoutServiceUrl           string                 `json:"singleLogoutServiceUrl,omitempty"`
 	SingleSignOnServiceUrl           string                 `json:"singleSignOnServiceUrl,omitempty"`
 	SigningCertificate               string                 `json:"signingCertificate,omitempty"`

--- a/provider/resource_keycloak_attribute_importer_identity_provider_mapper_test.go
+++ b/provider/resource_keycloak_attribute_importer_identity_provider_mapper_test.go
@@ -284,6 +284,7 @@ data "keycloak_realm" "realm" {
 resource "keycloak_saml_identity_provider" "saml" {
 	realm                      = data.keycloak_realm.realm.id
 	alias                      = "%s"
+	entity_id                  = "https://example.com/entity_id"
 	single_sign_on_service_url = "https://example.com/auth"
 }
 

--- a/provider/resource_keycloak_attribute_to_role_identity_provider_mapper_test.go
+++ b/provider/resource_keycloak_attribute_to_role_identity_provider_mapper_test.go
@@ -292,6 +292,7 @@ data "keycloak_realm" "realm" {
 resource "keycloak_saml_identity_provider" "saml" {
 	realm                      = data.keycloak_realm.realm.id
 	alias                      = "%s"
+	entity_id                  = "https://example.com/entity_id"
 	single_sign_on_service_url = "https://example.com/auth"
 }
 

--- a/provider/resource_keycloak_hardcoded_attribute_identity_provider_mapper_test.go
+++ b/provider/resource_keycloak_hardcoded_attribute_identity_provider_mapper_test.go
@@ -293,6 +293,7 @@ data "keycloak_realm" "realm" {
 resource "keycloak_saml_identity_provider" "saml" {
 	realm                      = data.keycloak_realm.realm.id
 	alias                      = "%s"
+	entity_id                  = "https://example.com/entity_id"
 	single_sign_on_service_url = "https://example.com/auth"
 }
 

--- a/provider/resource_keycloak_hardcoded_role_identity_provider_mapper_test.go
+++ b/provider/resource_keycloak_hardcoded_role_identity_provider_mapper_test.go
@@ -281,6 +281,7 @@ data "keycloak_realm" "realm" {
 resource "keycloak_saml_identity_provider" "saml" {
 	realm                      = data.keycloak_realm.realm.id
 	alias                      = "%s"
+	entity_id                  = "https://example.com/entity_id"
 	single_sign_on_service_url = "https://example.com/auth"
 }
 

--- a/provider/resource_keycloak_saml_identity_provider.go
+++ b/provider/resource_keycloak_saml_identity_provider.go
@@ -60,6 +60,11 @@ func resourceKeycloakSamlIdentityProvider() *schema.Resource {
 			Optional:    true,
 			Description: "Logout URL.",
 		},
+		"entity_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The Entity ID that will be used to uniquely identify this SAML Service Provider.",
+		},
 		"single_sign_on_service_url": {
 			Type:        schema.TypeString,
 			Required:    true,
@@ -131,6 +136,7 @@ func getSamlIdentityProviderFromData(data *schema.ResourceData) (*keycloak.Ident
 		HideOnLoginPage:                  keycloak.KeycloakBoolQuoted(data.Get("hide_on_login_page").(bool)),
 		BackchannelSupported:             keycloak.KeycloakBoolQuoted(data.Get("backchannel_supported").(bool)),
 		NameIDPolicyFormat:               nameIdPolicyFormats[data.Get("name_id_policy_format").(string)],
+		EntityId:                         data.Get("entity_id").(string),
 		SingleLogoutServiceUrl:           data.Get("single_logout_service_url").(string),
 		SingleSignOnServiceUrl:           data.Get("single_sign_on_service_url").(string),
 		SigningCertificate:               data.Get("signing_certificate").(string),
@@ -155,6 +161,7 @@ func setSamlIdentityProviderData(data *schema.ResourceData, identityProvider *ke
 	data.Set("validate_signature", identityProvider.Config.ValidateSignature)
 	data.Set("hide_on_login_page", identityProvider.Config.HideOnLoginPage)
 	data.Set("name_id_policy_format", identityProvider.Config.NameIDPolicyFormat)
+	data.Set("entity_id", identityProvider.Config.EntityId)
 	data.Set("single_logout_service_url", identityProvider.Config.SingleLogoutServiceUrl)
 	data.Set("single_sign_on_service_url", identityProvider.Config.SingleSignOnServiceUrl)
 	data.Set("signing_certificate", identityProvider.Config.SigningCertificate)

--- a/provider/resource_keycloak_saml_identity_provider_test.go
+++ b/provider/resource_keycloak_saml_identity_provider_test.go
@@ -102,12 +102,13 @@ func TestAccKeycloakSamlIdentityProvider_basicUpdateAll(t *testing.T) {
 		Alias:   acctest.RandString(10),
 		Enabled: firstEnabled,
 		Config: &keycloak.IdentityProviderConfig{
-			SingleSignOnServiceUrl:           "https://example.com/signon/2",
+			EntityId:                         "https://example.com/entity_id/1",
+			SingleSignOnServiceUrl:           "https://example.com/signon/1",
 			BackchannelSupported:             keycloak.KeycloakBoolQuoted(firstBackchannel),
 			ValidateSignature:                keycloak.KeycloakBoolQuoted(firstValidateSignature),
 			HideOnLoginPage:                  keycloak.KeycloakBoolQuoted(firstHideOnLogin),
 			NameIDPolicyFormat:               "Email",
-			SingleLogoutServiceUrl:           "https://example.com/logout/2",
+			SingleLogoutServiceUrl:           "https://example.com/logout/1",
 			SigningCertificate:               acctest.RandString(10),
 			SignatureAlgorithm:               "RSA_SHA512",
 			XmlSignKeyInfoKeyNameTransformer: "KEY_ID",
@@ -125,6 +126,7 @@ func TestAccKeycloakSamlIdentityProvider_basicUpdateAll(t *testing.T) {
 		Alias:   acctest.RandString(10),
 		Enabled: !firstEnabled,
 		Config: &keycloak.IdentityProviderConfig{
+			EntityId:                         "https://example.com/entity_id/2",
 			SingleSignOnServiceUrl:           "https://example.com/signon/2",
 			BackchannelSupported:             keycloak.KeycloakBoolQuoted(!firstBackchannel),
 			ValidateSignature:                keycloak.KeycloakBoolQuoted(!firstValidateSignature),
@@ -231,6 +233,7 @@ resource "keycloak_realm" "realm" {
 resource "keycloak_saml_identity_provider" "saml" {
 	realm             			= "${keycloak_realm.realm.id}"
 	alias             			= "%s"
+	entity_id					= "https://example.com/entity_id"
 	single_sign_on_service_url = "https://example.com/auth"
 }
 	`, realm, saml)
@@ -246,6 +249,7 @@ resource "keycloak_saml_identity_provider" "saml" {
 	realm             			= "${keycloak_realm.realm.id}"
 	alias             			= "%s"
 	enabled           			= %t
+	entity_id					= "%s"
 	single_sign_on_service_url = "%s"
 	backchannel_supported      = %t
 	validate_signature         = %t
@@ -262,5 +266,5 @@ resource "keycloak_saml_identity_provider" "saml" {
 	want_assertions_signed     = %t
 	want_assertions_encrypted  = %t
 }
-	`, saml.Realm, saml.Alias, saml.Enabled, saml.Config.SingleSignOnServiceUrl, bool(saml.Config.BackchannelSupported), bool(saml.Config.ValidateSignature), bool(saml.Config.HideOnLoginPage), saml.Config.NameIDPolicyFormat, saml.Config.SingleLogoutServiceUrl, saml.Config.SigningCertificate, saml.Config.SignatureAlgorithm, saml.Config.XmlSignKeyInfoKeyNameTransformer, bool(saml.Config.PostBindingAuthnRequest), bool(saml.Config.PostBindingResponse), bool(saml.Config.PostBindingLogout), bool(saml.Config.ForceAuthn), bool(saml.Config.WantAssertionsSigned), bool(saml.Config.WantAssertionsEncrypted))
+	`, saml.Realm, saml.Alias, saml.Enabled, saml.Config.EntityId, saml.Config.SingleSignOnServiceUrl, bool(saml.Config.BackchannelSupported), bool(saml.Config.ValidateSignature), bool(saml.Config.HideOnLoginPage), saml.Config.NameIDPolicyFormat, saml.Config.SingleLogoutServiceUrl, saml.Config.SigningCertificate, saml.Config.SignatureAlgorithm, saml.Config.XmlSignKeyInfoKeyNameTransformer, bool(saml.Config.PostBindingAuthnRequest), bool(saml.Config.PostBindingResponse), bool(saml.Config.PostBindingLogout), bool(saml.Config.ForceAuthn), bool(saml.Config.WantAssertionsSigned), bool(saml.Config.WantAssertionsEncrypted))
 }

--- a/provider/resource_keycloak_user_template_importer_identity_provider_mapper_test.go
+++ b/provider/resource_keycloak_user_template_importer_identity_provider_mapper_test.go
@@ -276,6 +276,7 @@ data "keycloak_realm" "realm" {
 resource "keycloak_saml_identity_provider" "saml" {
 	realm                      = data.keycloak_realm.realm.id
 	alias                      = "%s"
+	entity_id = "https://example.com/entity_id"
 	single_sign_on_service_url = "https://example.com/auth"
 }
 


### PR DESCRIPTION
This PR adds support for the required field `entity_id` on the resource `keycloak_saml_identity_provider`.

Notice: This is a breaking change. I think it is weird that this field is required in the Admin Console but the REST API seems to be ok if the field is missing. I would still make it a required field as using the Admin Console on an SAML identity provider may otherwise result in unexpected behavior.

Fixes https://github.com/mrparkers/terraform-provider-keycloak/issues/510