### PR TITLE
fix: treat empty string as false when parsing quoted bools from keycloak protocol mapper API

### DIFF
--- a/keycloak/openid_audience_protocol_mapper.go
+++ b/keycloak/openid_audience_protocol_mapper.go
@@ -35,12 +35,12 @@ func (mapper *OpenIdAudienceProtocolMapper) convertToGenericProtocolMapper() *pr
 }
 
 func (protocolMapper *protocolMapper) convertToOpenIdAudienceProtocolMapper(realmId, clientId, clientScopeId string) (*OpenIdAudienceProtocolMapper, error) {
-	addToIdToken, err := strconv.ParseBool(protocolMapper.Config[addToIdTokenField])
+	addToIdToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToIdTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToAccessToken, err := strconv.ParseBool(protocolMapper.Config[addToAccessTokenField])
+	addToAccessToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToAccessTokenField])
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/openid_full_name_protocol_mapper.go
+++ b/keycloak/openid_full_name_protocol_mapper.go
@@ -32,17 +32,17 @@ func (mapper *OpenIdFullNameProtocolMapper) convertToGenericProtocolMapper() *pr
 }
 
 func (protocolMapper *protocolMapper) convertToOpenIdFullNameProtocolMapper(realmId, clientId, clientScopeId string) (*OpenIdFullNameProtocolMapper, error) {
-	idTokenClaim, err := strconv.ParseBool(protocolMapper.Config[addToIdTokenField])
+	idTokenClaim, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToIdTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	accessTokenClaim, err := strconv.ParseBool(protocolMapper.Config[addToAccessTokenField])
+	accessTokenClaim, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToAccessTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	userinfoTokenClaim, err := strconv.ParseBool(protocolMapper.Config[addToUserInfoField])
+	userinfoTokenClaim, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToUserInfoField])
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/openid_group_membership_protocol_mapper.go
+++ b/keycloak/openid_group_membership_protocol_mapper.go
@@ -37,22 +37,22 @@ func (mapper *OpenIdGroupMembershipProtocolMapper) convertToGenericProtocolMappe
 }
 
 func (protocolMapper *protocolMapper) convertToOpenIdGroupMembershipProtocolMapper(realmId, clientId, clientScopeId string) (*OpenIdGroupMembershipProtocolMapper, error) {
-	fullPath, err := strconv.ParseBool(protocolMapper.Config[fullPathField])
+	fullPath, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[fullPathField])
 	if err != nil {
 		return nil, err
 	}
 
-	idTokenClaim, err := strconv.ParseBool(protocolMapper.Config[addToIdTokenField])
+	idTokenClaim, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToIdTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	accessTokenClaim, err := strconv.ParseBool(protocolMapper.Config[addToAccessTokenField])
+	accessTokenClaim, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToAccessTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	userinfoTokenClaim, err := strconv.ParseBool(protocolMapper.Config[addToUserInfoField])
+	userinfoTokenClaim, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToUserInfoField])
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/openid_hardcoded_claim_protocol_mapper.go
+++ b/keycloak/openid_hardcoded_claim_protocol_mapper.go
@@ -39,17 +39,17 @@ func (mapper *OpenIdHardcodedClaimProtocolMapper) convertToGenericProtocolMapper
 }
 
 func (protocolMapper *protocolMapper) convertToOpenIdHardcodedClaimProtocolMapper(realmId, clientId, clientScopeId string) (*OpenIdHardcodedClaimProtocolMapper, error) {
-	addToIdToken, err := strconv.ParseBool(protocolMapper.Config[addToIdTokenField])
+	addToIdToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToIdTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToAccessToken, err := strconv.ParseBool(protocolMapper.Config[addToAccessTokenField])
+	addToAccessToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToAccessTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToUserInfo, err := strconv.ParseBool(protocolMapper.Config[addToUserInfoField])
+	addToUserInfo, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToUserInfoField])
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/openid_script_protocol_mapper.go
+++ b/keycloak/openid_script_protocol_mapper.go
@@ -42,17 +42,17 @@ func (mapper *OpenIdScriptProtocolMapper) convertToGenericProtocolMapper() *prot
 }
 
 func (protocolMapper *protocolMapper) convertToOpenIdScriptProtocolMapper(realmId, clientId, clientScopeId string) (*OpenIdScriptProtocolMapper, error) {
-	addToIdToken, err := strconv.ParseBool(protocolMapper.Config[addToIdTokenField])
+	addToIdToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToIdTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToAccessToken, err := strconv.ParseBool(protocolMapper.Config[addToAccessTokenField])
+	addToAccessToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToAccessTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToUserInfo, err := strconv.ParseBool(protocolMapper.Config[addToUserInfoField])
+	addToUserInfo, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToUserInfoField])
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/openid_user_attribute_protocol_mapper.go
+++ b/keycloak/openid_user_attribute_protocol_mapper.go
@@ -44,17 +44,17 @@ func (mapper *OpenIdUserAttributeProtocolMapper) convertToGenericProtocolMapper(
 }
 
 func (protocolMapper *protocolMapper) convertToOpenIdUserAttributeProtocolMapper(realmId, clientId, clientScopeId string) (*OpenIdUserAttributeProtocolMapper, error) {
-	addToIdToken, err := strconv.ParseBool(protocolMapper.Config[addToIdTokenField])
+	addToIdToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToIdTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToAccessToken, err := strconv.ParseBool(protocolMapper.Config[addToAccessTokenField])
+	addToAccessToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToAccessTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToUserInfo, err := strconv.ParseBool(protocolMapper.Config[addToUserInfoField])
+	addToUserInfo, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToUserInfoField])
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/openid_user_client_role_protocol_mapper.go
+++ b/keycloak/openid_user_client_role_protocol_mapper.go
@@ -44,22 +44,22 @@ func (mapper *OpenIdUserClientRoleProtocolMapper) convertToGenericProtocolMapper
 }
 
 func (protocolMapper *protocolMapper) convertToOpenIdUserClientRoleProtocolMapper(realmId, clientId, clientScopeId string) (*OpenIdUserClientRoleProtocolMapper, error) {
-	addToIdToken, err := strconv.ParseBool(protocolMapper.Config[addToIdTokenField])
+	addToIdToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToIdTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToAccessToken, err := strconv.ParseBool(protocolMapper.Config[addToAccessTokenField])
+	addToAccessToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToAccessTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToUserInfo, err := strconv.ParseBool(protocolMapper.Config[addToUserInfoField])
+	addToUserInfo, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToUserInfoField])
 	if err != nil {
 		return nil, err
 	}
 
