### PR TITLE
Changing config for identity_provider_mapper

### DIFF
--- a/provider/generic_keycloak_identity_provider_mapper.go
+++ b/provider/generic_keycloak_identity_provider_mapper.go
@@ -36,6 +36,10 @@ func resourceKeycloakIdentityProviderMapper() *schema.Resource {
 				ForceNew:    true,
 				Description: "IDP Alias",
 			},
+			"config": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 			"extra_config": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -51,7 +55,18 @@ func getIdentityProviderMapperFromData(data *schema.ResourceData) (*keycloak.Ide
 		Name:                  data.Get("name").(string),
 		IdentityProviderAlias: data.Get("identity_provider_alias").(string),
 		Config: &keycloak.IdentityProviderMapperConfig{
-			ExtraConfig: getExtraConfigFromData(data),
+			UserAttribute:         data.Get("config.UserAttribute").(string),
+			UserAttributeName:     data.Get("config.UserAttributeName").(string),
+			Claim:                 data.Get("config.Claim").(string),
+			ClaimValue:            data.Get("config.ClaimValue").(string),
+			HardcodedAttribute:    data.Get("config.HardcodedAttribute").(string),
+			Attribute:             data.Get("config.Attribute").(string),
+			AttributeValue:        data.Get("config.AttributeValue").(string),
+			AttributeFriendlyName: data.Get("config.AttributeFriendlyName").(string),
+			Template:              data.Get("config.Template").(string),
+			Role:                  data.Get("config.Role").(string),
+			JsonField:             data.Get("config.JsonField").(string),
+			ExtraConfig:           getExtraConfigFromData(data),
 		},
 	}
 	return rec, nil


### PR DESCRIPTION
I was having the same issue as in the issue below.
Fixes #571 

I don't really know go, but this seems to work for me.  To work with this branch you will need to move all of the config items into the "config" block, and leave the extra config items in the "extra_config" block.

Config items are the ones listed [here](https://github.com/mrparkers/terraform-provider-keycloak/blob/f29d1f3b932de0479354bd19ead640507095dfe6/keycloak/identity_provider_mapper.go#L9)