### PR TITLE
fix: use consistent config / extra_config across identity providers

### DIFF
--- a/docs/resources/oidc_google_identity_provider.md
+++ b/docs/resources/oidc_google_identity_provider.md
@@ -22,10 +22,7 @@ resource "keycloak_oidc_google_identity_provider" "google" {
   client_secret = var.google_identity_provider_client_secret
   trust_email   = true
   hosted_domain = "example.com"
-
-  extra_config = {
-    "syncMode" = "IMPORT"
-  }
+  sync_mode     = "IMPORT"
 }
 ```
 
@@ -49,6 +46,8 @@ resource "keycloak_oidc_google_identity_provider" "google" {
 - `accepts_prompt_none_forward_from_client` - (Optional) When `true`, unauthenticated requests with `prompt=none` will be forwarded to Google instead of returning an error. Defaults to `false`.
 - `disable_user_info` - (Optional) When `true`, disables the usage of the user info service to obtain additional user information. Defaults to `false`.
 - `hide_on_login_page` - (Optional) When `true`, this identity provider will be hidden on the login page. Defaults to `false`.
+- `sync_mode` - (Optional) The default sync mode to use for all mappers attached to this identity provider. Can be once of `IMPORT`, `FORCE`, or `LEGACY`.
+- `gui_order` - (Optional) A number defining the order of this identity provider in the GUI.
 - `extra_config` - (Optional) A map of key/value pairs to add extra configuration to this identity provider. This can be used for custom oidc provider implementations, or to add configuration that is not yet supported by this Terraform provider.
 
 ## Attribute Reference

--- a/docs/resources/oidc_google_identity_provider.md
+++ b/docs/resources/oidc_google_identity_provider.md
@@ -23,6 +23,10 @@ resource "keycloak_oidc_google_identity_provider" "google" {
   trust_email   = true
   hosted_domain = "example.com"
   sync_mode     = "IMPORT"
+
+  extra_config = {
+    "myCustomConfigKey" = "myValue"
+  }
 }
 ```
 
