### PR TITLE
add extra_config for openid clients to handle custom attributes (#387)

### DIFF
--- a/docs/resources/openid_client.md
+++ b/docs/resources/openid_client.md
@@ -31,6 +31,11 @@ resource "keycloak_openid_client" "openid_client" {
   ]
 
   login_theme = "keycloak"
+      
+  extra_config = {
+		"key1" = "value1"
+		"key2" = "value2"
+    }
 }
 ```
 
@@ -81,6 +86,7 @@ is set to `true`.
 - `backchannel_logout_url` - (Optional) The URL that will cause the client to log itself out when a logout request is sent to this realm. If omitted, no logout request will be sent to the client is this case.
 - `backchannel_logout_session_required` - (Optional) When `true`, a sid (session ID) claim will be included in the logout token when the backchannel logout URL is used. Defaults to `true`.
 - `backchannel_logout_revoke_offline_sessions` - (Optional) Specifying whether a "revoke_offline_access" event is included in the Logout Token when the Backchannel Logout URL is used. Keycloak will revoke offline sessions when receiving a Logout Token with this event.
+- `extra_config` - (Optional) A map of key/value pairs to add extra configuration attributes to this client. This can be used for custom attributes, or to add configuration attributes that is not yet supported by this Terraform provider. Use this attribute at your own risk, as s may conflict with top-level configuration attributes in future provider updates.
 
 ## Attributes Reference
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -214,6 +214,10 @@ resource "keycloak_openid_client" "test_client" {
   backchannel_logout_url                     = "http://localhost:3333/backchannel"
   backchannel_logout_session_required        = true
   backchannel_logout_revoke_offline_sessions = true
+
+  extra_config = {
+    customAttribute = "a test custom value"    
+  }
 }
 
 resource "keycloak_openid_client_scope" "test_default_client_scope" {

--- a/provider/data_source_keycloak_openid_client.go
+++ b/provider/data_source_keycloak_openid_client.go
@@ -183,6 +183,11 @@ func dataSourceKeycloakOpenidClient() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"extra_config": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -224,6 +227,37 @@ func resourceKeycloakOpenidClient() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"extra_config": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				// you aren't allowed to specify any keys in extra_config that could be defined as top level attributes
+				ValidateDiagFunc: func(v interface{}, path cty.Path) diag.Diagnostics {
+					var diags diag.Diagnostics
+
+					extraConfig := v.(map[string]interface{})
+					value := reflect.ValueOf(&keycloak.OpenidClientAttributes{}).Elem()
+
+					for i := 0; i < value.NumField(); i++ {
+						field := value.Field(i)
+						jsonKey := strings.Split(value.Type().Field(i).Tag.Get("json"), ",")[0]
+
+						if jsonKey != "-" && field.CanSet() {
+							if _, ok := extraConfig[jsonKey]; ok {
+								diags = append(diags, diag.Diagnostic{
+									Severity: diag.Error,
+									Summary:  "Invalid extra_config key",
+									Detail:   fmt.Sprintf(`extra_config key "%s" is not allowed, as it conflicts with a top-level schema attribute`, jsonKey),
+									AttributePath: append(path, cty.IndexStep{
+										Key: cty.StringVal(jsonKey),
+									}),
+								})
+							}
+						}
+					}
+
+					return diags
+				},
+			},
 		},
 		CustomizeDiff: customdiff.ComputedIf("service_account_user_id", func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 			return d.HasChange("service_accounts_enabled")
@@ -266,6 +300,13 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 		}
 	}
 
+	extraConfig := map[string]interface{}{}
+	if v, ok := data.GetOk("extra_config"); ok {
+		for key, value := range v.(map[string]interface{}) {
+			extraConfig[key] = value
+		}
+	}
+
 	openidClient := &keycloak.OpenidClient{
 		Id:                        data.Id(),
 		ClientId:                  data.Get("client_id").(string),
@@ -292,6 +333,7 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 			BackchannelLogoutUrl:                 data.Get("backchannel_logout_url").(string),
 			BackchannelLogoutRevokeOfflineTokens: keycloak.KeycloakBoolQuoted(data.Get("backchannel_logout_session_required").(bool)),
 			BackchannelLogoutSessionRequired:     keycloak.KeycloakBoolQuoted(data.Get("backchannel_logout_revoke_offline_sessions").(bool)),
+			ExtraConfig:                          extraConfig,
 		},
 		ValidRedirectUris: validRedirectUris,
 		WebOrigins:        webOrigins,
@@ -387,6 +429,7 @@ func setOpenidClientData(keycloakClient *keycloak.KeycloakClient, data *schema.R
 	data.Set("backchannel_logout_url", client.Attributes.BackchannelLogoutUrl)
 	data.Set("backchannel_logout_session_required", client.Attributes.BackchannelLogoutRevokeOfflineTokens)
 	data.Set("backchannel_logout_revoke_offline_sessions", client.Attributes.BackchannelLogoutSessionRequired)
+	data.Set("extra_config", client.Attributes.ExtraConfig)
 
 	if client.AuthorizationServicesEnabled {
 		data.Set("resource_server_id", client.Id)


### PR DESCRIPTION
Hello @mrparkers ,

As the PR #389 seems blocked since several months and because I need to manage custom attributes on openid clients, I tried to make a new PR. This new PR handles only a new `extra_config` field on `keycloak_openid_client`.

However I have a question : as Keycloak recently added 2 new attributes with default values (`backchannel.logout.revoke.offline.tokens=false` and `backchannel.logout.session.required=true`, as described in #568), how should we handle these attributes ? I modified all the tests to add these new attributes in data, is this correct waiting for an official support for these fields ?
The advantage on this solution is that it allows to set all new attributes added by Keycloak before an official support in the provider.
The drawback is it become mandatory to set this extra_config when using KC >= 12.x with a provider which do not support this fields natively.
```
extra_config = {
  "backchannel.logout.revoke.offline.tokens" = "false"
  "backchannel.logout.session.required"      = "true"
}
```