### PR TITLE
feat: configure consent settings for keycloak_openid_client

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -820,6 +820,41 @@ resource "keycloak_openid_client" "test_client_auth" {
   client_secret = "secret"
 }
 
+resource keycloak_openid_client test_open_id_client_with_consent_text {
+  client_id   = "test_open_id_client_with_consent_text"
+  name        = "test_open_id_client_with_consent_text"
+  realm_id    = keycloak_realm.test.id
+  description = "a test openid client that has consent text"
+
+  standard_flow_enabled    = true
+  service_accounts_enabled = true
+
+  access_type = "CONFIDENTIAL"
+
+  valid_redirect_uris = [
+    "http://localhost:5555/callback",
+  ]
+
+  client_secret = "secret"
+
+  pkce_code_challenge_method = "plain"
+
+  login_theme = "keycloak"
+
+  backchannel_logout_url                     = "http://localhost:3333/backchannel"
+  backchannel_logout_session_required        = true
+  backchannel_logout_revoke_offline_sessions = true
+
+  extra_config = {
+    customAttribute = "a test custom value"
+  }
+
+  consent_required                 = true
+  display_client_on_consent_screen = true
+  consent_screen_text              = "some consent screen text"
+}
+
+
 resource "keycloak_openid_client_authorization_permission" "resource" {
   resource_server_id = keycloak_openid_client.test_client_auth.resource_server_id
   realm_id           = keycloak_realm.test.id

--- a/keycloak/openid_client.go
+++ b/keycloak/openid_client.go
@@ -61,6 +61,8 @@ type OpenidClientAttributes struct {
 	AccessTokenLifespan                   string                 `json:"access.token.lifespan"`
 	LoginTheme                            string                 `json:"login_theme"`
 	ClientOfflineSessionIdleTimeout       string                 `json:"client.offline.session.idle.timeout,omitempty"`
+	DisplayClientOnConsentScreen          KeycloakBoolQuoted     `json:"display.on.consent.screen"`
+	ConsentScreenText                     string                 `json:"consent.screen.text"`
 	ClientOfflineSessionMaxLifespan       string                 `json:"client.offline.session.max.lifespan,omitempty"`
 	ClientSessionIdleTimeout              string                 `json:"client.session.idle.timeout,omitempty"`
 	ClientSessionMaxLifespan              string                 `json:"client.session.max.lifespan,omitempty"`

--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -193,6 +193,14 @@ func resourceKeycloakOpenidClient() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"display_client_on_consent_screen": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"consent_screen_text": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"authentication_flow_binding_overrides": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -323,6 +331,8 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 			Oauth2DeviceAuthorizationGrantEnabled: keycloak.KeycloakBoolQuoted(data.Get("oauth2_device_authorization_grant_enabled").(bool)),
 			Oauth2DeviceCodeLifespan:              data.Get("oauth2_device_code_lifespan").(string),
 			Oauth2DevicePollingInterval:           data.Get("oauth2_device_polling_interval").(string),
+			ConsentScreenText:                     data.Get("consent_screen_text").(string),
+			DisplayClientOnConsentScreen:          keycloak.KeycloakBoolQuoted(data.Get("display_client_on_consent_screen").(bool)),
 		},
 		ValidRedirectUris: validRedirectUris,
 		WebOrigins:        webOrigins,
@@ -419,6 +429,8 @@ func setOpenidClientData(keycloakClient *keycloak.KeycloakClient, data *schema.R
 	data.Set("client_offline_session_max_lifespan", client.Attributes.ClientOfflineSessionMaxLifespan)
 	data.Set("client_session_idle_timeout", client.Attributes.ClientSessionIdleTimeout)
 	data.Set("client_session_max_lifespan", client.Attributes.ClientSessionMaxLifespan)
+	data.Set("display_client_on_consent_screen", client.Attributes.DisplayClientOnConsentScreen)
+	data.Set("consent_screen_text", client.Attributes.ConsentScreenText)
 	data.Set("backchannel_logout_url", client.Attributes.BackchannelLogoutUrl)
 	data.Set("backchannel_logout_revoke_offline_sessions", client.Attributes.BackchannelLogoutRevokeOfflineTokens)
 	data.Set("backchannel_logout_session_required", client.Attributes.BackchannelLogoutSessionRequired)

--- a/provider/resource_keycloak_openid_client_test.go
+++ b/provider/resource_keycloak_openid_client_test.go
@@ -36,6 +36,30 @@ func TestAccKeycloakOpenidClient_basic(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakOpenidClient_basic_with_consent(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOpenidClientDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenidClient_basic_with_consent(clientId),
+				Check:  testAccCheckKeycloakOpenidClientExistsWithCorrectConsentSettings("keycloak_openid_client.client"),
+			},
+			{
+				ResourceName:            "keycloak_openid_client.client",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     testAccRealm.Realm + "/",
+				ImportStateVerifyIgnore: []string{"exclude_session_state_from_auth_response"},
+			},
+		},
+	})
+}
+
 func TestAccKeycloakOpenidClient_createAfterManualDestroy(t *testing.T) {
 	t.Parallel()
 	var client = &keycloak.OpenidClient{}
@@ -700,6 +724,29 @@ func testAccCheckKeycloakOpenidClientExistsWithCorrectProtocol(resourceName stri
 	}
 }
 
+func testAccCheckKeycloakOpenidClientExistsWithCorrectConsentSettings(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := getOpenidClientFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if client.ConsentRequired != true {
+			return fmt.Errorf("expected openid client to have ConsentRequired %v, but got %v", true, client.ConsentRequired)
+		}
+
+		if client.Attributes.DisplayClientOnConsentScreen != true {
+			return fmt.Errorf("expected openid client to have DisplayClientOnConsentScreen %v, but got %v", true, client.Attributes.DisplayClientOnConsentScreen)
+		}
+
+		if client.Attributes.ConsentScreenText != "some consent screen text" {
+			return fmt.Errorf("expected openid client to have ConsentScreenText %v, but got %v", "some consent screen text", client.Attributes.ConsentScreenText)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckKeycloakOpenidClientHasBackchannelSettings(resourceName, backchannelLogoutUrl string, backchannelLogoutSessionRequired, backchannelLogoutRevokeOfflineSessions bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client, err := getOpenidClientFromState(s, resourceName)
@@ -1081,6 +1128,23 @@ resource "keycloak_openid_client" "client" {
 	client_id   = "%s"
 	realm_id    = data.keycloak_realm.realm.id
 	access_type = "CONFIDENTIAL"
+}
+	`, testAccRealm.Realm, clientId)
+}
+
+func testKeycloakOpenidClient_basic_with_consent(clientId string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "client" {
+	client_id   = "%s"
+	realm_id    = data.keycloak_realm.realm.id
+	access_type = "CONFIDENTIAL"
+	consent_required                 = true
+	display_client_on_consent_screen = true
+	consent_screen_text              = "some consent screen text"
 }
 	`, testAccRealm.Realm, clientId)
 }


### PR DESCRIPTION
closes #525