@@ -48,7 +52,7 @@ resource "keycloak_oidc_google_identity_provider" "google" {
 - `hide_on_login_page` - (Optional) When `true`, this identity provider will be hidden on the login page. Defaults to `false`.
 - `sync_mode` - (Optional) The default sync mode to use for all mappers attached to this identity provider. Can be once of `IMPORT`, `FORCE`, or `LEGACY`.
 - `gui_order` - (Optional) A number defining the order of this identity provider in the GUI.
-- `extra_config` - (Optional) A map of key/value pairs to add extra configuration to this identity provider. This can be used for custom oidc provider implementations, or to add configuration that is not yet supported by this Terraform provider.
+- `extra_config` - (Optional) A map of key/value pairs to add extra configuration to this identity provider. This can be used for custom oidc provider implementations, or to add configuration that is not yet supported by this Terraform provider. Use this attribute at your own risk, as custom attributes may conflict with top-level configuration attributes in future provider updates.
 
 ## Attribute Reference
 

--- a/docs/resources/oidc_identity_provider.md
+++ b/docs/resources/oidc_identity_provider.md
@@ -60,7 +60,7 @@ resource "keycloak_oidc_identity_provider" "realm_identity_provider" {
 - `default_scopes` - (Optional) The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to `openid`.
 - `sync_mode` - (Optional) The default sync mode to use for all mappers attached to this identity provider. Can be once of `IMPORT`, `FORCE`, or `LEGACY`.
 - `gui_order` - (Optional) A number defining the order of this identity provider in the GUI.
-- `extra_config` - (Optional) A map of key/value pairs to add extra configuration to this identity provider. This can be used for custom oidc provider implementations, or to add configuration that is not yet supported by this Terraform provider.
+- `extra_config` - (Optional) A map of key/value pairs to add extra configuration to this identity provider. This can be used for custom oidc provider implementations, or to add configuration that is not yet supported by this Terraform provider. Use this attribute at your own risk, as custom attributes may conflict with top-level configuration attributes in future provider updates.
     - `clientAuthMethod` (Optional) The client authentication method. Since Keycloak 8, this is a required attribute if OIDC provider is created using the Keycloak GUI. It accepts the values `client_secret_post` (Client secret sent as post), `client_secret_basic` (Client secret sent as basic auth), `client_secret_jwt` (Client secret as jwt) and `private_key_jwt ` (JTW signed with private key)
 
 ## Attribute Reference

--- a/docs/resources/oidc_identity_provider.md
+++ b/docs/resources/oidc_identity_provider.md
@@ -58,6 +58,8 @@ resource "keycloak_oidc_identity_provider" "realm_identity_provider" {
 - `ui_locales` - (Optional) Pass current locale to identity provider. Defaults to `false`.
 - `accepts_prompt_none_forward_from_client` (Optional) When `true`, the IDP will accept forwarded authentication requests that contain the `prompt=none` query parameter. Defaults to `false`.
 - `default_scopes` - (Optional) The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to `openid`.
+- `sync_mode` - (Optional) The default sync mode to use for all mappers attached to this identity provider. Can be once of `IMPORT`, `FORCE`, or `LEGACY`.
+- `gui_order` - (Optional) A number defining the order of this identity provider in the GUI.
 - `extra_config` - (Optional) A map of key/value pairs to add extra configuration to this identity provider. This can be used for custom oidc provider implementations, or to add configuration that is not yet supported by this Terraform provider.
     - `clientAuthMethod` (Optional) The client authentication method. Since Keycloak 8, this is a required attribute if OIDC provider is created using the Keycloak GUI. It accepts the values `client_secret_post` (Client secret sent as post), `client_secret_basic` (Client secret sent as basic auth), `client_secret_jwt` (Client secret as jwt) and `private_key_jwt ` (JTW signed with private key)
 

--- a/docs/resources/saml_identity_provider.md
+++ b/docs/resources/saml_identity_provider.md
@@ -63,6 +63,9 @@ resource "keycloak_saml_identity_provider" "realm_saml_identity_provider" {
 - `signing_certificate` - (Optional) Signing Certificate.
 - `signature_algorithm` - (Optional) Signing Algorithm. Defaults to empty.
 - `xml_sign_key_info_key_name_transformer` - (Optional) Sign Key Transformer. Defaults to empty.
+- `sync_mode` - (Optional) The default sync mode to use for all mappers attached to this identity provider. Can be once of `IMPORT`, `FORCE`, or `LEGACY`.
+- `gui_order` - (Optional) A number defining the order of this identity provider in the GUI.
+- `extra_config` - (Optional) A map of key/value pairs to add extra configuration to this identity provider. This can be used for custom oidc provider implementations, or to add configuration that is not yet supported by this Terraform provider.
 
 ## Import
 

--- a/docs/resources/saml_identity_provider.md
+++ b/docs/resources/saml_identity_provider.md
@@ -65,7 +65,7 @@ resource "keycloak_saml_identity_provider" "realm_saml_identity_provider" {
 - `xml_sign_key_info_key_name_transformer` - (Optional) Sign Key Transformer. Defaults to empty.
 - `sync_mode` - (Optional) The default sync mode to use for all mappers attached to this identity provider. Can be once of `IMPORT`, `FORCE`, or `LEGACY`.
 - `gui_order` - (Optional) A number defining the order of this identity provider in the GUI.
-- `extra_config` - (Optional) A map of key/value pairs to add extra configuration to this identity provider. This can be used for custom oidc provider implementations, or to add configuration that is not yet supported by this Terraform provider.
+- `extra_config` - (Optional) A map of key/value pairs to add extra configuration to this identity provider. This can be used for custom oidc provider implementations, or to add configuration that is not yet supported by this Terraform provider. Use this attribute at your own risk, as custom attributes may conflict with top-level configuration attributes in future provider updates.
 
 ## Import
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -8,9 +8,9 @@ terraform {
 }
 
 provider "keycloak" {
-  client_id     = "terraform"
-  client_secret = "884e0f95-0f42-4a63-9b1f-94274655669e"
-  url           = "http://localhost:8080"
+  client_id          = "terraform"
+  client_secret      = "884e0f95-0f42-4a63-9b1f-94274655669e"
+  url                = "http://localhost:8080"
   additional_headers = {
     foo = "bar"
   }
@@ -76,20 +76,24 @@ resource "keycloak_realm" "test" {
 
   ssl_required    = "external"
   password_policy = "upperCase(1) and length(8) and forceExpiredPasswordChange(365) and notUsername"
-  attributes = {
+  attributes      = {
     mycustomAttribute = "myCustomValue"
   }
 
   web_authn_policy {
     relying_party_entity_name = "Example"
-    relying_party_id = "keycloak.example.com"
-    signature_algorithms = ["ES256", "RS256"]
+    relying_party_id          = "keycloak.example.com"
+    signature_algorithms      = [
+      "ES256",
+      "RS256"]
   }
 
   web_authn_passwordless_policy {
     relying_party_entity_name = "Example"
-    relying_party_id = "keycloak.example.com"
-    signature_algorithms = ["ES256", "RS256"]
+    relying_party_id          = "keycloak.example.com"
+    signature_algorithms      = [
+      "ES256",
+      "RS256"]
   }
 }
 
@@ -111,10 +115,10 @@ resource "keycloak_required_action" "custom-configured_totp" {
 }
 
 resource "keycloak_required_action" "required_action" {
-  realm_id  = keycloak_realm.test.realm
-  alias     = "webauthn-register"
-  enabled   = true
-  name      = "Webauthn Register"
+  realm_id = keycloak_realm.test.realm
+  alias    = "webauthn-register"
+  enabled  = true
+  name     = "Webauthn Register"
 }
 
 resource "keycloak_group" "foo" {
@@ -182,7 +186,8 @@ resource "keycloak_group" "baz" {
 
 resource "keycloak_default_groups" "default" {
   realm_id  = keycloak_realm.test.id
-  group_ids = [keycloak_group.baz.id]
+  group_ids = [
+    keycloak_group.baz.id]
 }
 
 resource "keycloak_openid_client" "test_client" {
@@ -274,10 +279,10 @@ resource "keycloak_ldap_user_federation" "openldap" {
   read_timeout       = "10s"
 
   kerberos {
-    server_principal = "HTTP/keycloak.local@FOO.LOCAL"
+    server_principal                         = "HTTP/keycloak.local@FOO.LOCAL"
     use_kerberos_for_password_authentication = false
-    key_tab = "/etc/keycloak.keytab"
-    kerberos_realm = "FOO.LOCAL"
+    key_tab                                  = "/etc/keycloak.keytab"
+    kerberos_realm                           = "FOO.LOCAL"
   }
 
   cache {
@@ -450,15 +455,15 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "user_client_role_cl
   realm_id  = keycloak_realm.test.id
   client_id = keycloak_openid_client.test_client.id
 
-  claim_name = "foo"
+  claim_name  = "foo"
   multivalued = false
 
-  client_id_for_role_mappings   = keycloak_openid_client.bearer_only_client.client_id
-  client_role_prefix = "prefixValue"
+  client_id_for_role_mappings = keycloak_openid_client.bearer_only_client.client_id
+  client_role_prefix          = "prefixValue"
 
   add_to_id_token     = true
   add_to_access_token = false
-  add_to_userinfo = false
+  add_to_userinfo     = false
 }
 
 resource "keycloak_openid_user_client_role_protocol_mapper" "user_client_role_client_scope" {
@@ -469,35 +474,35 @@ resource "keycloak_openid_user_client_role_protocol_mapper" "user_client_role_cl
   claim_name  = "foo"
   multivalued = false
 
-  client_id_for_role_mappings   = keycloak_openid_client.bearer_only_client.client_id
-  client_role_prefix = "prefixValue"
+  client_id_for_role_mappings = keycloak_openid_client.bearer_only_client.client_id
+  client_role_prefix          = "prefixValue"
 
   add_to_id_token     = true
   add_to_access_token = false
-  add_to_userinfo    = false
+  add_to_userinfo     = false
 }
 
 resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_client" {
-	name               = "tf-test-open-id-user-session-note-protocol-mapper-client"
-	realm_id           = keycloak_realm.test.id
-	client_id          = keycloak_openid_client.test_client.id
+  name      = "tf-test-open-id-user-session-note-protocol-mapper-client"
+  realm_id  = keycloak_realm.test.id
+  client_id = keycloak_openid_client.test_client.id
 
-	claim_name         = "foo"
-	claim_value_type   = "String"
-	session_note       = "bar"
+  claim_name       = "foo"
+  claim_value_type = "String"
+  session_note     = "bar"
 
   add_to_id_token     = true
   add_to_access_token = false
 }
 
 resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_client_scope" {
-	name               = "tf-test-open-id-user-session-note-protocol-mapper-client-scope"
-	realm_id           = keycloak_realm.test.id
-	client_scope_id    = keycloak_openid_client_scope.test_default_client_scope.id
+  name            = "tf-test-open-id-user-session-note-protocol-mapper-client-scope"
+  realm_id        = keycloak_realm.test.id
+  client_scope_id = keycloak_openid_client_scope.test_default_client_scope.id
 
-	claim_name         = "foo2"
-	claim_value_type   = "String"
-	session_note       = "bar2"
+  claim_name       = "foo2"
+  claim_value_type = "String"
+  session_note     = "bar2"
 
   add_to_id_token     = true
   add_to_access_token = false
@@ -586,6 +591,8 @@ resource keycloak_oidc_identity_provider oidc {
   client_id         = "example_id"
   client_secret     = "example_token"
   default_scopes    = "openid random profile"
+  sync_mode         = "FORCE"
+  gui_order         = 1
 }
 
 resource keycloak_oidc_google_identity_provider google {
@@ -596,6 +603,8 @@ resource keycloak_oidc_google_identity_provider google {
   request_refresh_token                   = true
   default_scopes                          = "openid random profile"
   accepts_prompt_none_forward_from_client = false
+  sync_mode                               = "FORCE"
+  gui_order                               = 2
 }
 
 //This example does not work in keycloak 10, because the interfaces that our customIdp implements, have changed in the keycloak latest version.
@@ -684,6 +693,8 @@ resource keycloak_saml_identity_provider saml {
   alias                      = "saml"
   entity_id                  = "https://example.com/entity_id"
   single_sign_on_service_url = "https://example.com/auth"
+  sync_mode                  = "FORCE"
+  gui_order                  = 3
 }
 
 resource keycloak_attribute_importer_identity_provider_mapper saml {
@@ -852,61 +863,61 @@ resource "keycloak_openid_client_service_account_role" "read_token" {
 }
 
 resource "keycloak_authentication_flow" "browser-copy-flow" {
-  alias    = "browserCopyFlow"
-  realm_id = keycloak_realm.test.id
+  alias       = "browserCopyFlow"
+  realm_id    = keycloak_realm.test.id
   description = "browser based authentication"
 }
 
 resource "keycloak_authentication_execution" "browser-copy-cookie" {
-  realm_id = keycloak_realm.test.id
+  realm_id          = keycloak_realm.test.id
   parent_flow_alias = keycloak_authentication_flow.browser-copy-flow.alias
-  authenticator = "auth-cookie"
-  requirement = "ALTERNATIVE"
-  depends_on = [
+  authenticator     = "auth-cookie"
+  requirement       = "ALTERNATIVE"
+  depends_on        = [
     keycloak_authentication_execution.browser-copy-kerberos
   ]
 }
 
 resource "keycloak_authentication_execution" "browser-copy-kerberos" {
-  realm_id = keycloak_realm.test.id
+  realm_id          = keycloak_realm.test.id
   parent_flow_alias = keycloak_authentication_flow.browser-copy-flow.alias
-  authenticator = "auth-spnego"
-  requirement = "DISABLED"
+  authenticator     = "auth-spnego"
+  requirement       = "DISABLED"
 }
 
 resource "keycloak_authentication_execution" "browser-copy-idp-redirect" {
-  realm_id = keycloak_realm.test.id
+  realm_id          = keycloak_realm.test.id
   parent_flow_alias = keycloak_authentication_flow.browser-copy-flow.alias
-  authenticator = "identity-provider-redirector"
-  requirement = "ALTERNATIVE"
-  depends_on = [
+  authenticator     = "identity-provider-redirector"
+  requirement       = "ALTERNATIVE"
+  depends_on        = [
     keycloak_authentication_execution.browser-copy-cookie
   ]
 }
 
 resource "keycloak_authentication_subflow" "browser-copy-flow-forms" {
-  realm_id = keycloak_realm.test.id
+  realm_id          = keycloak_realm.test.id
   parent_flow_alias = keycloak_authentication_flow.browser-copy-flow.alias
-  alias    = "browser-copy-flow-forms"
-  requirement = "ALTERNATIVE"
-  depends_on = [
+  alias             = "browser-copy-flow-forms"
+  requirement       = "ALTERNATIVE"
+  depends_on        = [
     keycloak_authentication_execution.browser-copy-idp-redirect
   ]
 }
 
 resource "keycloak_authentication_execution" "browser-copy-auth-username-password-form" {
-  realm_id = keycloak_realm.test.id
+  realm_id          = keycloak_realm.test.id
   parent_flow_alias = keycloak_authentication_subflow.browser-copy-flow-forms.alias
-  authenticator = "auth-username-password-form"
-  requirement = "REQUIRED"
+  authenticator     = "auth-username-password-form"
+  requirement       = "REQUIRED"
 }
 
 resource "keycloak_authentication_execution" "browser-copy-otp" {
-  realm_id = keycloak_realm.test.id
+  realm_id          = keycloak_realm.test.id
   parent_flow_alias = keycloak_authentication_subflow.browser-copy-flow-forms.alias
-  authenticator = "auth-otp-form"
-  requirement = "REQUIRED"
-  depends_on = [
+  authenticator     = "auth-otp-form"
+  requirement       = "REQUIRED"
+  depends_on        = [
     keycloak_authentication_execution.browser-copy-auth-username-password-form
   ]
 }
@@ -915,7 +926,7 @@ resource "keycloak_authentication_execution_config" "config" {
   realm_id     = keycloak_realm.test.id
   execution_id = keycloak_authentication_execution.browser-copy-idp-redirect.id
   alias        = "idp-XXX-config"
-  config = {
+  config       = {
     defaultProvider = "idp-XXX"
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,10 @@ module github.com/mrparkers/terraform-provider-keycloak
 
 require (
 	github.com/hashicorp/errwrap v1.0.0
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.2-0.20200817173939-b72757e734f6
+	github.com/imdario/mergo v0.3.12
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 )
 

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
+github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
@@ -531,6 +533,8 @@ gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qS
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/provider/resource_keycloak_saml_identity_provider_test.go
+++ b/provider/resource_keycloak_saml_identity_provider_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAccKeycloakSamlIdentityProvider_basic(t *testing.T) {
-	realmName := acctest.RandomWithPrefix("tf-acc")
 	samlName := acctest.RandomWithPrefix("tf-acc")
 
 	resource.Test(t, resource.TestCase{
@@ -22,7 +21,7 @@ func TestAccKeycloakSamlIdentityProvider_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckKeycloakSamlIdentityProviderDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakSamlIdentityProvider_basic(realmName, samlName),
+				Config: testKeycloakSamlIdentityProvider_basic(samlName),
 				Check:  testAccCheckKeycloakSamlIdentityProviderExists("keycloak_saml_identity_provider.saml"),
 			},
 		},
@@ -69,7 +68,6 @@ func TestAccKeycloakSamlIdentityProvider_extraConfigInvalid(t *testing.T) {
 func TestAccKeycloakSamlIdentityProvider_createAfterManualDestroy(t *testing.T) {
 	var saml = &keycloak.IdentityProvider{}
 
-	realmName := acctest.RandomWithPrefix("tf-acc")
 	samlName := acctest.RandomWithPrefix("tf-acc")
 
 	resource.Test(t, resource.TestCase{
@@ -78,7 +76,7 @@ func TestAccKeycloakSamlIdentityProvider_createAfterManualDestroy(t *testing.T) 
 		CheckDestroy:      testAccCheckKeycloakSamlIdentityProviderDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakSamlIdentityProvider_basic(realmName, samlName),
+				Config: testKeycloakSamlIdentityProvider_basic(samlName),
 				Check:  testAccCheckKeycloakSamlIdentityProviderFetch("keycloak_saml_identity_provider.saml", saml),
 			},
 			{
@@ -88,36 +86,8 @@ func TestAccKeycloakSamlIdentityProvider_createAfterManualDestroy(t *testing.T) 
 						t.Fatal(err)
 					}
 				},
-				Config: testKeycloakSamlIdentityProvider_basic(realmName, samlName),
+				Config: testKeycloakSamlIdentityProvider_basic(samlName),
 				Check:  testAccCheckKeycloakSamlIdentityProviderExists("keycloak_saml_identity_provider.saml"),
-			},
-		},
-	})
-}
-
-func TestAccKeycloakSamlIdentityProvider_basicUpdateRealm(t *testing.T) {
-	firstRealm := acctest.RandomWithPrefix("tf-acc")
-	secondRealm := acctest.RandomWithPrefix("tf-acc")
-	samlName := acctest.RandomWithPrefix("tf-acc")
-
-	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      testAccCheckKeycloakSamlIdentityProviderDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testKeycloakSamlIdentityProvider_basic(firstRealm, samlName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKeycloakSamlIdentityProviderExists("keycloak_saml_identity_provider.saml"),
-					resource.TestCheckResourceAttr("keycloak_saml_identity_provider.saml", "realm", firstRealm),
-				),
-			},
-			{
-				Config: testKeycloakSamlIdentityProvider_basic(secondRealm, samlName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKeycloakSamlIdentityProviderExists("keycloak_saml_identity_provider.saml"),
-					resource.TestCheckResourceAttr("keycloak_saml_identity_provider.saml", "realm", secondRealm),
-				),
 			},
 		},
 	})
@@ -282,7 +252,7 @@ func getKeycloakSamlIdentityProviderFromState(s *terraform.State, resourceName s
 	return saml, nil
 }
 
-func testKeycloakSamlIdentityProvider_basic(realm, saml string) string {
+func testKeycloakSamlIdentityProvider_basic(saml string) string {
 	return fmt.Sprintf(`
 data "keycloak_realm" "realm" {
 	realm = "%s"
@@ -294,7 +264,7 @@ resource "keycloak_saml_identity_provider" "saml" {
 	entity_id					= "https://example.com/entity_id"
 	single_sign_on_service_url  = "https://example.com/auth"
 }
-	`, realm, saml)
+	`, testAccRealm.Realm, saml)
 }
 
 func testKeycloakSamlIdentityProvider_extra_config(alias, configKey, configValue string) string {
@@ -344,5 +314,5 @@ resource "keycloak_saml_identity_provider" "saml" {
 	gui_order                  = %s
 	sync_mode                  = "%s"
 }
-	`, saml.Realm, saml.Alias, saml.Enabled, saml.Config.EntityId, saml.Config.SingleSignOnServiceUrl, bool(saml.Config.BackchannelSupported), bool(saml.Config.ValidateSignature), bool(saml.Config.HideOnLoginPage), saml.Config.NameIDPolicyFormat, saml.Config.SingleLogoutServiceUrl, saml.Config.SigningCertificate, saml.Config.SignatureAlgorithm, saml.Config.XmlSignKeyInfoKeyNameTransformer, bool(saml.Config.PostBindingAuthnRequest), bool(saml.Config.PostBindingResponse), bool(saml.Config.PostBindingLogout), bool(saml.Config.ForceAuthn), bool(saml.Config.WantAssertionsSigned), bool(saml.Config.WantAssertionsEncrypted), saml.Config.GuiOrder, saml.Config.SyncMode)
+	`, testAccRealm.Realm, saml.Alias, saml.Enabled, saml.Config.EntityId, saml.Config.SingleSignOnServiceUrl, bool(saml.Config.BackchannelSupported), bool(saml.Config.ValidateSignature), bool(saml.Config.HideOnLoginPage), saml.Config.NameIDPolicyFormat, saml.Config.SingleLogoutServiceUrl, saml.Config.SigningCertificate, saml.Config.SignatureAlgorithm, saml.Config.XmlSignKeyInfoKeyNameTransformer, bool(saml.Config.PostBindingAuthnRequest), bool(saml.Config.PostBindingResponse), bool(saml.Config.PostBindingLogout), bool(saml.Config.ForceAuthn), bool(saml.Config.WantAssertionsSigned), bool(saml.Config.WantAssertionsEncrypted), saml.Config.GuiOrder, saml.Config.SyncMode)
 }

--- a/provider/resource_keycloak_saml_identity_provider_test.go
+++ b/provider/resource_keycloak_saml_identity_provider_test.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -22,6 +24,43 @@ func TestAccKeycloakSamlIdentityProvider_basic(t *testing.T) {
 			{
 				Config: testKeycloakSamlIdentityProvider_basic(realmName, samlName),
 				Check:  testAccCheckKeycloakSamlIdentityProviderExists("keycloak_saml_identity_provider.saml"),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakSamlIdentityProvider_extraConfig(t *testing.T) {
+	samlName := acctest.RandomWithPrefix("tf-acc")
+	customConfigValue := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakSamlIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakSamlIdentityProvider_extra_config(samlName, "dummyConfig", customConfigValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakSamlIdentityProviderHasCustomConfigValue("keycloak_saml_identity_provider.saml", customConfigValue),
+				),
+			},
+		},
+	})
+}
+
+// ensure that extra_config keys which are covered by top-level attributes are not allowed
+func TestAccKeycloakSamlIdentityProvider_extraConfigInvalid(t *testing.T) {
+	samlName := acctest.RandomWithPrefix("tf-acc")
+	customConfigValue := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakSamlIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testKeycloakSamlIdentityProvider_extra_config(samlName, "syncMode", customConfigValue),
+				ExpectError: regexp.MustCompile("extra_config key \"syncMode\" is not allowed"),
 			},
 		},
 	})
@@ -118,6 +157,8 @@ func TestAccKeycloakSamlIdentityProvider_basicUpdateAll(t *testing.T) {
 			ForceAuthn:                       keycloak.KeycloakBoolQuoted(firstForceAuthn),
 			WantAssertionsSigned:             keycloak.KeycloakBoolQuoted(firstAssertionsSigned),
 			WantAssertionsEncrypted:          keycloak.KeycloakBoolQuoted(firstAssertionsEncrypted),
+			GuiOrder:                         strconv.Itoa(acctest.RandIntRange(1, 3)),
+			SyncMode:                         randomStringInSlice(syncModes),
 		},
 	}
 
@@ -142,6 +183,8 @@ func TestAccKeycloakSamlIdentityProvider_basicUpdateAll(t *testing.T) {
 			ForceAuthn:                       keycloak.KeycloakBoolQuoted(!firstForceAuthn),
 			WantAssertionsSigned:             keycloak.KeycloakBoolQuoted(!firstAssertionsSigned),
 			WantAssertionsEncrypted:          keycloak.KeycloakBoolQuoted(!firstAssertionsEncrypted),
+			GuiOrder:                         strconv.Itoa(acctest.RandIntRange(1, 3)),
+			SyncMode:                         randomStringInSlice(syncModes),
 		},
 	}
 
@@ -187,6 +230,21 @@ func testAccCheckKeycloakSamlIdentityProviderFetch(resourceName string, saml *ke
 	}
 }
 
+func testAccCheckKeycloakSamlIdentityProviderHasCustomConfigValue(resourceName, customConfigValue string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		fetchedSaml, err := getKeycloakSamlIdentityProviderFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if fetchedSaml.Config.ExtraConfig["dummyConfig"].(string) != customConfigValue {
+			return fmt.Errorf("expected custom saml provider to have config with a custom key 'dummyConfig' with a value %s, but value was %s", customConfigValue, fetchedSaml.Config.ExtraConfig["dummyConfig"].(string))
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckKeycloakSamlIdentityProviderDestroy() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -226,27 +284,45 @@ func getKeycloakSamlIdentityProviderFromState(s *terraform.State, resourceName s
 
 func testKeycloakSamlIdentityProvider_basic(realm, saml string) string {
 	return fmt.Sprintf(`
-resource "keycloak_realm" "realm" {
+data "keycloak_realm" "realm" {
 	realm = "%s"
 }
 
 resource "keycloak_saml_identity_provider" "saml" {
-	realm             			= "${keycloak_realm.realm.id}"
+	realm             			= data.keycloak_realm.realm.id
 	alias             			= "%s"
 	entity_id					= "https://example.com/entity_id"
-	single_sign_on_service_url = "https://example.com/auth"
+	single_sign_on_service_url  = "https://example.com/auth"
 }
 	`, realm, saml)
 }
 
-func testKeycloakSamlIdentityProvider_basicFromInterface(saml *keycloak.IdentityProvider) string {
+func testKeycloakSamlIdentityProvider_extra_config(alias, configKey, configValue string) string {
 	return fmt.Sprintf(`
-resource "keycloak_realm" "realm" {
+data "keycloak_realm" "realm" {
 	realm = "%s"
 }
 
 resource "keycloak_saml_identity_provider" "saml" {
-	realm             			= "${keycloak_realm.realm.id}"
+	realm             			= data.keycloak_realm.realm.id
+	alias             			= "%s"
+	entity_id					= "https://example.com/entity_id"
+	single_sign_on_service_url  = "https://example.com/auth"
+	extra_config                = {
+		%s = "%s"
+	}
+}
+	`, testAccRealm.Realm, alias, configKey, configValue)
+}
+
+func testKeycloakSamlIdentityProvider_basicFromInterface(saml *keycloak.IdentityProvider) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_saml_identity_provider" "saml" {
+	realm             			= data.keycloak_realm.realm.id
 	alias             			= "%s"
 	enabled           			= %t
 	entity_id					= "%s"
@@ -265,6 +341,8 @@ resource "keycloak_saml_identity_provider" "saml" {
 	force_authn                = %t
 	want_assertions_signed     = %t
 	want_assertions_encrypted  = %t
+	gui_order                  = %s
+	sync_mode                  = "%s"
 }
-	`, saml.Realm, saml.Alias, saml.Enabled, saml.Config.EntityId, saml.Config.SingleSignOnServiceUrl, bool(saml.Config.BackchannelSupported), bool(saml.Config.ValidateSignature), bool(saml.Config.HideOnLoginPage), saml.Config.NameIDPolicyFormat, saml.Config.SingleLogoutServiceUrl, saml.Config.SigningCertificate, saml.Config.SignatureAlgorithm, saml.Config.XmlSignKeyInfoKeyNameTransformer, bool(saml.Config.PostBindingAuthnRequest), bool(saml.Config.PostBindingResponse), bool(saml.Config.PostBindingLogout), bool(saml.Config.ForceAuthn), bool(saml.Config.WantAssertionsSigned), bool(saml.Config.WantAssertionsEncrypted))
+	`, saml.Realm, saml.Alias, saml.Enabled, saml.Config.EntityId, saml.Config.SingleSignOnServiceUrl, bool(saml.Config.BackchannelSupported), bool(saml.Config.ValidateSignature), bool(saml.Config.HideOnLoginPage), saml.Config.NameIDPolicyFormat, saml.Config.SingleLogoutServiceUrl, saml.Config.SigningCertificate, saml.Config.SignatureAlgorithm, saml.Config.XmlSignKeyInfoKeyNameTransformer, bool(saml.Config.PostBindingAuthnRequest), bool(saml.Config.PostBindingResponse), bool(saml.Config.PostBindingLogout), bool(saml.Config.ForceAuthn), bool(saml.Config.WantAssertionsSigned), bool(saml.Config.WantAssertionsEncrypted), saml.Config.GuiOrder, saml.Config.SyncMode)
 }


### PR DESCRIPTION
- `gui_order` and `sync_mode` are now supported by all identity providers as top-level attributes
- `extra_config` attribute now fails validation if a key is used that conflicts with the existing identity provider config JSON model 

This doesn't really "fix" the root problem, but the extra validation here will prevent potentially bad configuration for an identity provider from reaching a Keycloak instance.

Fixes #520 

cc @tomrutsaert @alex-hempel