### PR TITLE
Add datasource keycloak_client_description_converter

### DIFF
--- a/keycloak/generic_client_description_converter.go
+++ b/keycloak/generic_client_description_converter.go
@@ -1,0 +1,63 @@
+package keycloak
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type GenericClientRepresentation struct {
+	Access                             map[string]string              `json:"access"`
+	AdminUrl                           string                         `json:"adminUrl"`
+	Attributes                         map[string]string              `json:"attributes"`
+	AuthenticationFlowBindingOverrides map[string]string              `json:"authenticationFlowBindingOverrides"`
+	AuthorizationServicesEnabled       bool                           `json:"authorizationServicesEnabled"`
+	AuthorizationSettings              map[string]string              `json:"authorizationSettings"`
+	BaseUrl                            string                         `json:"baseUrl"`
+	BearerOnly                         bool                           `json:"bearerOnly"`
+	ClientAuthenticatorType            string                         `json:"clientAuthenticatorType"`
+	ClientId                           string                         `json:"clientId"`
+	ConsentRequired                    string                         `json:"consentRequired"`
+	DefaultClientScopes                []string                       `json:"defaultClientScopes"`
+	DefaultRoles                       []string                       `json:"defaultRoles"`
+	Description                        string                         `json:"description"`
+	DirectAccessGrantsEnabled          bool                           `json:"directAccessGrantsEnabled"`
+	Enabled                            bool                           `json:"enabled"`
+	FrontchannelLogout                 bool                           `json:"frontchannelLogout"`
+	FullScopeAllowed                   bool                           `json:"fullScopeAllowed"`
+	Id                                 string                         `json:"id"`
+	ImplicitFlowEnabled                bool                           `json:"implicitFlowEnabled"`
+	Name                               string                         `json:"name"`
+	NotBefore                          int                            `json:"notBefore"`
+	OptionalClientScopes               []string                       `json:"optionalClientScopes"`
+	Origin                             string                         `json:"origin"`
+	Protocol                           string                         `json:"protocol"`
+	ProtocolMappers                    []*GenericClientProtocolMapper `json:"protocolMappers"`
+	PublicClient                       bool                           `json:"publicClient"`
+	RedirectUris                       []string                       `json:"redirectUris"`
+	RegisteredNodes                    map[string]string              `json:"registeredNodes"`
+	RegistrationAccessToken            string                         `json:"registrationAccessToken"`
+	RootUrl                            string                         `json:"rootUrl"`
+	Secret                             string                         `json:"secret"`
+	ServiceAccountsEnabled             bool                           `json:"serviceAccountsEnabled"`
+	StandardFlowEnabled                bool                           `json:"standardFlowEnabled"`
+	SurrogateAuthRequired              bool                           `json:"surrogateAuthRequired"`
+	WebOrigins                         []string                       `json:"webOrigins"`
+}
+
+func (keycloakClient *KeycloakClient) NewGenericClientDescription(realmId string, body string) (*GenericClientRepresentation, error) {
+	var genericClientRepresentation GenericClientRepresentation
+
+	result, err := keycloakClient.sendRaw(fmt.Sprintf("/realms/%s/client-description-converter", realmId), []byte(body))
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(result, &genericClientRepresentation)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &genericClientRepresentation, nil
+}

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -371,6 +371,19 @@ func (keycloakClient *KeycloakClient) getRaw(path string, params map[string]stri
 	return body, err
 }
 
