### PR TITLE
getServerInfo results in HTTP 403

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ like to manage your entire Keycloak instance, or in any other realm if you only 
     1. Set `Direct Access Grants Enabled` to `OFF`
     1. Set `Service Accounts Enabled` to `ON`.
 1. Grant required roles for managing Keycloak via the `Service Account Roles` tab in the client you created in step 1, see [Assigning Roles](#assigning-roles) section below.
+1. Add scope "roles" as DefaultClientScope
 
 ### Password Grant Setup
 


### PR DESCRIPTION
Using the client_credentials grant I have a HTTP 403 when the keycloak client tries to get the SeverInfo.

In order to make the client works, I had to set the scope "roles" to my client settings as a DefaultClientScope.