### PR TITLE
Add import attribute for keycloak_openid_client

### DIFF
--- a/docs/resources/openid_client.md
+++ b/docs/resources/openid_client.md
@@ -77,6 +77,7 @@ is set to `true`.
     - `decision_strategy` - (Optional) Dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. Could be one of `AFFIRMATIVE`, `CONSENSUS`, or `UNANIMOUS`. Applies to permissions.
     - `allow_remote_resource_management` - (Optional) When `true`, resources can be managed remotely by the resource server. Defaults to `false`.
     - `keep_defaults` - (Optional) When `true`, defaults set by Keycloak will be respected. Defaults to `false`.
+- `import` - (Optional) When `true`, the client with specified `client_id` must exists and it will be imported into terrafrom state instead of being created. This attribute is useful when dealing with clients created during realm creation (like `account`, `account-console`, etc). Note, that the client will not be removed during destruction if `import` is `true`.
 
 ## Attributes Reference
 

--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ test: fmtcheck vet
 	go test $(TEST)
 
 testacc: fmtcheck vet
-	TF_ACC=1 CHECKPOINT_DISABLE=1 go test -v -timeout 30m -parallel 4 $(TEST) $(TESTARGS)
+	TF_ACC=1 CHECKPOINT_DISABLE=1 go test -v -timeout 60m -parallel 4 $(TEST) $(TESTARGS)
 
 fmtcheck:
 	lineCount=$(shell gofmt -l -s $(GOFMT_FILES) | wc -l | tr -d ' ') && exit $$lineCount

--- a/provider/resource_keycloak_openid_client_test.go
+++ b/provider/resource_keycloak_openid_client_test.go
@@ -545,6 +545,26 @@ func TestAccKeycloakOpenidClient_loginTheme(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakOpenidClient_import(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOpenidClientNotDestroyed(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testKeycloakOpenidClient_import("non-existing-client", true),
+				ExpectError: regexp.MustCompile("Error: openid client with name non-existing-client does not exist"),
+			},
+			{
+				Config: testKeycloakOpenidClient_import("account", false),
+				Check:  testAccCheckKeycloakOpenidClientExistsWithEnabledStatus("keycloak_openid_client.client", false),
+			},
+		},
+	})
+}
+
 func testAccCheckKeycloakOpenidClientExistsWithCorrectProtocol(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client, err := getOpenidClientFromState(s, resourceName)
@@ -732,6 +752,26 @@ func testAccCheckKeycloakOpenidClientDestroy() resource.TestCheckFunc {
 	}
 }
 
+func testAccCheckKeycloakOpenidClientNotDestroyed() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "keycloak_openid_client" {
+				continue
+			}
+
+			id := rs.Primary.ID
+			realm := rs.Primary.Attributes["realm_id"]
+
+			client, _ := keycloakClient.GetOpenidClient(realm, id)
+			if client == nil {
+				return fmt.Errorf("openid client %s dost not exists", id)
+			}
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckKeycloakOpenidClientHasPkceCodeChallengeMethod(resourceName, pkceCodeChallengeMethod string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client, err := getOpenidClientFromState(s, resourceName)
@@ -821,6 +861,21 @@ func testAccCheckKeycloakOpenidClientLoginTheme(resourceName string, loginTheme 
 
 		if client.Attributes.LoginTheme != loginTheme {
 			return fmt.Errorf("expected openid client to have login theme set to %s, but got %s", loginTheme, client.Attributes.LoginTheme)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckKeycloakOpenidClientExistsWithEnabledStatus(resourceName string, enabled bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := getOpenidClientFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if client.Enabled != enabled {
+			return fmt.Errorf("expected openid client to have enabled status %t, but got %t", enabled, client.Enabled)
 		}
 
 		return nil
@@ -1209,4 +1264,21 @@ resource "keycloak_openid_client" "client" {
 	login_theme = "%s"
 }
 	`, testAccRealm.Realm, clientId, loginTheme)
+}
+
+func testKeycloakOpenidClient_import(clientId string, enabled bool) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "client" {
+	client_id   = "%s"
+	realm_id    = data.keycloak_realm.realm.id
+	access_type = "PUBLIC"
+	root_url    = ""
+	enabled     = %t
+	import      = true
+}
+	`, testAccRealm.Realm, clientId, enabled)
 }


### PR DESCRIPTION
Keycloak creates few openid clients by default (like account, account-console) and the only way to manage those clients with terraform is by manual import. This PR adds `import` attribute to `keycloak_openid_client` resources, which controls whether or not the client should be created or "imported". Note, that if `import` attribute is true, the resource will not be removed during destruction.

With this change, for example, one can disable the `account` client with a configuration like this:

```hcl
resource "keycloak_realm" "realm" {
  realm = "test-realm"
}

resource "keycloak_openid_client" "account" {
  realm_id    = keycloak_realm.realm.id
  client_id   = "account"
  access_type = "PUBLIC"
  enabled     = false
  import      = true
}
```

Acceptance tests:

```
=== RUN   TestAccKeycloakOpenidClient_import
=== PAUSE TestAccKeycloakOpenidClient_import
=== CONT  TestAccKeycloakOpenidClient_import
--- PASS: TestAccKeycloakOpenidClient_import (19.38s)
```