### PR TITLE
feat: Adding support for login theme on saml_client resource

### DIFF
--- a/docs/resources/saml_client.md
+++ b/docs/resources/saml_client.md
@@ -38,6 +38,7 @@ resource "keycloak_saml_client" "saml_client" {
 - `name` - (Optional) The display name of this client in the GUI.
 - `enabled` - (Optional) When false, this client will not be able to initiate a login or obtain access tokens. Defaults to `true`.
 - `description` - (Optional) The description of this client in the GUI.
+- `login_theme` - (Optional) The login theme of this client.
 - `include_authn_statement` - (Optional) When `true`, an `AuthnStatement` will be included in the SAML response.
 - `sign_documents` - (Optional) When `true`, the SAML document will be signed by Keycloak using the realm's private key.
 - `sign_assertions` - (Optional) When `true`, the SAML assertions will be signed by Keycloak using the realm's private key, and embedded within the SAML XML Auth response.

--- a/keycloak/saml_client.go
+++ b/keycloak/saml_client.go
@@ -25,6 +25,7 @@ type SamlClientAttributes struct {
 	AssertionConsumerRedirectURL    string  `json:"saml_assertion_consumer_url_redirect"`
 	LogoutServicePostBindingURL     string  `json:"saml_single_logout_service_url_post"`
 	LogoutServiceRedirectBindingURL string  `json:"saml_single_logout_service_url_redirect"`
+	LoginTheme                      string  `json:"login_theme"`
 }
 
 type SamlAuthenticationFlowBindingOverrides struct {

--- a/provider/data_source_keycloak_saml_client.go
+++ b/provider/data_source_keycloak_saml_client.go
@@ -148,6 +148,10 @@ func dataSourceKeycloakSamlClient() *schema.Resource {
 					},
 				},
 			},
+			"login_theme": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/provider/data_source_keycloak_saml_client_test.go
+++ b/provider/data_source_keycloak_saml_client_test.go
@@ -50,6 +50,7 @@ func TestAccKeycloakDataSourceSamlClient_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "logout_service_post_binding_url", resourceName, "logout_service_post_binding_url"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "logout_service_redirect_binding_url", resourceName, "logout_service_redirect_binding_url"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "full_scope_allowed", resourceName, "full_scope_allowed"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "login_theme", resourceName, "login_theme"),
 				),
 			},
 		},

--- a/provider/resource_keycloak_saml_client.go
+++ b/provider/resource_keycloak_saml_client.go
@@ -238,6 +238,7 @@ func mapToSamlClientFromData(data *schema.ResourceData) *keycloak.SamlClient {
 		AssertionConsumerRedirectURL:    data.Get("assertion_consumer_redirect_url").(string),
 		LogoutServicePostBindingURL:     data.Get("logout_service_post_binding_url").(string),
 		LogoutServiceRedirectBindingURL: data.Get("logout_service_redirect_binding_url").(string),
+		LoginTheme: data.Get("login_theme").(string),
 	}
 
 	if encryptionCertificate, ok := data.GetOkExists("encryption_certificate"); ok {
@@ -424,6 +425,7 @@ func mapToDataFromSamlClient(data *schema.ResourceData, client *keycloak.SamlCli
 	data.Set("logout_service_post_binding_url", client.Attributes.LogoutServicePostBindingURL)
 	data.Set("logout_service_redirect_binding_url", client.Attributes.LogoutServiceRedirectBindingURL)
 	data.Set("full_scope_allowed", client.FullScopeAllowed)
+	data.Set("login_theme", client.Attributes.LoginTheme)
 
 	return nil
 }

--- a/provider/resource_keycloak_saml_client.go
+++ b/provider/resource_keycloak_saml_client.go
@@ -238,7 +238,7 @@ func mapToSamlClientFromData(data *schema.ResourceData) *keycloak.SamlClient {
 		AssertionConsumerRedirectURL:    data.Get("assertion_consumer_redirect_url").(string),
 		LogoutServicePostBindingURL:     data.Get("logout_service_post_binding_url").(string),
 		LogoutServiceRedirectBindingURL: data.Get("logout_service_redirect_binding_url").(string),
-		LoginTheme: data.Get("login_theme").(string),
+		LoginTheme:                      data.Get("login_theme").(string),
 	}
 
 	if encryptionCertificate, ok := data.GetOkExists("encryption_certificate"); ok {

--- a/provider/resource_keycloak_saml_client.go
+++ b/provider/resource_keycloak_saml_client.go
@@ -120,6 +120,10 @@ func resourceKeycloakSamlClient() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"login_theme": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"master_saml_processing_url": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/provider/resource_keycloak_saml_client_test.go
+++ b/provider/resource_keycloak_saml_client_test.go
@@ -173,6 +173,7 @@ func TestAccKeycloakSamlClient_updateInPlace(t *testing.T) {
 			AssertionConsumerRedirectURL:    acctest.RandString(20),
 			LogoutServicePostBindingURL:     acctest.RandString(20),
 			LogoutServiceRedirectBindingURL: acctest.RandString(20),
+			LoginTheme:                      "keycloak",
 		},
 	}
 
@@ -213,6 +214,7 @@ func TestAccKeycloakSamlClient_updateInPlace(t *testing.T) {
 			AssertionConsumerRedirectURL:    acctest.RandString(20),
 			LogoutServicePostBindingURL:     acctest.RandString(20),
 			LogoutServiceRedirectBindingURL: acctest.RandString(20),
+			LoginTheme:                      "keycloak",
 		},
 	}
 


### PR DESCRIPTION
I've been using the provider for a little while and noticed the SAML Client doesn't support setting the login theme via TF. This should enable that. If there's anything that needs tweaking let me know.