### PR TITLE
feat: add oauth2 device authorization grant

### DIFF
--- a/docs-old/resources/keycloak_realm.md
+++ b/docs-old/resources/keycloak_realm.md
@@ -124,6 +124,11 @@ The attributes below should be specified as [Go duration strings](https://golang
 - `access_code_lifespan_user_action` - (Optional) The maximum amount of time a user has to complete login related actions, such as updating a password.
 - `action_token_generated_by_user_lifespan` - (Optional) The maximum time a user has to use a user-generated permit before it expires.
 - `action_token_generated_by_admin_lifespan` - (Optional) The maximum time a user has to use an admin-generated permit before it expires.
+- `oauth2_device_code_lifespan` - (Optional) The maximum amount of time a client has to finish the device code flow before it expires.
+
+The attributes below should be specified in seconds.
+
+- `oauth2_device_polling_interval` - (Optional) The minimum amount of time in seconds that the client should wait between polling requests to the token endpoint.
 
 ##### SMTP
 

--- a/docs/resources/openid_client.md
+++ b/docs/resources/openid_client.md
@@ -78,6 +78,9 @@ is set to `true`.
 - `login_theme` - (Optional) The client login theme. This will override the default theme for the realm.
 - `exclude_session_state_from_auth_response` - (Optional) When `true`, the parameter `session_state` will not be included in OpenID Connect Authentication Response.
 - `use_refresh_tokens` - (Optional) If this is `true`, a refresh_token will be created and added to the token response. If this is `false` then no refresh_token will be generated.  Defaults to `true`.
+- `oauth2_device_authorization_grant_enabled` - (Optional) Enables support for OAuth 2.0 Device Authorization Grant, which means that client is an application on device that has limited input capabilities or lack a suitable browser.
+- `oauth2_device_code_lifespan` - (Optional) The maximum amount of time a client has to finish the device code flow before it expires.
+- `oauth2_device_polling_interval` - (Optional) The minimum amount of time in seconds that the client should wait between polling requests to the token endpoint.
 - `authorization` - (Optional) When this block is present, fine-grained authorization will be enabled for this client. The client's `access_type` must be `CONFIDENTIAL`, and `service_accounts_enabled` must be `true`. This block has the following arguments:
     - `policy_enforcement_mode` - (Required) Dictates how policies are enforced when evaluating authorization requests. Can be one of `ENFORCING`, `PERMISSIVE`, or `DISABLED`.
     - `decision_strategy` - (Optional) Dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. Could be one of `AFFIRMATIVE`, `CONSENSUS`, or `UNANIMOUS`. Applies to permissions.

--- a/docs/resources/realm.md
+++ b/docs/resources/realm.md
@@ -132,6 +132,11 @@ The arguments below should be specified as [Go duration strings](https://golang.
 - `access_code_lifespan_user_action` - (Optional) The maximum amount of time a user has to complete login related actions, such as updating a password.
 - `action_token_generated_by_user_lifespan` - (Optional) The maximum time a user has to use a user-generated permit before it expires.
 - `action_token_generated_by_admin_lifespan` - (Optional) The maximum time a user has to use an admin-generated permit before it expires.
+- `oauth2_device_code_lifespan` - (Optional) The maximum amount of time a client has to finish the device code flow before it expires.
+
+The attributes below should be specified in seconds.
+
+- `oauth2_device_polling_interval` - (Optional) The minimum amount of time in seconds that the client should wait between polling requests to the token endpoint.
 
 ### SMTP
 

--- a/keycloak/openid_client.go
+++ b/keycloak/openid_client.go
@@ -56,19 +56,22 @@ type OpenidClient struct {
 }
 
 type OpenidClientAttributes struct {
-	PkceCodeChallengeMethod              string                 `json:"pkce.code.challenge.method"`
-	ExcludeSessionStateFromAuthResponse  KeycloakBoolQuoted     `json:"exclude.session.state.from.auth.response"`
-	AccessTokenLifespan                  string                 `json:"access.token.lifespan"`
-	LoginTheme                           string                 `json:"login_theme"`
-	ClientOfflineSessionIdleTimeout      string                 `json:"client.offline.session.idle.timeout,omitempty"`
-	ClientOfflineSessionMaxLifespan      string                 `json:"client.offline.session.max.lifespan,omitempty"`
-	ClientSessionIdleTimeout             string                 `json:"client.session.idle.timeout,omitempty"`
-	ClientSessionMaxLifespan             string                 `json:"client.session.max.lifespan,omitempty"`
-	UseRefreshTokens                     KeycloakBoolQuoted     `json:"use.refresh.tokens"`
-	BackchannelLogoutUrl                 string                 `json:"backchannel.logout.url"`
-	BackchannelLogoutRevokeOfflineTokens KeycloakBoolQuoted     `json:"backchannel.logout.revoke.offline.tokens"`
-	BackchannelLogoutSessionRequired     KeycloakBoolQuoted     `json:"backchannel.logout.session.required"`
-	ExtraConfig                          map[string]interface{} `json:"-"`
+	PkceCodeChallengeMethod               string                 `json:"pkce.code.challenge.method"`
+	ExcludeSessionStateFromAuthResponse   KeycloakBoolQuoted     `json:"exclude.session.state.from.auth.response"`
+	AccessTokenLifespan                   string                 `json:"access.token.lifespan"`
+	LoginTheme                            string                 `json:"login_theme"`
+	ClientOfflineSessionIdleTimeout       string                 `json:"client.offline.session.idle.timeout,omitempty"`
+	ClientOfflineSessionMaxLifespan       string                 `json:"client.offline.session.max.lifespan,omitempty"`
+	ClientSessionIdleTimeout              string                 `json:"client.session.idle.timeout,omitempty"`
+	ClientSessionMaxLifespan              string                 `json:"client.session.max.lifespan,omitempty"`
+	UseRefreshTokens                      KeycloakBoolQuoted     `json:"use.refresh.tokens"`
+	BackchannelLogoutUrl                  string                 `json:"backchannel.logout.url"`
+	BackchannelLogoutRevokeOfflineTokens  KeycloakBoolQuoted     `json:"backchannel.logout.revoke.offline.tokens"`
+	BackchannelLogoutSessionRequired      KeycloakBoolQuoted     `json:"backchannel.logout.session.required"`
+	ExtraConfig                           map[string]interface{} `json:"-"`
+	Oauth2DeviceAuthorizationGrantEnabled KeycloakBoolQuoted     `json:"oauth2.device.authorization.grant.enabled"`
+	Oauth2DeviceCodeLifespan              string                 `json:"oauth2.device.code.lifespan,omitempty"`
+	Oauth2DevicePollingInterval           string                 `json:"oauth2.device.polling.interval,omitempty"`
 }
 
 type OpenidAuthenticationFlowBindingOverrides struct {

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -66,6 +66,8 @@ type Realm struct {
 	AccessCodeLifespanUserAction        int    `json:"accessCodeLifespanUserAction,omitempty"`
 	ActionTokenGeneratedByUserLifespan  int    `json:"actionTokenGeneratedByUserLifespan,omitempty"`
 	ActionTokenGeneratedByAdminLifespan int    `json:"actionTokenGeneratedByAdminLifespan,omitempty"`
+	Oauth2DeviceCodeLifespan            int    `json:"oauth2DeviceCodeLifespan,omitempty"`
+	Oauth2DevicePollingInterval         int    `json:"oauth2DevicePollingInterval,omitempty"`
 
 	//internationalization
 	InternationalizationEnabled bool     `json:"internationalizationEnabled"`

--- a/provider/data_source_keycloak_openid_client.go
+++ b/provider/data_source_keycloak_openid_client.go
@@ -188,6 +188,19 @@ func dataSourceKeycloakOpenidClient() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"oauth2_device_authorization_grant_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"oauth2_device_code_lifespan": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"oauth2_device_polling_interval": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }

--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -309,6 +309,14 @@ func dataSourceKeycloakRealm() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"oauth2_device_code_lifespan": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"oauth2_device_polling_interval": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 
 			//internationalization
 			"internationalization": {

--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -230,6 +230,19 @@ func resourceKeycloakOpenidClient() *schema.Resource {
 				Optional:         true,
 				ValidateDiagFunc: validateExtraConfig(reflect.ValueOf(&keycloak.OpenidClientAttributes{}).Elem()),
 			},
+			"oauth2_device_authorization_grant_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"oauth2_device_code_lifespan": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"oauth2_device_polling_interval": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 		CustomizeDiff: customdiff.ComputedIf("service_account_user_id", func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 			return d.HasChange("service_accounts_enabled")
@@ -286,19 +299,22 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 		ServiceAccountsEnabled:    data.Get("service_accounts_enabled").(bool),
 		FullScopeAllowed:          data.Get("full_scope_allowed").(bool),
 		Attributes: keycloak.OpenidClientAttributes{
-			PkceCodeChallengeMethod:              data.Get("pkce_code_challenge_method").(string),
-			ExcludeSessionStateFromAuthResponse:  keycloak.KeycloakBoolQuoted(data.Get("exclude_session_state_from_auth_response").(bool)),
-			AccessTokenLifespan:                  data.Get("access_token_lifespan").(string),
-			LoginTheme:                           data.Get("login_theme").(string),
-			ClientOfflineSessionIdleTimeout:      data.Get("client_offline_session_idle_timeout").(string),
-			ClientOfflineSessionMaxLifespan:      data.Get("client_offline_session_max_lifespan").(string),
-			ClientSessionIdleTimeout:             data.Get("client_session_idle_timeout").(string),
-			ClientSessionMaxLifespan:             data.Get("client_session_max_lifespan").(string),
-			UseRefreshTokens:                     keycloak.KeycloakBoolQuoted(data.Get("use_refresh_tokens").(bool)),
-			BackchannelLogoutUrl:                 data.Get("backchannel_logout_url").(string),
-			BackchannelLogoutRevokeOfflineTokens: keycloak.KeycloakBoolQuoted(data.Get("backchannel_logout_revoke_offline_sessions").(bool)),
-			BackchannelLogoutSessionRequired:     keycloak.KeycloakBoolQuoted(data.Get("backchannel_logout_session_required").(bool)),
-			ExtraConfig:                          getExtraConfigFromData(data),
+			PkceCodeChallengeMethod:               data.Get("pkce_code_challenge_method").(string),
+			ExcludeSessionStateFromAuthResponse:   keycloak.KeycloakBoolQuoted(data.Get("exclude_session_state_from_auth_response").(bool)),
+			AccessTokenLifespan:                   data.Get("access_token_lifespan").(string),
+			LoginTheme:                            data.Get("login_theme").(string),
+			ClientOfflineSessionIdleTimeout:       data.Get("client_offline_session_idle_timeout").(string),
+			ClientOfflineSessionMaxLifespan:       data.Get("client_offline_session_max_lifespan").(string),
+			ClientSessionIdleTimeout:              data.Get("client_session_idle_timeout").(string),
+			ClientSessionMaxLifespan:              data.Get("client_session_max_lifespan").(string),
+			UseRefreshTokens:                      keycloak.KeycloakBoolQuoted(data.Get("use_refresh_tokens").(bool)),
+			BackchannelLogoutUrl:                  data.Get("backchannel_logout_url").(string),
+			BackchannelLogoutRevokeOfflineTokens:  keycloak.KeycloakBoolQuoted(data.Get("backchannel_logout_revoke_offline_sessions").(bool)),
+			BackchannelLogoutSessionRequired:      keycloak.KeycloakBoolQuoted(data.Get("backchannel_logout_session_required").(bool)),
+			ExtraConfig:                           getExtraConfigFromData(data),
+			Oauth2DeviceAuthorizationGrantEnabled: keycloak.KeycloakBoolQuoted(data.Get("oauth2_device_authorization_grant_enabled").(bool)),
+			Oauth2DeviceCodeLifespan:              data.Get("oauth2_device_code_lifespan").(string),
+			Oauth2DevicePollingInterval:           data.Get("oauth2_device_polling_interval").(string),
 		},
 		ValidRedirectUris: validRedirectUris,
 		WebOrigins:        webOrigins,
@@ -387,6 +403,9 @@ func setOpenidClientData(keycloakClient *keycloak.KeycloakClient, data *schema.R
 	data.Set("access_token_lifespan", client.Attributes.AccessTokenLifespan)
 	data.Set("login_theme", client.Attributes.LoginTheme)
 	data.Set("use_refresh_tokens", client.Attributes.UseRefreshTokens)
+	data.Set("oauth2_device_authorization_grant_enabled", client.Attributes.Oauth2DeviceAuthorizationGrantEnabled)
+	data.Set("oauth2_device_code_lifespan", client.Attributes.Oauth2DeviceCodeLifespan)
+	data.Set("oauth2_device_polling_interval", client.Attributes.Oauth2DevicePollingInterval)
 	data.Set("client_offline_session_idle_timeout", client.Attributes.ClientOfflineSessionIdleTimeout)
 	data.Set("client_offline_session_max_lifespan", client.Attributes.ClientOfflineSessionMaxLifespan)
 	data.Set("client_session_idle_timeout", client.Attributes.ClientSessionIdleTimeout)

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -407,6 +407,17 @@ func resourceKeycloakRealm() *schema.Resource {
 				Computed:         true,
 				DiffSuppressFunc: suppressDurationStringDiff,
 			},
+			"oauth2_device_code_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: suppressDurationStringDiff,
+			},
+			"oauth2_device_polling_interval": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 
 			// internationalization
 			"internationalization": {
@@ -862,6 +873,18 @@ func getRealmFromData(data *schema.ResourceData) (*keycloak.Realm, error) {
 		realm.ActionTokenGeneratedByAdminLifespan = actionTokenGeneratedByAdminLifespanDurationString
 	}
 
+	if oauth2DeviceCodeLifespan := data.Get("oauth2_device_code_lifespan").(string); oauth2DeviceCodeLifespan != "" {
+		oauth2DeviceCodeLifespanDurationString, err := getSecondsFromDurationString(oauth2DeviceCodeLifespan)
+		if err != nil {
+			return nil, err
+		}
+		realm.Oauth2DeviceCodeLifespan = oauth2DeviceCodeLifespanDurationString
+	}
+
+	if oauth2DevicePollingInterval, ok := data.GetOk("oauth2_device_polling_interval"); ok {
+		realm.Oauth2DevicePollingInterval = oauth2DevicePollingInterval.(int)
+	}
+
 	//security defenses
 	if v, ok := data.GetOk("security_defenses"); ok {
 		securityDefensesSettings := v.([]interface{})[0].(map[string]interface{})
@@ -1166,6 +1189,8 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm) {
 	data.Set("access_code_lifespan_user_action", getDurationStringFromSeconds(realm.AccessCodeLifespanUserAction))
 	data.Set("action_token_generated_by_user_lifespan", getDurationStringFromSeconds(realm.ActionTokenGeneratedByUserLifespan))
 	data.Set("action_token_generated_by_admin_lifespan", getDurationStringFromSeconds(realm.ActionTokenGeneratedByAdminLifespan))
+	data.Set("oauth2_device_code_lifespan", getDurationStringFromSeconds(realm.Oauth2DeviceCodeLifespan))
+	data.Set("oauth2_device_polling_interval", realm.Oauth2DevicePollingInterval)
 
 	//internationalization
 	if realm.InternationalizationEnabled {

--- a/scripts/create-terraform-client.sh
+++ b/scripts/create-terraform-client.sh
@@ -91,7 +91,8 @@ masterRealmExtendAccessToken=$(jq -n "{
     accessCodeLifespanUserAction: 86400,
     accessCodeLifespanLogin: 86400,
     actionTokenGeneratedByAdminLifespan: 86400,
-    actionTokenGeneratedByUserLifespan: 86400
+    actionTokenGeneratedByUserLifespan: 86400,
+    oauth2DeviceCodeLifespan: 86400
 }")
 
 put "/realms/master" "${masterRealmExtendAccessToken}"


### PR DESCRIPTION
Suppport for the relatively recent OAuth2 Device Authorization Grant. The corresponding settings are present in a realm and a client.

In Keycloak the settings can be found as following:

Realm (Tokens tab):
- OAuth 2.0 Device Code Lifespan
- OAuth 2.0 Device Polling Interval 

Client (Settings tab):
- OAuth 2.0 Device Authorization Grant Enabled 
- OAuth 2.0 Device Code Lifespan
- OAuth 2.0 Device Polling Interval 

Please note the [OAuth2 Device Authorization Grant](https://www.keycloak.org/docs/latest/release_notes/#oauth-2-0-device-authorization-grant-rfc-8628) was firstly introduced in Keycloak 13. This is also the reason why the tests with Keycloak 11 and 12 fail.