### PR TITLE
Microsoft IdP

### DIFF
--- a/docs/resources/oidc_microsoft_identity_provider.md
+++ b/docs/resources/oidc_microsoft_identity_provider.md
@@ -41,7 +41,7 @@ resource "keycloak_oidc_microsoft_identity_provider" "microsoft" {
 - `first_broker_login_flow_alias` - (Optional) The authentication flow to use when users log in for the first time through this identity provider. Defaults to `first broker login`.
 - `post_broker_login_flow_alias` - (Optional) The authentication flow to use after users have successfully logged in, which can be used to perform additional user verification (such as OTP checking). Defaults to an empty string, which means no post login flow will be used.
 - `provider_id` - (Optional) The ID of the identity provider to use. Defaults to `microsoft`, which should be used unless you have extended Keycloak and provided your own implementation.
-- `default_scopes` - (Optional) The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to `openid profile email`.
+- `default_scopes` - (Optional) The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to `User.read`.
 - `accepts_prompt_none_forward_from_client` - (Optional) When `true`, unauthenticated requests with `prompt=none` will be forwarded to Microsoft instead of returning an error. Defaults to `false`.
 - `disable_user_info` - (Optional) When `true`, disables the usage of the user info service to obtain additional user information. Defaults to `false`.
 - `hide_on_login_page` - (Optional) When `true`, this identity provider will be hidden on the login page. Defaults to `false`.

--- a/docs/resources/oidc_microsoft_identity_provider.md
+++ b/docs/resources/oidc_microsoft_identity_provider.md
@@ -1,0 +1,60 @@
+---
+page_title: "keycloak_oidc_microsoft_identity_provider Resource"
+---
+
+# keycloak\_oidc\_microsoft\_identity\_provider Resource
+
+Allows for creating and managing OIDC Identity Providers within Keycloak.
+
+OIDC (OpenID Connect) identity providers allows users to authenticate through a third party system using the OIDC standard.
+
+## Example Usage
+
+```hcl
+resource "keycloak_realm" "realm" {
+  realm   = "my-realm"
+  enabled = true
+}
+
+resource "keycloak_oidc_microsoft_identity_provider" "microsoft" {
+  realm         = keycloak_realm.realm.id
+  client_id     = var.microsoft_identity_provider_client_id
+  client_secret = var.microsoft_identity_provider_client_secret
+  sync_mode     = "IMPORT"
+
+  extra_config = {
+    "myCustomConfigKey" = "myValue"
+  }
+}
+```
+
+## Argument Reference
+
+- `realm` - (Required) The name of the realm. This is unique across Keycloak.
+- `client_id` - (Required) The client or client identifier registered within the identity provider.
+- `client_secret` - (Required) The client or client secret registered within the identity provider. This field is able to obtain its value from vault, use $${vault.ID} format.
+- `enabled` - (Optional) When `true`, users will be able to log in to this realm using this identity provider. Defaults to `true`.
+- `store_token` - (Optional) When `true`, tokens will be stored after authenticating users. Defaults to `true`.
+- `add_read_token_role_on_create` - (Optional) When `true`, new users will be able to read stored tokens. This will automatically assign the `broker.read-token` role. Defaults to `false`.
+- `link_only` - (Optional) When `true`, users cannot login using this provider, but their existing accounts will be linked when possible. Defaults to `false`.
+- `trust_email` - (Optional) When `true`, email addresses for users in this provider will automatically be verified regardless of the realm's email verification policy. Defaults to `false`.
+- `first_broker_login_flow_alias` - (Optional) The authentication flow to use when users log in for the first time through this identity provider. Defaults to `first broker login`.
+- `post_broker_login_flow_alias` - (Optional) The authentication flow to use after users have successfully logged in, which can be used to perform additional user verification (such as OTP checking). Defaults to an empty string, which means no post login flow will be used.
+- `provider_id` - (Optional) The ID of the identity provider to use. Defaults to `microsoft`, which should be used unless you have extended Keycloak and provided your own implementation.
+- `default_scopes` - (Optional) The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to `openid profile email`.
+- `accepts_prompt_none_forward_from_client` - (Optional) When `true`, unauthenticated requests with `prompt=none` will be forwarded to Microsoft instead of returning an error. Defaults to `false`.
+- `disable_user_info` - (Optional) When `true`, disables the usage of the user info service to obtain additional user information. Defaults to `false`.
+- `hide_on_login_page` - (Optional) When `true`, this identity provider will be hidden on the login page. Defaults to `false`.
+- `sync_mode` - (Optional) The default sync mode to use for all mappers attached to this identity provider. Can be once of `IMPORT`, `FORCE`, or `LEGACY`.
+- `gui_order` - (Optional) A number defining the order of this identity provider in the GUI.
+- `extra_config` - (Optional) A map of key/value pairs to add extra configuration to this identity provider. This can be used for custom oidc provider implementations, or to add configuration that is not yet supported by this Terraform provider. Use this attribute at your own risk, as custom attributes may conflict with top-level configuration attributes in future provider updates.
+
+## Attribute Reference
+
+- `internal_id` - (Computed) The unique ID that Keycloak assigns to the identity provider upon creation.
+- `alias` - (Computed) The alias for the Microsoft identity provider.
+- `display_name` - (Computed) Display name for the Microsoft identity provider in the GUI.
+
+## Import
+
+This resource does not yet support importing.

--- a/example/main.tf
+++ b/example/main.tf
@@ -637,6 +637,14 @@ resource keycloak_oidc_google_identity_provider google {
   gui_order                               = 2
 }
 
+resource keycloak_oidc_microsoft_identity_provider microsoft {
+  realm                                   = keycloak_realm.test.id
+  client_id                               = "azure-app-client-id"
+  client_secret                           = "azure-app-client-secret"
+  sync_mode                               = "IMPORT"
+  gui_order                               = 3
+}
+
 //This example does not work in keycloak 10, because the interfaces that our customIdp implements, have changed in the keycloak latest version.
 //We need to make decide which keycloak version we going to support and test for the customIdp
 //resource keycloak_oidc_identity_provider custom_oidc_idp {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -88,6 +88,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 			"keycloak_custom_identity_provider_mapper":                   resourceKeycloakCustomIdentityProviderMapper(),
 			"keycloak_saml_identity_provider":                            resourceKeycloakSamlIdentityProvider(),
 			"keycloak_oidc_google_identity_provider":                     resourceKeycloakOidcGoogleIdentityProvider(),
+			"keycloak_oidc_microsoft_identity_provider":                  resourceKeycloakOidcMicrosoftIdentityProvider(),
 			"keycloak_oidc_identity_provider":                            resourceKeycloakOidcIdentityProvider(),
 			"keycloak_openid_client_authorization_resource":              resourceKeycloakOpenidClientAuthorizationResource(),
 			"keycloak_openid_client_group_policy":                        resourceKeycloakOpenidClientAuthorizationGroupPolicy(),

--- a/provider/resource_keycloak_oidc_microsoft_identity_provider.go
+++ b/provider/resource_keycloak_oidc_microsoft_identity_provider.go
@@ -1,0 +1,104 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/imdario/mergo"
+	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakOidcMicrosoftIdentityProvider() *schema.Resource {
+	oidcMicrosoftSchema := map[string]*schema.Schema{
+		"alias": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The alias uniquely identifies an identity provider and it is also used to build the redirect uri. In case of microsoft this is computed and always microsoft",
+		},
+		"display_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Not used by this provider, will be implicitly Microsoft",
+		},
+		"provider_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "microsoft",
+			Description: "provider id, is always microsoft, unless you have a extended custom implementation",
+		},
+		"client_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Client ID.",
+		},
+		"client_secret": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Client Secret.",
+		},
+		"default_scopes": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "",
+			Description: "The scopes to be sent when asking for authorization. See the documentation for possible values, separator and default value'",
+		},
+		"accepts_prompt_none_forward_from_client": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "This is just used together with Identity Provider Authenticator or when kc_idp_hint points to this identity provider. In case that client sends a request with prompt=none and user is not yet authenticated, the error will not be directly returned to client, but the request with prompt=none will be forwarded to this identity provider.",
+		},
+		"disable_user_info": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Disable usage of User Info service to obtain additional user information?  Default is to use this OIDC service.",
+		},
+		"hide_on_login_page": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Hide On Login Page.",
+		},
+	}
+	oidcResource := resourceKeycloakIdentityProvider()
+	oidcResource.Schema = mergeSchemas(oidcResource.Schema, oidcMicrosoftSchema)
+	oidcResource.CreateContext = resourceKeycloakIdentityProviderCreate(getOidcMicrosoftIdentityProviderFromData, setOidcMicrosoftIdentityProviderData)
+	oidcResource.ReadContext = resourceKeycloakIdentityProviderRead(setOidcMicrosoftIdentityProviderData)
+	oidcResource.UpdateContext = resourceKeycloakIdentityProviderUpdate(getOidcMicrosoftIdentityProviderFromData, setOidcMicrosoftIdentityProviderData)
+	return oidcResource
+}
+
+func getOidcMicrosoftIdentityProviderFromData(data *schema.ResourceData) (*keycloak.IdentityProvider, error) {
+	rec, defaultConfig := getIdentityProviderFromData(data)
+	rec.ProviderId = data.Get("provider_id").(string)
+	rec.Alias = "microsoft"
+
+	microsoftOidcIdentityProviderConfig := &keycloak.IdentityProviderConfig{
+		ClientId:                    data.Get("client_id").(string),
+		ClientSecret:                data.Get("client_secret").(string),
+		HideOnLoginPage:             keycloak.KeycloakBoolQuoted(data.Get("hide_on_login_page").(bool)),
+		DefaultScope:                data.Get("default_scopes").(string),
+		AcceptsPromptNoneForwFrmClt: keycloak.KeycloakBoolQuoted(data.Get("accepts_prompt_none_forward_from_client").(bool)),
+		UseJwksUrl:                  true,
+		DisableUserInfo:             keycloak.KeycloakBoolQuoted(data.Get("disable_user_info").(bool)),
+	}
+
+	if err := mergo.Merge(microsoftOidcIdentityProviderConfig, defaultConfig); err != nil {
+		return nil, err
+	}
+
+	rec.Config = microsoftOidcIdentityProviderConfig
+
+	return rec, nil
+}
+
+func setOidcMicrosoftIdentityProviderData(data *schema.ResourceData, identityProvider *keycloak.IdentityProvider) error {
+	setIdentityProviderData(data, identityProvider)
+	data.Set("provider_id", identityProvider.ProviderId)
+	data.Set("client_id", identityProvider.Config.ClientId)
+	data.Set("hide_on_login_page", identityProvider.Config.HideOnLoginPage)
+	data.Set("default_scopes", identityProvider.Config.DefaultScope)
+	data.Set("accepts_prompt_none_forward_from_client", identityProvider.Config.AcceptsPromptNoneForwFrmClt)
+	data.Set("disable_user_info", identityProvider.Config.DisableUserInfo)
+	return nil
+}

