### PR TITLE
Declarative User Profile : Annotations & validator config as Json

### DIFF
--- a/docs/resources/realm_user_profile.md
+++ b/docs/resources/realm_user_profile.md
@@ -63,6 +63,17 @@ resource "keycloak_realm_user_profile" "userprofile" {
 
   attribute {
     name = "field2"
+
+    validator {
+      name   = "options"
+      config = {
+        options = jsonencode ( [ "opt1" ])
+      }
+    }
+
+    annotations = {
+      foo = jsonencode ( {"key": "val" } )
+    }
   }
 
   group {
@@ -72,6 +83,7 @@ resource "keycloak_realm_user_profile" "userprofile" {
 
     annotations = {
       foo = "bar"
+      foo2 = jsonencode ( { "key": "val" } )
     }
   }
 
@@ -97,7 +109,7 @@ resource "keycloak_realm_user_profile" "userprofile" {
 - `required_for_scopes` - (Optional) A list of scopes for which the attribute will be required.
 - `permissions` - (Optional) The [permissions](#permissions-arguments) configuration information.
 - `validator` - (Optional) A list of [validators](#validator-arguments) for the attribute.
-- `annotations` - (Optional) A map of annotations for the attribute.
+- `annotations` - (Optional) A map of annotations for the attribute. Values can be a String or a json object.
 
 #### Permissions Arguments
 
@@ -107,14 +119,14 @@ resource "keycloak_realm_user_profile" "userprofile" {
 #### Validator Arguments
 
 - `name` - (Required) The name of the validator.
-- `config` - (Optional) A map defining the configuration of the validator.
+- `config` - (Optional) A map defining the configuration of the validator. Values can be a String or a json object.
 
 ### Group Arguments
 
 - `name` - (Required) The name of the group.
 - `display_header` - (Optional) The display header of the group.
 - `display_description` - (Optional) The display description of the group.
-- `annotations` - (Optional) A map of annotations for the group.
+- `annotations` - (Optional) A map of annotations for the group. Values can be a String or a json object.
 
 ## Import
 

--- a/keycloak/realm_user_profile.go
+++ b/keycloak/realm_user_profile.go
@@ -23,7 +23,7 @@ type RealmUserProfileSelector struct {
 type RealmUserProfileValidationConfig map[string]interface{}
 
 type RealmUserProfileAttribute struct {
-	Annotations map[string]string                           `json:"annotations,omitempty"`
+	Annotations map[string]interface{}                      `json:"annotations,omitempty"`
 	DisplayName string                                      `json:"displayName,omitempty"`
 	Group       string                                      `json:"group,omitempty"`
 	Name        string                                      `json:"name"`
@@ -34,10 +34,10 @@ type RealmUserProfileAttribute struct {
 }
 
 type RealmUserProfileGroup struct {
-	Annotations        map[string]string `json:"annotations,omitempty"`
-	DisplayDescription string            `json:"displayDescription,omitempty"`
-	DisplayHeader      string            `json:"displayHeader,omitempty"`
-	Name               string            `json:"name"`
+	Annotations        map[string]interface{} `json:"annotations,omitempty"`
+	DisplayDescription string                 `json:"displayDescription,omitempty"`
+	DisplayHeader      string                 `json:"displayHeader,omitempty"`
+	Name               string                 `json:"name"`
 }
 
 type RealmUserProfile struct {
@@ -65,5 +65,50 @@ func (keycloakClient *KeycloakClient) GetRealmUserProfile(ctx context.Context, r
 		return nil, err
 	}
 
+	for _, attr := range realmUserProfile.Attributes {
+		if attr.Validations != nil {
+			for name, config := range attr.Validations {
+
+				c := make(map[string]interface{})
+				for k, v := range config {
+					if _, ok := v.([]interface{}); ok {
+						tmp, _ := json.Marshal(v)
+						c[k] = string(tmp)
+					} else {
+						c[k] = v
+					}
+				}
+
+				attr.Validations[name] = c
+			}
+		}
+		if attr.Annotations != nil {
+			for k, v := range attr.Annotations {
+
+				if _, ok := v.(map[string]interface{}); ok {
+					tmp, _ := json.Marshal(v)
+					attr.Annotations[k] = string(tmp)
+				} else {
+					attr.Annotations[k] = v
+				}
+
+			}
+		}
+	}
+
+	for _, attr := range realmUserProfile.Groups {
+		if attr.Annotations != nil {
+			for k, v := range attr.Annotations {
+
+				if _, ok := v.(map[string]interface{}); ok {
+					tmp, _ := json.Marshal(v)
+					attr.Annotations[k] = string(tmp)
+				} else {
+					attr.Annotations[k] = v
+				}
+
+			}
+		}
+	}
 	return &realmUserProfile, nil
 }

--- a/provider/resource_keycloak_realm_user_profile_test.go
+++ b/provider/resource_keycloak_realm_user_profile_test.go
@@ -75,13 +75,24 @@ func TestAccKeycloakRealmUserProfile_basicFull(t *testing.T) {
 				},
 				Validations: map[string]keycloak.RealmUserProfileValidationConfig{
 					"person-name-prohibited-characters": map[string]interface{}{},
-					"pattern":                           map[string]interface{}{"pattern": "^[a-z]+$", "error_message": "Error!"},
+					"pattern":                           map[string]interface{}{"pattern": "\"^[a-z]+$\"", "error_message": "\"Error!\""},
 				},
-				Annotations: map[string]string{"foo": "bar"},
+				Annotations: map[string]interface{}{
+					"foo":               "\"bar\"",
+					"inputOptionLabels": "{\"a\":\"b\"}",
+				},
 			},
 		},
 		Groups: []*keycloak.RealmUserProfileGroup{
-			{Name: "group", DisplayDescription: "Description", DisplayHeader: "Header", Annotations: map[string]string{"foo": "bar"}},
+			{
+				Name:               "group",
+				DisplayDescription: "Description",
+				DisplayHeader:      "Header",
+				Annotations: map[string]interface{}{
+					"foo":  "\"bar\"",
+					"test": "{\"a2\":\"b2\"}",
+				},
+			},
 		},
 	}
 
@@ -165,7 +176,8 @@ func TestAccKeycloakRealmUserProfile_attributeValidator(t *testing.T) {
 			{
 				Name: "attribute",
 				Validations: map[string]keycloak.RealmUserProfileValidationConfig{
-					"length": map[string]interface{}{"min": "5", "max": "10"},
+					"length":  map[string]interface{}{"min": "5", "max": "10"},
+					"options": map[string]interface{}{"options": "[\"cgu\"]"},
 				},
 			},
 		},
@@ -405,7 +417,7 @@ resource "keycloak_realm_user_profile" "realm_user_profile" {
             {{- if $config }}
             config = {
                 {{- range $key, $value := $config }}
-                {{ $key }} = "{{ $value }}"
+                {{ $key }} = jsonencode ( {{ $value }} )
                 {{- end }}
             }
             {{- end }}
@@ -416,7 +428,7 @@ resource "keycloak_realm_user_profile" "realm_user_profile" {
 		{{- if $attribute.Annotations }}
         annotations = {
             {{- range $key, $value := $attribute.Annotations }}
-            {{ $key }} = "{{ $value }}"
+            {{ $key }} = jsonencode ( {{ $value }} )
             {{- end }}
         }
 		{{- end }}
@@ -438,7 +450,7 @@ resource "keycloak_realm_user_profile" "realm_user_profile" {
 		{{- if $group.Annotations }}
         annotations = {
             {{- range $key, $value := $group.Annotations }}
-            {{ $key }} = "{{ $value }}"
+            {{ $key }} = jsonencode ( {{ $value }} )
             {{- end }}
         }
 		{{- end }}


### PR DESCRIPTION
Hello,

In "Declarative User Profile", Annotations and Validators are not just `map[string]string`, it should be `map[string]interface{}`

In Terraform, an attribut (in a map) for a resource cannot be String or Object in the same time (Generics missing ;))

With this PR, the workaround I propose is to serialize the object as a Json string.

Hope this will help