-	multivalued, err := strconv.ParseBool(protocolMapper.Config[multivaluedField])
+	multivalued, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[multivaluedField])
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/openid_user_property_protocol_mapper.go
+++ b/keycloak/openid_user_property_protocol_mapper.go
@@ -39,17 +39,17 @@ func (mapper *OpenIdUserPropertyProtocolMapper) convertToGenericProtocolMapper()
 }
 
 func (protocolMapper *protocolMapper) convertToOpenIdUserPropertyProtocolMapper(realmId, clientId, clientScopeId string) (*OpenIdUserPropertyProtocolMapper, error) {
-	addToIdToken, err := strconv.ParseBool(protocolMapper.Config[addToIdTokenField])
+	addToIdToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToIdTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToAccessToken, err := strconv.ParseBool(protocolMapper.Config[addToAccessTokenField])
+	addToAccessToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToAccessTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToUserInfo, err := strconv.ParseBool(protocolMapper.Config[addToUserInfoField])
+	addToUserInfo, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToUserInfoField])
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/openid_user_realm_role_protocol_mapper.go
+++ b/keycloak/openid_user_realm_role_protocol_mapper.go
@@ -41,22 +41,22 @@ func (mapper *OpenIdUserRealmRoleProtocolMapper) convertToGenericProtocolMapper(
 }
 
 func (protocolMapper *protocolMapper) convertToOpenIdUserRealmRoleProtocolMapper(realmId, clientId, clientScopeId string) (*OpenIdUserRealmRoleProtocolMapper, error) {
-	addToIdToken, err := strconv.ParseBool(protocolMapper.Config[addToIdTokenField])
+	addToIdToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToIdTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToAccessToken, err := strconv.ParseBool(protocolMapper.Config[addToAccessTokenField])
+	addToAccessToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToAccessTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToUserInfo, err := strconv.ParseBool(protocolMapper.Config[addToUserInfoField])
+	addToUserInfo, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToUserInfoField])
 	if err != nil {
 		return nil, err
 	}
 
-	multivalued, err := strconv.ParseBool(protocolMapper.Config[multivaluedField])
+	multivalued, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[multivaluedField])
 	if err != nil {
 		return nil, err
 	}

--- a/keycloak/openid_user_session_note_protocol_mapper.go
+++ b/keycloak/openid_user_session_note_protocol_mapper.go
@@ -37,12 +37,12 @@ func (mapper *OpenIdUserSessionNoteProtocolMapper) convertToGenericProtocolMappe
 }
 
 func (protocolMapper *protocolMapper) convertToOpenIdUserSessionNoteProtocolMapper(realmId, clientId, clientScopeId string) (*OpenIdUserSessionNoteProtocolMapper, error) {
-	addToIdToken, err := strconv.ParseBool(protocolMapper.Config[addToIdTokenField])
+	addToIdToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToIdTokenField])
 	if err != nil {
 		return nil, err
 	}
 
-	addToAccessToken, err := strconv.ParseBool(protocolMapper.Config[addToAccessTokenField])
+	addToAccessToken, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToAccessTokenField])
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #621 