--- a/provider/resource_keycloak_oidc_microsoft_identity_provider_test.go
+++ b/provider/resource_keycloak_oidc_microsoft_identity_provider_test.go
@@ -1,0 +1,264 @@
+package provider
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+/*
+	note: we cannot use parallel tests for this resource as only one instance of a microsoft identity provider can be created
+	for a realm.
+*/
+
+func TestAccKeycloakOidcMicrosoftIdentityProvider_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOidcMicrosoftIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOidcMicrosoftIdentityProvider_basic(),
+				Check:  testAccCheckKeycloakOidcMicrosoftIdentityProviderExists("keycloak_oidc_microsoft_identity_provider.microsoft"),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOidcMicrosoftIdentityProvider_extraConfig(t *testing.T) {
+	customConfigValue := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOidcMicrosoftIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOidcMicrosoftIdentityProvider_customConfig("dummyConfig", customConfigValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOidcMicrosoftIdentityProviderExists("keycloak_oidc_microsoft_identity_provider.microsoft_custom"),
+					testAccCheckKeycloakOidcMicrosoftIdentityProviderHasCustomConfigValue("keycloak_oidc_microsoft_identity_provider.microsoft_custom", customConfigValue),
+				),
+			},
+		},
+	})
+}
+
+// ensure that extra_config keys which are covered by top-level attributes are not allowed
+func TestAccKeycloakOidcMicrosoftIdentityProvider_extraConfigInvalid(t *testing.T) {
+	customConfigValue := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOidcMicrosoftIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testKeycloakOidcMicrosoftIdentityProvider_customConfig("syncMode", customConfigValue),
+				ExpectError: regexp.MustCompile("extra_config key \"syncMode\" is not allowed"),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOidcMicrosoftIdentityProvider_createAfterManualDestroy(t *testing.T) {
+	var idp = &keycloak.IdentityProvider{}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOidcMicrosoftIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOidcMicrosoftIdentityProvider_basic(),
+				Check:  testAccCheckKeycloakOidcMicrosoftIdentityProviderFetch("keycloak_oidc_microsoft_identity_provider.microsoft", idp),
+			},
+			{
+				PreConfig: func() {
+					err := keycloakClient.DeleteIdentityProvider(testCtx, idp.Realm, idp.Alias)
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testKeycloakOidcMicrosoftIdentityProvider_basic(),
+				Check:  testAccCheckKeycloakOidcMicrosoftIdentityProviderExists("keycloak_oidc_microsoft_identity_provider.microsoft"),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOidcMicrosoftIdentityProvider_basicUpdateAll(t *testing.T) {
+	firstEnabled := randomBool()
+
+	firstOidc := &keycloak.IdentityProvider{
+		Alias:   acctest.RandString(10),
+		Enabled: firstEnabled,
+		Config: &keycloak.IdentityProviderConfig{
+			AcceptsPromptNoneForwFrmClt: false,
+			ClientId:                    acctest.RandString(10),
+			ClientSecret:                acctest.RandString(10),
+			GuiOrder:                    strconv.Itoa(acctest.RandIntRange(1, 3)),
+			SyncMode:                    randomStringInSlice(syncModes),
+		},
+	}
+
+	secondOidc := &keycloak.IdentityProvider{
+		Alias:   acctest.RandString(10),
+		Enabled: !firstEnabled,
+		Config: &keycloak.IdentityProviderConfig{
+			AcceptsPromptNoneForwFrmClt: false,
+			ClientId:                    acctest.RandString(10),
+			ClientSecret:                acctest.RandString(10),
+			GuiOrder:                    strconv.Itoa(acctest.RandIntRange(1, 3)),
+			SyncMode:                    randomStringInSlice(syncModes),
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOidcMicrosoftIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOidcMicrosoftIdentityProvider_basicFromInterface(firstOidc),
+				Check:  testAccCheckKeycloakOidcMicrosoftIdentityProviderExists("keycloak_oidc_microsoft_identity_provider.microsoft"),
+			},
+			{
+				Config: testKeycloakOidcMicrosoftIdentityProvider_basicFromInterface(secondOidc),
+				Check:  testAccCheckKeycloakOidcMicrosoftIdentityProviderExists("keycloak_oidc_microsoft_identity_provider.microsoft"),
+			},
+		},
+	})
+}
+
+func testAccCheckKeycloakOidcMicrosoftIdentityProviderExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, err := getKeycloakOidcMicrosoftIdentityProviderFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckKeycloakOidcMicrosoftIdentityProviderFetch(resourceName string, idp *keycloak.IdentityProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		fetchedOidc, err := getKeycloakOidcMicrosoftIdentityProviderFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		idp.Alias = fetchedOidc.Alias
+		idp.Realm = fetchedOidc.Realm
+
+		return nil
+	}
+}
+
+func testAccCheckKeycloakOidcMicrosoftIdentityProviderHasCustomConfigValue(resourceName, customConfigValue string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		fetchedOidc, err := getKeycloakOidcMicrosoftIdentityProviderFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if fetchedOidc.Config.ExtraConfig["dummyConfig"].(string) != customConfigValue {
+			return fmt.Errorf("expected custom oidc provider to have config with a custom key 'dummyConfig' with a value %s, but value was %s", customConfigValue, fetchedOidc.Config.ExtraConfig["dummyConfig"].(string))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckKeycloakOidcMicrosoftIdentityProviderDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "keycloak_oidc_microsoft_identity_provider" {
+				continue
+			}
+
+			id := rs.Primary.ID
+			realm := rs.Primary.Attributes["realm"]
+
+			idp, _ := keycloakClient.GetIdentityProvider(testCtx, realm, id)
+			if idp != nil {
+				return fmt.Errorf("oidc config with id %s still exists", id)
+			}
+		}
+
+		return nil
+	}
+}
+
+func getKeycloakOidcMicrosoftIdentityProviderFromState(s *terraform.State, resourceName string) (*keycloak.IdentityProvider, error) {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("resource not found: %s", resourceName)
+	}
+
+	realm := rs.Primary.Attributes["realm"]
+	alias := rs.Primary.Attributes["alias"]
+
+	idp, err := keycloakClient.GetIdentityProvider(testCtx, realm, alias)
+	if err != nil {
+		return nil, fmt.Errorf("error getting oidc identity provider config with alias %s: %s", alias, err)
+	}
+
+	return idp, nil
+}
+
+func testKeycloakOidcMicrosoftIdentityProvider_basic() string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_oidc_microsoft_identity_provider" "microsoft" {
+	realm             = data.keycloak_realm.realm.id
+	client_id         = "example_id"
+	client_secret     = "example_token"
+}
+	`, testAccRealm.Realm)
+}
+
+func testKeycloakOidcMicrosoftIdentityProvider_customConfig(configKey, configValue string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_oidc_microsoft_identity_provider" "microsoft_custom" {
+	realm             = data.keycloak_realm.realm.id
+	provider_id       = "microsoft"
+	client_id         = "example_id"
+	client_secret     = "example_token"
+	extra_config      = {
+		%s = "%s"
+	}
+}
+	`, testAccRealm.Realm, configKey, configValue)
+}
+
+func testKeycloakOidcMicrosoftIdentityProvider_basicFromInterface(idp *keycloak.IdentityProvider) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_oidc_microsoft_identity_provider" "microsoft" {
+	realm             						= data.keycloak_realm.realm.id
+	enabled           						= %t
+	accepts_prompt_none_forward_from_client	= %t
+	client_id         						= "%s"
+	client_secret     						= "%s"
+	gui_order                               = %s
+	sync_mode                               = "%s"
+}
+	`, testAccRealm.Realm, idp.Enabled, idp.Config.AcceptsPromptNoneForwFrmClt, idp.Config.ClientId, idp.Config.ClientSecret, idp.Config.GuiOrder, idp.Config.SyncMode)
+}


### PR DESCRIPTION
Hi @mrparkers, first of all thanks for creating and maintaining this great piece of code, I found it really usefull :smile: 
I need to use Microsoft IdP but due to https://github.com/keycloak/keycloak/issues/9004 it's not possible to configure it (and I believe any other IdP) using generic oidc provider, so I've created one for Microsoft.

I also found a little issue or just a thing I'm not sure about -  https://github.com/mrparkers/terraform-provider-keycloak/blob/master/provider/generic_keycloak_identity_provider.go#L62 why default value of this is set to true when storing tokens is disabled by default?