### PR TITLE
Changed validators to schema to support options

### DIFF
--- a/docs/resources/realm_user_profile.md
+++ b/docs/resources/realm_user_profile.md
@@ -45,14 +45,15 @@ resource "keycloak_realm_user_profile" "userprofile" {
     }
 
     validator {
-      name = "person-name-prohibited-characters"
-    }
-
-    validator {
-      name   = "pattern"
-      config = {
+      person_name_prohibited_characters {}
+      pattern {
         pattern       = "^[a-z]+$"
         error_message = "Nope"
+      }
+      length {
+        min           = 1
+        max           = 10
+        trim_disabled = false
       }
     }
 
@@ -63,6 +64,31 @@ resource "keycloak_realm_user_profile" "userprofile" {
 
   attribute {
     name = "field2"
+  }
+
+  attribute {
+    name = "field3"
+    display_name = "Field 3"
+
+    validator {
+      options {
+        options = ["option1", "option2"]
+      }
+      email {}
+    }
+  
+  }
+
+
+  attribute {
+    name = "field4"
+
+    validator {
+      double {
+        max = 5.5
+        min = 1.5
+      }
+    }
   }
 
   group {
@@ -106,8 +132,49 @@ resource "keycloak_realm_user_profile" "userprofile" {
 
 #### Validator Arguments
 
-- `name` - (Required) The name of the validator.
-- `config` - (Optional) A map defining the configuration of the validator.
+- `length` - (Optional) Check the length of a string value [length](#length).
+- `integer` - (Optional) Check if the value is an integer and within a lower and upper range [integer](#integer).
+- `double` - (Optional) Check if the value is a double and within a lower and upper range [double](#double).
+- `uri` - (Optional) Check if the value is a valid URI. Has no arguments.
+- `pattern` - (Optional) Check if the value matches a specific RegEx pattern [pattern](#pattern)
+- `email` - (Optional) Check if the value has a valid e-mail format. Has no arguments.
+- `local_date` - (Optional) Check if the value has a valid format based on the realm and/or user locale. Has no arguments.
+- `person_name_prohibited_characters` - (Optional) Check if the value is a valid person name as an additional barrier for attacks such as script injection. The validation is based on a default RegEx pattern that blocks characters not common in person names [person_name_prohibited_characters](#personnameprohibitedcharacters).
+- `username_prohibited_characters` - (Optional) Check if the value is a valid username as an additional barrier for attacks such as script injection. The validation is based on a default RegEx pattern that blocks characters not common in usernames [username_prohibited_characters](#usernameprohibitedcharacters).
+- `options` - (Optional) Check if the value is from the defined set of allowed values. Useful to validate values entered through select and multiselect fields[options](#options).
+
+#### Length
+
+- `min` - (Required) Minimum character length.
+- `max`- (Required) Maximum character length.
+- `trim_disabled` - (Optional) Whether value is trimmed prior to validation.
+
+#### Integer
+
+- `min` - (Required) Defines lower range.
+- `max`- (Required) Defines upper range.
+
+#### Double
+
+- `min` - (Required) Defines lower range.
+- `max`- (Required) Defines upper range.
+
+#### Pattern
+
+- `pattern`- (Required) The RegEx pattern to use when validating values.
+- `error_message`- (Optional) The key of the error message in i18n bundle. If not set a generic message is used.
+
+#### Person_name_prohibited_characters
+
+- `error_message`- (Optional) The key of the error message in i18n bundle. If not set a generic message is used.
+
+#### User_name_prohibited_characters
+
+- `error_message`- (Optional) The key of the error message in i18n bundle. If not set a generic message is used.
+
+#### Options
+
+- `options`- (Required) Array of strings containing allowed values.
 
 ### Group Arguments
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -1027,6 +1027,17 @@ resource "keycloak_realm_user_profile" "userprofile" {
   realm_id = keycloak_realm.test.id
 
   attribute {
+    name = "field0"
+
+    validator {
+      length {
+        min = 100
+        max = 120
+      }
+    }
+  }
+
+  attribute {
     name         = "field1"
     display_name = "Field 1"
     group        = "group1"
@@ -1042,15 +1053,22 @@ resource "keycloak_realm_user_profile" "userprofile" {
     }
 
     validator {
-      name = "person-name-prohibited-characters"
-    }
-
-    validator {
-      name   = "pattern"
-      config = {
+      pattern {
         pattern       = "^[a-z]+$"
         error_message = "Nope"
       }
+
+      length {
+        min = 1
+        max = 10
+        trim_disabled = true
+      }
+
+      double {
+        max = 5.5
+        min = 1.5
+      }
+
     }
 
     annotations = {
@@ -1060,7 +1078,71 @@ resource "keycloak_realm_user_profile" "userprofile" {
 
   attribute {
     name = "field2"
+
+    validator {
+      integer {
+        min = 1
+        max = 12
+      }
+    }
   }
+
+  attribute {
+    name = "field3"
+
+    validator {
+      double {
+        min = 1.5
+        max = 12.9
+      }
+    }
+  }
+
+  attribute {
+    name = "field4"
+
+    validator {
+      uri {}
+    }
+  }
+
+  attribute {
+    name = "field5"
+
+    validator {
+      email {}
+    }
+  }
+
+  attribute {
+    name = "field6"
+
+    validator {
+      local_date {}
+    }
+  }
+
+  attribute {
+    name = "field7"
+
+    validator {
+      person_name_prohibited_characters {}
+      username_prohibited_characters {
+        error_message = "error!"
+      }
+    }
+  }
+  attribute {
+    name = "field8"
+
+    validator {
+      options {
+        options = ["o1", "o2", "o3", "o4"]
+      }
+    }
+  }
+
+
 
   group {
     name                = "group1"

--- a/keycloak/realm_user_profile.go
+++ b/keycloak/realm_user_profile.go
@@ -20,17 +20,57 @@ type RealmUserProfileSelector struct {
 	Scopes []string `json:"scopes,omitempty"`
 }
 
-type RealmUserProfileValidationConfig map[string]interface{}
+type RealmUserProfileValidationLength struct {
+	Min          int  `json:"min,omitempty"`
+	Max          int  `json:"max,omitempty"`
+	TrimDisabled bool `json:"trim-disabled,omitempty"`
+}
+
+type RealmUserProfileValidationInteger struct {
+	Min int `json:"min,omitempty"`
+	Max int `json:"max,omitempty"`
+}
+
+type RealmUserProfileValidationDouble struct {
+	Min float64 `json:"min,omitempty"`
+	Max float64 `json:"max,omitempty"`
+}
+
+type RealmUserProfileValidationPattern struct {
+	Pattern      string `json:"pattern,omitempty"`
+	ErrorMessage string `json:"error-message,omitempty"`
+}
+
+type RealmUserProfileValidationProhibited struct {
+	ErrorMessage string `json:"error-message,omitempty"`
+}
+
+type RealmUserProfileValidationOptions struct {
+	Options []string `json:"options,omitempty"`
+}
+
+type RealmUserProfileValidationConfig struct {
+	Length                    *RealmUserProfileValidationLength     `json:"length,omitempty"`
+	Integer                   *RealmUserProfileValidationInteger    `json:"integer,omitempty"`
+	Double                    *RealmUserProfileValidationDouble     `json:"double,omitempty"`
+	URI                       *map[string]interface{}               `json:"uri,omitempty"`
+	Pattern                   *RealmUserProfileValidationPattern    `json:"pattern,omitempty"`
+	Email                     *map[string]interface{}               `json:"email,omitempty"`
+	LocalDate                 *map[string]interface{}               `json:"local-date,omitempty"`
+	PersonNameProhibitedChars *RealmUserProfileValidationProhibited `json:"person-name-prohibited-characters,omitempty"`
+	UsernameProhibitedChars   *RealmUserProfileValidationProhibited `json:"username-prohibited-characters,omitempty"`
+	Options                   *RealmUserProfileValidationOptions    `json:"options,omitempty"`
+}
 
 type RealmUserProfileAttribute struct {
-	Annotations map[string]string                           `json:"annotations,omitempty"`
-	DisplayName string                                      `json:"displayName,omitempty"`
-	Group       string                                      `json:"group,omitempty"`
-	Name        string                                      `json:"name"`
-	Permissions *RealmUserProfilePermissions                `json:"permissions,omitempty"`
-	Required    *RealmUserProfileRequired                   `json:"required,omitempty"`
-	Selector    *RealmUserProfileSelector                   `json:"selector,omitempty"`
-	Validations map[string]RealmUserProfileValidationConfig `json:"validations,omitempty"`
+	Annotations map[string]string                 `json:"annotations,omitempty"`
+	DisplayName string                            `json:"displayName,omitempty"`
+	Group       string                            `json:"group,omitempty"`
+	Name        string                            `json:"name"`
+	Permissions *RealmUserProfilePermissions      `json:"permissions,omitempty"`
+	Required    *RealmUserProfileRequired         `json:"required,omitempty"`
+	Selector    *RealmUserProfileSelector         `json:"selector,omitempty"`
+	Validations *RealmUserProfileValidationConfig `json:"validations,omitempty"`
 }
 
 type RealmUserProfileGroup struct {

--- a/provider/resource_keycloak_realm_user_profile_test.go
+++ b/provider/resource_keycloak_realm_user_profile_test.go
@@ -53,6 +53,7 @@ func TestAccKeycloakRealmUserProfile_basicEmpty(t *testing.T) {
 }
 
 func TestAccKeycloakRealmUserProfile_basicFull(t *testing.T) {
+
 	skipIfVersionIsLessThanOrEqualTo(testCtx, t, keycloakClient, keycloak.Version_14)
 
 	realmName := acctest.RandomWithPrefix("tf-acc")
@@ -73,11 +74,67 @@ func TestAccKeycloakRealmUserProfile_basicFull(t *testing.T) {
 					Edit: []string{"admin", "user"},
 					View: []string{"admin", "user"},
 				},
-				Validations: map[string]keycloak.RealmUserProfileValidationConfig{
-					"person-name-prohibited-characters": map[string]interface{}{},
-					"pattern":                           map[string]interface{}{"pattern": "^[a-z]+$", "error_message": "Error!"},
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					Pattern: &keycloak.RealmUserProfileValidationPattern{
+						Pattern:      "^[a-z]+$",
+						ErrorMessage: "Error!",
+					},
+					PersonNameProhibitedChars: &keycloak.RealmUserProfileValidationProhibited{
+						ErrorMessage: "Error!",
+					},
+					UsernameProhibitedChars: &keycloak.RealmUserProfileValidationProhibited{ErrorMessage: "Error!"},
 				},
+
 				Annotations: map[string]string{"foo": "bar"},
+			},
+			{
+				Name: "attribute3",
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					PersonNameProhibitedChars: &keycloak.RealmUserProfileValidationProhibited{},
+					UsernameProhibitedChars:   &keycloak.RealmUserProfileValidationProhibited{},
+				},
+			},
+			{
+				Name: "attribute4",
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					Length: &keycloak.RealmUserProfileValidationLength{
+						Min: 1,
+						Max: 2,
+					},
+					Integer: &keycloak.RealmUserProfileValidationInteger{
+						Min: 0,
+						Max: 50,
+					},
+				},
+			},
+			{
+				Name: "attribute5",
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					Length: &keycloak.RealmUserProfileValidationLength{
+						Min: 1,
+						Max: 4,
+					},
+					Double: &keycloak.RealmUserProfileValidationDouble{
+						Min: 0.01,
+						Max: 5.08,
+					},
+				},
+			},
+			{
+				Name: "attribute6",
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					URI:       &map[string]interface{}{},
+					Email:     &map[string]interface{}{},
+					LocalDate: &map[string]interface{}{},
+				},
+			},
+			{
+				Name: "attribute7",
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					Options: &keycloak.RealmUserProfileValidationOptions{
+						Options: []string{"1"},
+					},
+				},
 			},
 		},
 		Groups: []*keycloak.RealmUserProfileGroup{
@@ -164,8 +221,11 @@ func TestAccKeycloakRealmUserProfile_attributeValidator(t *testing.T) {
 		Attributes: []*keycloak.RealmUserProfileAttribute{
 			{
 				Name: "attribute",
-				Validations: map[string]keycloak.RealmUserProfileValidationConfig{
-					"length": map[string]interface{}{"min": "5", "max": "10"},
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					Length: &keycloak.RealmUserProfileValidationLength{
+						Min: 5,
+						Max: 10,
+					},
 				},
 			},
 		},
@@ -175,8 +235,11 @@ func TestAccKeycloakRealmUserProfile_attributeValidator(t *testing.T) {
 		Attributes: []*keycloak.RealmUserProfileAttribute{
 			{
 				Name: "attribute",
-				Validations: map[string]keycloak.RealmUserProfileValidationConfig{
-					"length": map[string]interface{}{"min": "6", "max": "10"},
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					Length: &keycloak.RealmUserProfileValidationLength{
+						Min: 6,
+						Max: 10,
+					},
 				},
 			},
 		},
@@ -186,9 +249,12 @@ func TestAccKeycloakRealmUserProfile_attributeValidator(t *testing.T) {
 		Attributes: []*keycloak.RealmUserProfileAttribute{
 			{
 				Name: "attribute",
-				Validations: map[string]keycloak.RealmUserProfileValidationConfig{
-					"person-name-prohibited-characters": map[string]interface{}{},
-					"length":                            map[string]interface{}{"min": "6", "max": "10"},
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					PersonNameProhibitedChars: &keycloak.RealmUserProfileValidationProhibited{},
+					Length: &keycloak.RealmUserProfileValidationLength{
+						Min: 6,
+						Max: 10,
+					},
 				},
 			},
 		},
@@ -233,6 +299,97 @@ func TestAccKeycloakRealmUserProfile_attributeValidator(t *testing.T) {
 				Config: testKeycloakRealmUserProfile_template(realmName, withoutValidator),
 				Check: testAccCheckKeycloakRealmUserProfileStateEqual(
 					"keycloak_realm_user_profile.realm_user_profile", withoutValidator,
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakRealmUserProfile_options(t *testing.T) {
+	skipIfVersionIsLessThanOrEqualTo(testCtx, t, keycloakClient, keycloak.Version_14)
+
+	realmName := acctest.RandomWithPrefix("tf-acc")
+
+	withInitialOptions := &keycloak.RealmUserProfile{
+		Attributes: []*keycloak.RealmUserProfileAttribute{
+			{
+				Name: "attribute",
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					Options: &keycloak.RealmUserProfileValidationOptions{
+						Options: []string{"option1", "option3", "option4"},
+					},
+				},
+			},
+		},
+	}
+
+	withNewOptions := &keycloak.RealmUserProfile{
+		Attributes: []*keycloak.RealmUserProfileAttribute{
+			{
+				Name: "attribute",
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					Options: &keycloak.RealmUserProfileValidationOptions{
+						Options: []string{"option1", "option2", "option3", "option4"},
+					},
+				},
+			},
+		},
+	}
+
+	withNewSmallerOptions := &keycloak.RealmUserProfile{
+		Attributes: []*keycloak.RealmUserProfileAttribute{
+			{
+				Name: "attribute",
+				Validations: &keycloak.RealmUserProfileValidationConfig{
+					Options: &keycloak.RealmUserProfileValidationOptions{
+						Options: []string{"option1", "option6"},
+					},
+				},
+			},
+		},
+	}
+
+	withoutOptions := &keycloak.RealmUserProfile{
+		Attributes: []*keycloak.RealmUserProfileAttribute{
+			{
+				Name: "attribute",
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakRealmUserProfileDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakRealmUserProfile_template(realmName, withInitialOptions),
+				Check: testAccCheckKeycloakRealmUserProfileStateEqual(
+					"keycloak_realm_user_profile.realm_user_profile", withInitialOptions,
+				),
+			},
+			{
+				Config: testKeycloakRealmUserProfile_template(realmName, withNewOptions),
+				Check: testAccCheckKeycloakRealmUserProfileStateEqual(
+					"keycloak_realm_user_profile.realm_user_profile", withNewOptions,
+				),
+			},
+			{
+				Config: testKeycloakRealmUserProfile_template(realmName, withNewSmallerOptions),
+				Check: testAccCheckKeycloakRealmUserProfileStateEqual(
+					"keycloak_realm_user_profile.realm_user_profile", withNewSmallerOptions,
+				),
+			},
+			{
+				Config: testKeycloakRealmUserProfile_template(realmName, withNewSmallerOptions),
+				Check: testAccCheckKeycloakRealmUserProfileStateEqual(
+					"keycloak_realm_user_profile.realm_user_profile", withNewSmallerOptions,
+				),
+			},
+			{
+				Config: testKeycloakRealmUserProfile_template(realmName, withoutOptions),
+				Check: testAccCheckKeycloakRealmUserProfileStateEqual(
+					"keycloak_realm_user_profile.realm_user_profile", withoutOptions,
 				),
 			},
 		},
@@ -337,10 +494,10 @@ func TestAccKeycloakRealmUserProfile_attributePermissions(t *testing.T) {
 func testKeycloakRealmUserProfile_featureDisabled(realm string) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
-	realm = "%s"
+    realm = "%s"
 }
 resource "keycloak_realm_user_profile" "realm_user_profile" {
-	realm_id = keycloak_realm.realm.id
+    realm_id = keycloak_realm.realm.id
 }
 `, realm)
 }
@@ -348,104 +505,161 @@ resource "keycloak_realm_user_profile" "realm_user_profile" {
 func testKeycloakRealmUserProfile_template(realm string, realmUserProfile *keycloak.RealmUserProfile) string {
 	tmpl, err := template.New("").Funcs(template.FuncMap{"StringsJoin": strings.Join}).Parse(`
 resource "keycloak_realm" "realm" {
-	realm 	   = "{{ .realm }}"
+    realm 	   = "{{ .realm }}"
 
-	attributes = {
-		userProfileEnabled  = true
-	}
+    attributes = {
+        userProfileEnabled  = true
+    }
 }
 
 resource "keycloak_realm_user_profile" "realm_user_profile" {
-	realm_id = keycloak_realm.realm.id
+    realm_id = keycloak_realm.realm.id
 
-	{{- range $_, $attribute := .userProfile.Attributes }}
-	attribute {
+    {{- range $_, $attribute := .userProfile.Attributes }}
+    attribute {
         name = "{{ $attribute.Name }}"
-		{{- if $attribute.DisplayName }}
+        {{- if $attribute.DisplayName }}
         display_name = "{{ $attribute.DisplayName }}"
-		{{- end }}
+        {{- end }}
 
-		{{- if $attribute.Group }}
+        {{- if $attribute.Group }}
         group = "{{ $attribute.Group }}"
-		{{- end }}
+        {{- end }}
 
-		{{- if $attribute.Selector }}
-		{{- if $attribute.Selector.Scopes }}
+        {{- if $attribute.Selector }}
+        {{- if $attribute.Selector.Scopes }}
         enabled_when_scope = ["{{ StringsJoin $attribute.Selector.Scopes "\", \"" }}"]
-		{{- end }}
-		{{- end }}
+        {{- end }}
+        {{- end }}
 
-		{{- if $attribute.Required }}
-		{{- if $attribute.Required.Roles }}
+        {{- if $attribute.Required }}
+        {{- if $attribute.Required.Roles }}
         required_for_roles = ["{{ StringsJoin $attribute.Required.Roles "\", \"" }}"]
-		{{- end }}
-		{{- end }}
+        {{- end }}
+        {{- end }}
 
-		{{- if $attribute.Required }}
-		{{- if $attribute.Required.Scopes }}
+        {{- if $attribute.Required }}
+        {{- if $attribute.Required.Scopes }}
         required_for_scopes = ["{{ StringsJoin $attribute.Required.Scopes "\", \"" }}"]
-		{{- end }}
-		{{- end }}
+        {{- end }}
+        {{- end }}
 
-		{{- if $attribute.Permissions }}
+        {{- if $attribute.Permissions }}
         permissions {
-			{{- if $attribute.Permissions.View }}
+            {{- if $attribute.Permissions.View }}
             view = ["{{ StringsJoin $attribute.Permissions.View "\", \"" }}"]
-			{{- end }}
-			{{- if $attribute.Permissions.Edit }}
+            {{- end }}
+            {{- if $attribute.Permissions.Edit }}
             edit = ["{{ StringsJoin $attribute.Permissions.Edit "\", \"" }}"]
-			{{- end }}
+            {{- end }}
         }
-		{{- end }}
+        {{- end }}
 
-		{{- if $attribute.Validations }}
-		{{ range $name, $config := $attribute.Validations }}
+        {{- if $attribute.Validations }}
         validator {
-            name = "{{ $name }}"
-            {{- if $config }}
-            config = {
-                {{- range $key, $value := $config }}
-                {{ $key }} = "{{ $value }}"
+            {{- if $attribute.Validations.Length }}
+            length {
+                min = {{ $attribute.Validations.Length.Min }}
+                max = {{ $attribute.Validations.Length.Max }}
+                trim_disabled = {{ $attribute.Validations.Length.TrimDisabled }}
+            }
+            {{- end }}
+            
+            {{- if $attribute.Validations.Integer }}
+            integer {
+                min = {{ $attribute.Validations.Integer.Min }}
+                max = {{ $attribute.Validations.Integer.Max }}
+            }
+            {{- end }}
+
+            {{- if $attribute.Validations.Double }}
+            double {
+                min = {{ $attribute.Validations.Double.Min }}
+                max = {{ $attribute.Validations.Double.Max }}
+            }
+            {{- end }}
+
+            {{- if $attribute.Validations.URI }}
+            uri {}
+            {{- end }}
+
+            {{- if $attribute.Validations.Pattern }}
+            pattern {
+                pattern = "{{ $attribute.Validations.Pattern.Pattern }}"
+                error_message = "{{ $attribute.Validations.Pattern.ErrorMessage }}"
+            }
+            {{- end }}
+
+            {{- if $attribute.Validations.Email }}
+            email {}
+            {{- end }}
+
+            {{- if $attribute.Validations.LocalDate }}
+            local_date {}
+            {{- end }}
+
+            {{- if $attribute.Validations.PersonNameProhibitedChars }}
+            person_name_prohibited_characters {
+                {{- if $attribute.Validations.PersonNameProhibitedChars.ErrorMessage }}
+                error_message = "{{ $attribute.Validations.PersonNameProhibitedChars.ErrorMessage }}"
                 {{- end }}
             }
             {{- end }}
-        }
-		{{- end }}
-		{{- end }}
 
-		{{- if $attribute.Annotations }}
+            {{- if $attribute.Validations.UsernameProhibitedChars }}
+            username_prohibited_characters {
+                {{- if $attribute.Validations.UsernameProhibitedChars.ErrorMessage }}
+                error_message = "{{ $attribute.Validations.UsernameProhibitedChars.ErrorMessage }}"
+                {{- end }}
+            }
+            {{- end }}
+
+            {{- if $attribute.Validations.Options }}
+            options {
+                options = [
+                    {{- range $attribute.Validations.Options.Options }}
+                    "{{ . }}",
+                    {{- end }}
+                ]
+            }
+            {{- end }}
+
+        }
+        {{- end }}
+
+        {{- if $attribute.Annotations }}
         annotations = {
             {{- range $key, $value := $attribute.Annotations }}
             {{ $key }} = "{{ $value }}"
             {{- end }}
         }
-		{{- end }}
+        {{- end }}
     }
-	{{- end }}
+    {{- end }}
 
-	{{- range $_, $group := .userProfile.Groups }}
+    {{- range $_, $group := .userProfile.Groups }}
     group {
         name = "{{ $group.Name }}"
 
-		{{- if $group.DisplayHeader }}
+        {{- if $group.DisplayHeader }}
         display_header = "{{ $group.DisplayHeader }}"
-		{{- end }}
+        {{- end }}
 
-		{{- if $group.DisplayDescription }}
+        {{- if $group.DisplayDescription }}
         display_description = "{{ $group.DisplayDescription }}"
-		{{- end }}
+        {{- end }}
 
-		{{- if $group.Annotations }}
+        {{- if $group.Annotations }}
         annotations = {
             {{- range $key, $value := $group.Annotations }}
             {{ $key }} = "{{ $value }}"
             {{- end }}
         }
-		{{- end }}
+        {{- end }}
     }
-	{{- end }}
+    {{- end }}
 }
-	`)
+    `)
 	if err != nil {
 		fmt.Println(err)
 		return ""


### PR DESCRIPTION
The current implementation does not support option validator, since Keycloak requires it to be an array of strings. We couldn't find an easy way to implement it with the current schema, we had to add a specific schema for every validator that Keycloak supports. We added tests to cover this new schema.

This is a breaking change in the schema and should probably be in a major version. Let us know what you think.

@maximepiton is the original contributor for this feature, please review if possible