### PR TITLE
Support custom saml provider idp

### DIFF
--- a/docs/resources/saml_identity_provider.md
+++ b/docs/resources/saml_identity_provider.md
@@ -52,6 +52,7 @@ resource "keycloak_saml_identity_provider" "realm_saml_identity_provider" {
 - `single_sign_on_service_url` - (Required) The Url that must be used to send authentication requests (SAML AuthnRequest).
 - `single_logout_service_url` - (Optional) The Url that must be used to send logout requests.
 - `backchannel_supported` - (Optional) Does the external IDP support back-channel logout ?.
+- `provider_id` - (Optional) The ID of the identity provider to use. Defaults to `saml`, which should be used unless you have extended Keycloak and provided your own implementation.
 - `name_id_policy_format` - (Optional) Specifies the URI reference corresponding to a name identifier format. Defaults to empty.
 - `post_binding_response` - (Optional) Indicates whether to respond to requests using HTTP-POST binding. If false, HTTP-REDIRECT binding will be used..
 - `post_binding_authn_request` - (Optional) Indicates whether the AuthnRequest must be sent using HTTP-POST binding. If false, HTTP-REDIRECT binding will be used.

--- a/example/main.tf
+++ b/example/main.tf
@@ -365,7 +365,13 @@ resource "keycloak_ldap_full_name_mapper" "full_name_mapper" {
   read_only                = true
 }
 
+resource "keycloak_custom_user_federation" "custom" {
+  name        = "custom1"
+  realm_id    = "master"
+  provider_id = "custom"
 
+  enabled = true
+}
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "map_user_attributes_client" {
   name           = "tf-test-open-id-user-attribute-protocol-mapper-client"

--- a/example/main.tf
+++ b/example/main.tf
@@ -216,7 +216,7 @@ resource "keycloak_openid_client" "test_client" {
   backchannel_logout_revoke_offline_sessions = true
 
   extra_config = {
-    customAttribute = "a test custom value"    
+    customAttribute = "a test custom value"
   }
 }
 
@@ -365,13 +365,7 @@ resource "keycloak_ldap_full_name_mapper" "full_name_mapper" {
   read_only                = true
 }
 
-resource "keycloak_custom_user_federation" "custom" {
-  name        = "custom1"
-  realm_id    = "master"
-  provider_id = "custom"
 
-  enabled = true
-}
 
 resource "keycloak_openid_user_attribute_protocol_mapper" "map_user_attributes_client" {
   name           = "tf-test-open-id-user-attribute-protocol-mapper-client"
@@ -784,6 +778,19 @@ resource keycloak_hardcoded_attribute_identity_provider_mapper saml {
   #KC10 support
   extra_config = {
     syncMode = "INHERIT"
+  }
+}
+
+resource keycloak_saml_identity_provider saml_custom {
+  realm                      = keycloak_realm.test.id
+  alias                      = "custom_saml"
+  provider_id                = "saml"
+  entity_id                  = "https://example.com/entity_id"
+  single_sign_on_service_url = "https://example.com/auth"
+  sync_mode                  = "FORCE"
+  gui_order                  = 4
+  extra_config = {
+    mycustomAttribute = "aValue"
   }
 }
 

--- a/provider/resource_keycloak_saml_identity_provider.go
+++ b/provider/resource_keycloak_saml_identity_provider.go
@@ -37,6 +37,12 @@ var principalTypes = []string{
 
 func resourceKeycloakSamlIdentityProvider() *schema.Resource {
 	samlSchema := map[string]*schema.Schema{
+		"provider_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "saml",
+			Description: "provider id, is always saml, unless you have a custom implementation",
+		},
 		"backchannel_supported": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -150,7 +156,7 @@ func resourceKeycloakSamlIdentityProvider() *schema.Resource {
 
 func getSamlIdentityProviderFromData(data *schema.ResourceData) (*keycloak.IdentityProvider, error) {
 	rec, defaultConfig := getIdentityProviderFromData(data)
-	rec.ProviderId = "saml"
+	rec.ProviderId = data.Get("provider_id").(string)
 
 	samlIdentityProviderConfig := &keycloak.IdentityProviderConfig{
 		ValidateSignature:               keycloak.KeycloakBoolQuoted(data.Get("validate_signature").(bool)),

--- a/provider/resource_keycloak_saml_identity_provider_test.go
+++ b/provider/resource_keycloak_saml_identity_provider_test.go
@@ -30,6 +30,24 @@ func TestAccKeycloakSamlIdentityProvider_basic(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakSamlIdentityProvider_customProviderId(t *testing.T) {
+	t.Parallel()
+
+	samlName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakSamlIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakSamlIdentityProvider_customProviderId(samlName, "saml"),//actually needs to be something that exists
+				Check:  testAccCheckKeycloakSamlIdentityProviderExists("keycloak_saml_identity_provider.saml"),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakSamlIdentityProvider_extraConfig(t *testing.T) {
 	t.Parallel()
 
@@ -272,6 +290,22 @@ resource "keycloak_saml_identity_provider" "saml" {
 	single_sign_on_service_url  = "https://example.com/auth"
 }
 	`, testAccRealm.Realm, saml)
+}
+
+func testKeycloakSamlIdentityProvider_customProviderId(saml, providerId string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_saml_identity_provider" "saml" {
+	realm             			= data.keycloak_realm.realm.id
+	alias             			= "%s"
+	provider_id       			= "%s"
+	entity_id					= "https://example.com/entity_id"
+	single_sign_on_service_url  = "https://example.com/auth"
+}
+	`, testAccRealm.Realm, saml, providerId)
 }
 
 func testKeycloakSamlIdentityProvider_extra_config(alias, configKey, configValue string) string {

--- a/provider/resource_keycloak_saml_identity_provider_test.go
+++ b/provider/resource_keycloak_saml_identity_provider_test.go
@@ -41,7 +41,7 @@ func TestAccKeycloakSamlIdentityProvider_customProviderId(t *testing.T) {
 		CheckDestroy:      testAccCheckKeycloakSamlIdentityProviderDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakSamlIdentityProvider_customProviderId(samlName, "saml"),//actually needs to be something that exists
+				Config: testKeycloakSamlIdentityProvider_customProviderId(samlName, "saml"), //actually needs to be something that exists
 				Check:  testAccCheckKeycloakSamlIdentityProviderExists("keycloak_saml_identity_provider.saml"),
 			},
 		},


### PR DESCRIPTION
This allows to set a custom provider_id on the saml idp resource. This is similar as on the oidc idp resource.