### PR TITLE
docs: fix broken realm resource references in examples

### DIFF
--- a/docs/data-sources/openid_client_authorization_policy.md
+++ b/docs/data-sources/openid_client_authorization_policy.md
@@ -32,7 +32,7 @@ resource "keycloak_openid_client" "client_with_authz" {
 }
 
 data "keycloak_openid_client_authorization_policy" "default_permission" {
-  realm_id           = keycloak_realm.test.id
+  realm_id           = keycloak_realm.realm.id
   resource_server_id = keycloak_openid_client.client_with_authz.resource_server_id
   name               = "Default Permission"
 }
@@ -40,7 +40,7 @@ data "keycloak_openid_client_authorization_policy" "default_permission" {
 resource "keycloak_openid_client_authorization_resource" "resource" {
   resource_server_id = keycloak_openid_client.client_with_authz.resource_server_id
   name               = "authorization-resource"
-  realm_id           = keycloak_realm.test.id
+  realm_id           = keycloak_realm.realm.id
 
   uris = [
     "/endpoint/*",
@@ -53,7 +53,7 @@ resource "keycloak_openid_client_authorization_resource" "resource" {
 
 resource "keycloak_openid_client_authorization_permission" "permission" {
   resource_server_id = keycloak_openid_client.client_with_authz.resource_server_id
-  realm_id           = keycloak_realm.test.id
+  realm_id           = keycloak_realm.realm.id
   name               = "authorization-permission"
 
   policies = [

--- a/docs/resources/realm_keystore_aes_generated.md
+++ b/docs/resources/realm_keystore_aes_generated.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 
 resource "keycloak_realm_keystore_aes_generated" "keystore_aes_generated" {
 	name      = "my-aes-generated-key"
-	realm_id  = keycloak_realm.my_realm.realm
+	realm_id  = keycloak_realm.realm.realm
 
 	enabled = true
 	active  = true

--- a/docs/resources/realm_keystore_ecdsa_generated.md
+++ b/docs/resources/realm_keystore_ecdsa_generated.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 
 resource "keycloak_realm_keystore_ecdsa_generated" "keystore_ecdsa_generated" {
 	name      = "my-ecdsa-generated-key"
-	realm_id  = keycloak_realm.my_realm.realm
+	realm_id  = keycloak_realm.realm.realm
 
 	enabled = true
 	active  = true

--- a/docs/resources/realm_keystore_hmac_generated.md
+++ b/docs/resources/realm_keystore_hmac_generated.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 
 resource "keycloak_realm_keystore_hmac_generated" "keystore_hmac_generated" {
 	name      = "my-hmac-generated-key"
-	realm_id  = keycloak_realm.my_realm.realm
+	realm_id  = keycloak_realm.realm.realm
 
 	enabled = true
 	active  = true

--- a/docs/resources/realm_keystore_rsa_generated.md
+++ b/docs/resources/realm_keystore_rsa_generated.md
@@ -17,7 +17,7 @@ resource "keycloak_realm" "realm" {
 
 resource "keycloak_realm_keystore_rsa_generated" "keystore_rsa_generated" {
 	name      = "my-rsa-generated-key"
-	realm_id  = keycloak_realm.my_realm.realm
+	realm_id  = keycloak_realm.realm.realm
 
 	enabled = true
 	active  = true

--- a/docs/resources/saml_script_protocol_mapper.md
+++ b/docs/resources/saml_script_protocol_mapper.md
@@ -20,13 +20,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_saml_client" "saml_client" {
-  realm_id  = keycloak_realm.test.id
+  realm_id  = keycloak_realm.realm.id
   client_id = "saml-client"
   name      = "saml-client"
 }
 
 resource "keycloak_saml_script_protocol_mapper" "saml_script_mapper" {
-  realm_id  = keycloak_realm.test.id
+  realm_id  = keycloak_realm.realm.id
   client_id = keycloak_saml_client.saml_client.id
   name      = "script-mapper"
 

--- a/docs/resources/saml_user_attribute_protocol_mapper.md
+++ b/docs/resources/saml_user_attribute_protocol_mapper.md
@@ -21,13 +21,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_saml_client" "saml_client" {
-  realm_id  = keycloak_realm.test.id
+  realm_id  = keycloak_realm.realm.id
   client_id = "saml-client"
   name      = "saml-client"
 }
 
 resource "keycloak_saml_user_attribute_protocol_mapper" "saml_user_attribute_mapper" {
-  realm_id  = keycloak_realm.test.id
+  realm_id  = keycloak_realm.realm.id
   client_id = keycloak_saml_client.saml_client.id
   name      = "displayname-user-attribute-mapper"
 

--- a/docs/resources/saml_user_property_protocol_mapper.md
+++ b/docs/resources/saml_user_property_protocol_mapper.md
@@ -21,13 +21,13 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_saml_client" "saml_client" {
-  realm_id  = keycloak_realm.test.id
+  realm_id  = keycloak_realm.realm.id
   client_id = "saml-client"
   name      = "saml-client"
 }
 
 resource "keycloak_saml_user_property_protocol_mapper" "saml_user_property_mapper" {
-  realm_id  = keycloak_realm.test.id
+  realm_id  = keycloak_realm.realm.id
   client_id = keycloak_saml_client.saml_client.id
   name      = "email-user-property-mapper"
 


### PR DESCRIPTION
Some of the examples have a realm resource called `realm` but the dependent resources reference a different name. This PR should fix all occurrences within `/docs/`.