### PR TITLE
Update openid_client.md with additional info on web_origins

### DIFF
--- a/docs/resources/openid_client.md
+++ b/docs/resources/openid_client.md
@@ -67,7 +67,7 @@ resource "keycloak_openid_client" "openid_client" {
 - `valid_redirect_uris` - (Optional) A list of valid URIs a browser is permitted to redirect to after a successful login or logout. Simple
 wildcards in the form of an asterisk can be used here. This attribute must be set if either `standard_flow_enabled` or `implicit_flow_enabled`
 is set to `true`.
-- `web_origins` - (Optional) A list of allowed CORS origins. `+` can be used to permit all valid redirect URIs, and `*` can be used to permit all origins.
+- `web_origins` - (Optional) A list of allowed CORS origins. To permit all valid redirect URIs, add `+`. Note that this will not include the `*` wildcard. To permit all origins, explicitly add `*`."
 - `root_url` - (Optional) When specified, this URL is prepended to any relative URLs found within `valid_redirect_uris`, `web_origins`, and `admin_url`. NOTE: Due to limitations in the Keycloak API, when the `root_url` attribute is used, the `valid_redirect_uris`, `web_origins`, and `admin_url` attributes will be required.
 - `admin_url` - (Optional) URL to the admin interface of the client.
 - `base_url` - (Optional) Default URL to use when the auth server needs to redirect or link back to the client.


### PR DESCRIPTION
Although not well documented there is a small but important caveat with the use of '+' for web_origins.
'+' will permit all origins in `valid_redirect_uris` except '*'.
So without this additional info it is easy to make the mistake in believing that, when `valid_redirect_uris` contains '*', including '+' in `web_origins` will cause '*" to be included, which it is not.
The only reference in official Keycloak sources I could find comes from the source code of the admin-ui found here: https://github.com/keycloak/keycloak-admin-ui/blob/5fd344a7bd76bd7f2d3e91794c6fbf738e917bd8/src/clients/help.ts#L44