+func (keycloakClient *KeycloakClient) sendRaw(path string, requestBody []byte) ([]byte, error) {
+	resourceUrl := keycloakClient.baseUrl + apiUrl + path
+
+	request, err := http.NewRequest(http.MethodPost, resourceUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, _, err := keycloakClient.sendRequest(request, requestBody)
+
+	return body, err
+}
+
 func (keycloakClient *KeycloakClient) post(path string, requestBody interface{}) ([]byte, string, error) {
 	resourceUrl := keycloakClient.baseUrl + apiUrl + path
 

--- a/provider/data_source_keycloak_client_description_converter.go
+++ b/provider/data_source_keycloak_client_description_converter.go
@@ -1,0 +1,249 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
+)
+
+func dataSourceKeycloakClientDescriptionConverter() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceKeycloakClientDescriptionConverterRead,
+
+		Schema: map[string]*schema.Schema{
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"body": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"access": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"admin_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attributes": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"authentication_flow_binding_overrides": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"authorization_services_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"authorization_settings": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"base_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bearer_only": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"client_authenticator_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"client_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"consent_required": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"default_client_scopes": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"default_roles": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"direct_access_grants_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"frontchannel_logout": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"full_scope_allowed": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"implicit_flow_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"not_before": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"optional_client_scopes": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"origin": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"protocol_mappers": {
+				Type: schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protocol_mapper": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"config": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+			},
+			"public_client": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"redirect_uris": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"registered_nodes": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"registration_access_token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"root_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"secret": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_accounts_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"standard_flow_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"surrogate_auth_required": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"web_origins": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func setClientDescriptionConverterData(data *schema.ResourceData, description *keycloak.GenericClientRepresentation) {
+	data.SetId(description.ClientId)
+
+	data.Set("access", description.Access)
+	data.Set("admin_url", description.AdminUrl)
+	data.Set("attributes", description.Attributes)
+	data.Set("authentication_flow_binding_overrides", description.AuthenticationFlowBindingOverrides)
+	data.Set("authorization_services_enabled", description.AuthorizationServicesEnabled)
+	data.Set("authorization_settings", description.AuthorizationSettings)
+	data.Set("base_url", description.BaseUrl)
+	data.Set("bearer_only", description.BearerOnly)
+	data.Set("client_authenticator_type", description.ClientAuthenticatorType)
+	data.Set("client_id", description.ClientId)
+	data.Set("consent_required", description.ConsentRequired)
+	data.Set("default_client_scopes", description.DefaultClientScopes)
+	data.Set("default_roles", description.DefaultRoles)
+	data.Set("description", description.Description)
+	data.Set("direct_access_grants_enabled", description.DirectAccessGrantsEnabled)
+	data.Set("enabled", description.Enabled)
+	data.Set("frontchannel_logout", description.FrontchannelLogout)
+	data.Set("full_scope_allowed", description.FullScopeAllowed)
+	data.Set("implicit_flow_enabled", description.ImplicitFlowEnabled)
+	data.Set("name", description.Name)
+	data.Set("not_before", description.NotBefore)
+	data.Set("optional_client_scopes", description.OptionalClientScopes)
+	data.Set("origin", description.Origin)
+	data.Set("protocol", description.Protocol)
+	data.Set("protocol_mappers", description.ProtocolMappers)
+	data.Set("public_client", description.PublicClient)
+	data.Set("redirect_uris", description.RedirectUris)
+	data.Set("registered_nodes", description.RegisteredNodes)
+	data.Set("registration_access_token", description.RegistrationAccessToken)
+	data.Set("root_url", description.RootUrl)
+	data.Set("secret", description.Secret)
+	data.Set("service_accounts_enabled", description.ServiceAccountsEnabled)
+	data.Set("standard_flow_enabled", description.StandardFlowEnabled)
+	data.Set("surrogate_auth_required", description.SurrogateAuthRequired)
+	data.Set("web_origins", description.WebOrigins)
+}
+
+func dataSourceKeycloakClientDescriptionConverterRead(data *schema.ResourceData, meta interface{}) error {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	body := data.Get("body").(string)
+
+	description, err := keycloakClient.NewGenericClientDescription(realmId, body)
+
+	if err != nil {
+		return handleNotFoundError(err, data)
+	}
+
+	setClientDescriptionConverterData(data, description)
+
+	return nil
+}

--- a/provider/data_source_keycloak_client_description_converter_test.go
+++ b/provider/data_source_keycloak_client_description_converter_test.go
@@ -1,0 +1,71 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccKeycloakDataSourceClientDescriptionConverter_basic(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.keycloak_client_description_converter.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeycloakClientDescriptionConverterConfig(clientId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "protocol", "saml"),
+					resource.TestCheckResourceAttr(dataSourceName, "client_id", "FakeEntityId"),
+					resource.TestCheckResourceAttr(dataSourceName, "realm_id", testAccRealm.Realm),
+				),
+			},
+		},
+	})
+}
+
+func testAccKeycloakClientDescriptionConverterConfig(clientId string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+data "keycloak_client_description_converter" "test" {
+	realm_id = data.keycloak_realm.realm.id
+	body     = <<EOF
+	<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2021-04-17T12:41:46Z" cacheDuration="PT604800S" entityID="FakeEntityId">
+    <md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:KeyDescriptor use="signing">
+			<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+				<ds:X509Data>
+					<ds:X509Certificate>MIICyDCCAjGgAwIBAgIBADANBgkqhkiG9w0BAQ0FADCBgDELMAkGA1UEBhMCdXMx
+					CzAJBgNVBAgMAklBMSQwIgYDVQQKDBt0ZXJyYWZvcm0tcHJvdmlkZXIta2V5Y2xv
+					YWsxHDAaBgNVBAMME21ycGFya2Vycy5naXRodWIuaW8xIDAeBgkqhkiG9w0BCQEW
+					EW1pY2hhZWxAcGFya2VyLmdnMB4XDTE5MDEwODE0NDYzNloXDTI5MDEwNTE0NDYz
+					NlowgYAxCzAJBgNVBAYTAnVzMQswCQYDVQQIDAJJQTEkMCIGA1UECgwbdGVycmFm
+					b3JtLXByb3ZpZGVyLWtleWNsb2FrMRwwGgYDVQQDDBNtcnBhcmtlcnMuZ2l0aHVi
+					LmlvMSAwHgYJKoZIhvcNAQkBFhFtaWNoYWVsQHBhcmtlci5nZzCBnzANBgkqhkiG
+					9w0BAQEFAAOBjQAwgYkCgYEAxuZny7uyYxGVPtpie14gNQC4tT9sAvO2sVNDhuoe
+					qIKLRpNwkHnwQmwe5OxSh9K0BPHp/DNuuVWUqvo4tniEYn3jBr7FwLYLTKojQIxj
+					53S1UTT9EXq3eP5HsHMD0QnTuca2nlNYUDBm6ud2fQj0Jt5qLx86EbEC28N56IRv
+					GX8CAwEAAaNQME4wHQYDVR0OBBYEFMLnbQh77j7vhGTpAhKpDhCrBsPZMB8GA1Ud
+					IwQYMBaAFMLnbQh77j7vhGTpAhKpDhCrBsPZMAwGA1UdEwQFMAMBAf8wDQYJKoZI
+					hvcNAQENBQADgYEAB8wGrAQY0pAfwbnYSyBt4STbebeRTu1/q1ucfrtc3qsegcd5
+					n01xTR+T2uZJwqHFPpFjr4IPORiHx3+4BWCweslPD53qBjKUPXcbMO1Revjef6Tj
+					K3K0AuJ94fxgXVoT61Nzu/a6Lj6RhzU/Dao9mlSbJY+YSbm+ZBpsuRUQ84s=</ds:X509Certificate>
+				</ds:X509Data>
+			</ds:KeyInfo>
+		</md:KeyDescriptor>
+		<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+        <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost/acs/saml/" index="1"/>
+    </md:SPSSODescriptor>
+</md:EntityDescriptor>
+	EOF
+}
+`, testAccRealm.Realm)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -25,6 +25,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 			"keycloak_saml_client":                        dataSourceKeycloakSamlClient(),
 			"keycloak_authentication_execution":           dataSourceKeycloakAuthenticationExecution(),
 			"keycloak_authentication_flow":                dataSourceKeycloakAuthenticationFlow(),
+			"keycloak_client_description_converter":       dataSourceKeycloakClientDescriptionConverter(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"keycloak_realm":                                             resourceKeycloakRealm(),


### PR DESCRIPTION
This PR implements the client_description_converter endpoint as a datasource (documentation of this endpoint can be found here : https://www.keycloak.org/docs-api/5.0/rest-api/index.html#_paths).

I had to add a method in keycloak_client to be able to send xml data without escaping.

Please let me know if this suit you 😃 

Thanks by advance !