### PR TITLE
Fix authentication bindings when internalId differs from realm name

### DIFF
--- a/provider/resource_keycloak_authentication_bindings.go
+++ b/provider/resource_keycloak_authentication_bindings.go
@@ -98,7 +98,7 @@ func resourceKeycloakAuthenticationBindingsCreate(ctx context.Context, data *sch
 		return diag.FromErr(err)
 	}
 
-	realm, err = keycloakClient.GetRealm(ctx, realm.Id)
+	realm, err = keycloakClient.GetRealm(ctx, realm.Realm)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Fix for #686 