### PR TITLE
Support for NameIdPolicyFormat Transient on the saml idp

### DIFF
--- a/provider/resource_keycloak_saml_identity_provider.go
+++ b/provider/resource_keycloak_saml_identity_provider.go
@@ -14,6 +14,7 @@ var nameIdPolicyFormats = map[string]string{
 	"Kerberos":                      "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos",
 	"X.509 Subject Name":            "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
 	"Unspecified":                   "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+	"Transient":                     "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
 }
 
 var signatureAlgorithms = []string{


### PR DESCRIPTION
Added support for NameIdPolicyFormat Transient on the saml idp provider resource