### PR TITLE
Add possibility to delete default mappers for a ldap user federation resource

### DIFF
--- a/docs/resources/ldap_user_federation.md
+++ b/docs/resources/ldap_user_federation.md
@@ -95,7 +95,7 @@ resource "keycloak_ldap_user_federation" "ldap_user_federation" {
   - `server_principal` - (Required) The kerberos server principal, e.g. 'HTTP/host.foo.com@FOO.LOCAL'.
   - `key_tab` - (Required) Path to the kerberos keytab file on the server with credentials of the service principal.
   - `use_kerberos_for_password_authentication` - (Optional) Use kerberos login module instead of ldap service api. Defaults to `false`.
-
+- `default_mappers` - (Optional) If false, deletes the default mappers which are normally created when creating an LDAP user federation provider. Defaults to `true`.
 ## Import
 
 LDAP user federation providers can be imported using the format `{{realm_id}}/{{ldap_user_federation_id}}`.

--- a/example/main.tf
+++ b/example/main.tf
@@ -303,6 +303,45 @@ resource "keycloak_ldap_user_federation" "openldap" {
   }
 }
 
+
+resource "keycloak_ldap_user_federation" "openldap_no_default_mappers" {
+  name     = "openldap-no-default-mappers"
+  realm_id = keycloak_realm.test.id
+
+  enabled        = true
+  import_enabled = false
+
+  username_ldap_attribute = "cn"
+  rdn_ldap_attribute      = "cn"
+  uuid_ldap_attribute     = "entryDN"
+
+  user_object_classes = [
+    "simpleSecurityObject",
+    "organizationalRole",
+  ]
+
+  connection_url  = "ldap://openldap"
+  users_dn        = "dc=example,dc=org"
+  bind_dn         = "cn=admin,dc=example,dc=org"
+  bind_credential = "admin"
+
+  connection_timeout = "5s"
+  read_timeout       = "10s"
+
+  kerberos {
+    server_principal                         = "HTTP/keycloak.local@FOO.LOCAL"
+    use_kerberos_for_password_authentication = false
+    key_tab                                  = "/etc/keycloak.keytab"
+    kerberos_realm                           = "FOO.LOCAL"
+  }
+
+  cache {
+    policy = "NO_CACHE"
+  }
+
+  default_mappers = false
+}
+
 resource "keycloak_ldap_role_mapper" "ldap_role_mapper" {
   realm_id                = keycloak_realm.test.id
   ldap_user_federation_id = keycloak_ldap_user_federation.openldap.id

--- a/keycloak/component.go
+++ b/keycloak/component.go
@@ -1,5 +1,10 @@
 package keycloak
 
+import (
+	"context"
+	"fmt"
+)
+
 // https://www.keycloak.org/docs-api/4.2/rest-api/index.html#_component_resource
 
 type component struct {
@@ -25,4 +30,8 @@ func (component *component) getConfigOk(val string) (string, bool) {
 	}
 
 	return "", false
+}
+
+func (keycloakClient *KeycloakClient) DeleteComponent(ctx context.Context, realmId, id string) error {
+	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/components/%s", realmId, id), nil)
 }

--- a/keycloak/ldap_full_name_mapper.go
+++ b/keycloak/ldap_full_name_mapper.go
@@ -7,7 +7,7 @@ import (
 )
 
 type LdapFullNameMapper struct {
-	Id                   string
+	ComponentType
 	Name                 string
 	RealmId              string
 	LdapUserFederationId string
@@ -50,7 +50,9 @@ func convertFromComponentToLdapFullNameMapper(component *component, realmId stri
 	}
 
 	return &LdapFullNameMapper{
-		Id:                   component.Id,
+		ComponentType: ComponentType{
+			Id: component.Id,
+		},
 		Name:                 component.Name,
 		RealmId:              realmId,
 		LdapUserFederationId: component.ParentId,
@@ -109,5 +111,5 @@ func (keycloakClient *KeycloakClient) UpdateLdapFullNameMapper(ctx context.Conte
 }
 
 func (keycloakClient *KeycloakClient) DeleteLdapFullNameMapper(ctx context.Context, realmId, id string) error {
-	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/components/%s", realmId, id), nil)
+	return keycloakClient.DeleteComponent(ctx, realmId, id)
 }

--- a/keycloak/ldap_group_mapper.go
+++ b/keycloak/ldap_group_mapper.go
@@ -8,7 +8,7 @@ import (
 )
 
 type LdapGroupMapper struct {
-	Id                   string
+	ComponentType
 	Name                 string
 	RealmId              string
 	LdapUserFederationId string
@@ -115,7 +115,9 @@ func convertFromComponentToLdapGroupMapper(component *component, realmId string)
 	}
 
 	ldapGroupMapper := &LdapGroupMapper{
-		Id:                   component.Id,
+		ComponentType: ComponentType{
+			Id: component.Id,
+		},
 		Name:                 component.Name,
 		RealmId:              realmId,
 		LdapUserFederationId: component.ParentId,
@@ -186,5 +188,5 @@ func (keycloakClient *KeycloakClient) UpdateLdapGroupMapper(ctx context.Context,
 }
 
 func (keycloakClient *KeycloakClient) DeleteLdapGroupMapper(ctx context.Context, realmId, id string) error {
-	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/components/%s", realmId, id), nil)
+	return keycloakClient.DeleteComponent(ctx, realmId, id)
 }

--- a/keycloak/ldap_hardcoded_group_mapper.go
+++ b/keycloak/ldap_hardcoded_group_mapper.go
@@ -6,7 +6,7 @@ import (
 )
 
 type LdapHardcodedGroupMapper struct {
-	Id                   string
+	ComponentType
 	Name                 string
 	RealmId              string
 	LdapUserFederationId string
@@ -31,7 +31,9 @@ func convertFromLdapHardcodedGroupMapperToComponent(ldapMapper *LdapHardcodedGro
 
 func convertFromComponentToLdapHardcodedGroupMapper(component *component, realmId string) *LdapHardcodedGroupMapper {
 	return &LdapHardcodedGroupMapper{
-		Id:                   component.Id,
+		ComponentType: ComponentType{
+			Id: component.Id,
+		},
 		Name:                 component.Name,
 		RealmId:              realmId,
 		LdapUserFederationId: component.ParentId,
@@ -74,5 +76,5 @@ func (keycloakClient *KeycloakClient) UpdateLdapHardcodedGroupMapper(ctx context
 }
 
 func (keycloakClient *KeycloakClient) DeleteLdapHardcodedGroupMapper(ctx context.Context, realmId, id string) error {
-	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/components/%s", realmId, id), nil)
+	return keycloakClient.DeleteComponent(ctx, realmId, id)
 }

--- a/keycloak/ldap_hardcoded_role_mapper.go
+++ b/keycloak/ldap_hardcoded_role_mapper.go
@@ -6,7 +6,7 @@ import (
 )
 
 type LdapHardcodedRoleMapper struct {
-	Id                   string
+	ComponentType
 	Name                 string
 	RealmId              string
 	LdapUserFederationId string
@@ -31,7 +31,9 @@ func convertFromLdapHardcodedRoleMapperToComponent(ldapMapper *LdapHardcodedRole
 
 func convertFromComponentToLdapHardcodedRoleMapper(component *component, realmId string) *LdapHardcodedRoleMapper {
 	return &LdapHardcodedRoleMapper{
-		Id:                   component.Id,
+		ComponentType: ComponentType{
+			Id: component.Id,
+		},
 		Name:                 component.Name,
 		RealmId:              realmId,
 		LdapUserFederationId: component.ParentId,
@@ -74,5 +76,5 @@ func (keycloakClient *KeycloakClient) UpdateLdapHardcodedRoleMapper(ctx context.
 }
 
 func (keycloakClient *KeycloakClient) DeleteLdapHardcodedRoleMapper(ctx context.Context, realmId, id string) error {
-	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/components/%s", realmId, id), nil)
+	return keycloakClient.DeleteComponent(ctx, realmId, id)
 }

--- a/keycloak/ldap_msad_lds_user_account_control_mapper.go
+++ b/keycloak/ldap_msad_lds_user_account_control_mapper.go
@@ -6,7 +6,7 @@ import (
 )
 
 type LdapMsadLdsUserAccountControlMapper struct {
-	Id                   string
+	ComponentType
 	Name                 string
 	RealmId              string
 	LdapUserFederationId string
@@ -24,7 +24,9 @@ func convertFromLdapMsadLdsUserAccountControlMapperToComponent(ldapMsadLdsUserAc
 
 func convertFromComponentToLdapMsadLdsUserAccountControlMapper(component *component, realmId string) (*LdapMsadLdsUserAccountControlMapper, error) {
 	return &LdapMsadLdsUserAccountControlMapper{
-		Id:                   component.Id,
+		ComponentType: ComponentType{
+			Id: component.Id,
+		},
 		Name:                 component.Name,
 		RealmId:              realmId,
 		LdapUserFederationId: component.ParentId,
@@ -58,5 +60,5 @@ func (keycloakClient *KeycloakClient) UpdateLdapMsadLdsUserAccountControlMapper(
 }
 
 func (keycloakClient *KeycloakClient) DeleteLdapMsadLdsUserAccountControlMapper(ctx context.Context, realmId, id string) error {
-	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/components/%s", realmId, id), nil)
+	return keycloakClient.DeleteComponent(ctx, realmId, id)
 }

--- a/keycloak/ldap_msad_user_account_control_mapper.go
+++ b/keycloak/ldap_msad_user_account_control_mapper.go
@@ -7,7 +7,7 @@ import (
 )
 
 type LdapMsadUserAccountControlMapper struct {
-	Id                   string
+	ComponentType
 	Name                 string
 	RealmId              string
 	LdapUserFederationId string
@@ -37,7 +37,9 @@ func convertFromComponentToLdapMsadUserAccountControlMapper(component *component
 	}
 
 	return &LdapMsadUserAccountControlMapper{
-		Id:                   component.Id,
+		ComponentType: ComponentType{
+			Id: component.Id,
+		},
 		Name:                 component.Name,
 		RealmId:              realmId,
 		LdapUserFederationId: component.ParentId,
@@ -73,5 +75,5 @@ func (keycloakClient *KeycloakClient) UpdateLdapMsadUserAccountControlMapper(ctx
 }
 
 func (keycloakClient *KeycloakClient) DeleteLdapMsadUserAccountControlMapper(ctx context.Context, realmId, id string) error {
-	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/components/%s", realmId, id), nil)
+	return keycloakClient.DeleteComponent(ctx, realmId, id)
 }

--- a/keycloak/ldap_role_mapper.go
+++ b/keycloak/ldap_role_mapper.go
@@ -8,7 +8,7 @@ import (
 )
 
 type LdapRoleMapper struct {
-	Id                   string
+	ComponentType
 	Name                 string
 	RealmId              string
 	LdapUserFederationId string
@@ -91,7 +91,9 @@ func convertFromComponentToLdapRoleMapper(component *component, realmId string) 
 	}
 
 	ldapRoleMapper := &LdapRoleMapper{
-		Id:                   component.Id,
+		ComponentType: ComponentType{
+			Id: component.Id,
+		},
 		Name:                 component.Name,
 		RealmId:              realmId,
 		LdapUserFederationId: component.ParentId,
@@ -146,5 +148,5 @@ func (keycloakClient *KeycloakClient) UpdateLdapRoleMapper(ctx context.Context, 
 }
 
 func (keycloakClient *KeycloakClient) DeleteLdapRoleMapper(ctx context.Context, realmId, id string) error {
-	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/components/%s", realmId, id), nil)
+	return keycloakClient.DeleteComponent(ctx, realmId, id)
 }

--- a/keycloak/ldap_user_attribute_mapper.go
+++ b/keycloak/ldap_user_attribute_mapper.go
@@ -7,7 +7,7 @@ import (
 )
 
 type LdapUserAttributeMapper struct {
-	Id                   string
+	ComponentType
 	Name                 string
 	RealmId              string
 	LdapUserFederationId string
@@ -63,7 +63,9 @@ func convertFromComponentToLdapUserAttributeMapper(component *component, realmId
 	}
 
 	return &LdapUserAttributeMapper{
-		Id:                   component.Id,
+		ComponentType: ComponentType{
+			Id: component.Id,
+		},
 		Name:                 component.Name,
 		RealmId:              realmId,
 		LdapUserFederationId: component.ParentId,
@@ -103,5 +105,5 @@ func (keycloakClient *KeycloakClient) UpdateLdapUserAttributeMapper(ctx context.
 }
 
 func (keycloakClient *KeycloakClient) DeleteLdapUserAttributeMapper(ctx context.Context, realmId, id string) error {
-	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/components/%s", realmId, id), nil)
+	return keycloakClient.DeleteComponent(ctx, realmId, id)
 }

--- a/keycloak/ldap_user_federation.go
+++ b/keycloak/ldap_user_federation.go
@@ -55,6 +55,8 @@ type LdapUserFederation struct {
 	EvictionDay    *int
 	EvictionHour   *int
 	EvictionMinute *int
+
+	DefaultMappers bool
 }
 
 func convertFromLdapUserFederationToComponent(ldap *LdapUserFederation) (*component, error) {

--- a/provider/resource_keycloak_ldap_full_name_mapper.go
+++ b/provider/resource_keycloak_ldap_full_name_mapper.go
@@ -57,7 +57,9 @@ func resourceKeycloakLdapFullNameMapper() *schema.Resource {
 
 func getLdapFullNameMapperFromData(data *schema.ResourceData) *keycloak.LdapFullNameMapper {
 	return &keycloak.LdapFullNameMapper{
-		Id:                   data.Id(),
+		ComponentType: keycloak.ComponentType{
+			Id: data.Get("id").(string),
+		},
 		Name:                 data.Get("name").(string),
 		RealmId:              data.Get("realm_id").(string),
 		LdapUserFederationId: data.Get("ldap_user_federation_id").(string),

--- a/provider/resource_keycloak_ldap_group_mapper.go
+++ b/provider/resource_keycloak_ldap_group_mapper.go
@@ -136,7 +136,9 @@ func getLdapGroupMapperFromData(ctx context.Context, keycloakClient *keycloak.Ke
 	}
 
 	mapper := &keycloak.LdapGroupMapper{
-		Id:                   data.Id(),
+		ComponentType: keycloak.ComponentType{
+			Id: data.Id(),
+		},
 		Name:                 data.Get("name").(string),
 		RealmId:              data.Get("realm_id").(string),
 		LdapUserFederationId: data.Get("ldap_user_federation_id").(string),

--- a/provider/resource_keycloak_ldap_hardcoded_group_mapper.go
+++ b/provider/resource_keycloak_ldap_hardcoded_group_mapper.go
@@ -47,7 +47,9 @@ func resourceKeycloakLdapHardcodedGroupMapper() *schema.Resource {
 
 func getLdapHardcodedGroupMapperFromData(data *schema.ResourceData) *keycloak.LdapHardcodedGroupMapper {
 	return &keycloak.LdapHardcodedGroupMapper{
-		Id:                   data.Id(),
+		ComponentType: keycloak.ComponentType{
+			Id: data.Id(),
+		},
 		Name:                 data.Get("name").(string),
 		RealmId:              data.Get("realm_id").(string),
 		LdapUserFederationId: data.Get("ldap_user_federation_id").(string),

--- a/provider/resource_keycloak_ldap_hardcoded_role_mapper.go
+++ b/provider/resource_keycloak_ldap_hardcoded_role_mapper.go
@@ -47,7 +47,9 @@ func resourceKeycloakLdapHardcodedRoleMapper() *schema.Resource {
 
 func getLdapHardcodedRoleMapperFromData(data *schema.ResourceData) *keycloak.LdapHardcodedRoleMapper {
 	return &keycloak.LdapHardcodedRoleMapper{
-		Id:                   data.Id(),
+		ComponentType: keycloak.ComponentType{
+			Id: data.Id(),
+		},
 		Name:                 data.Get("name").(string),
 		RealmId:              data.Get("realm_id").(string),
 		LdapUserFederationId: data.Get("ldap_user_federation_id").(string),

--- a/provider/resource_keycloak_ldap_msad_lds_user_account_control_mapper.go
+++ b/provider/resource_keycloak_ldap_msad_lds_user_account_control_mapper.go
@@ -41,7 +41,9 @@ func resourceKeycloakLdapMsadLdsUserAccountControlMapper() *schema.Resource {
 
 func getLdapMsadLdsUserAccountControlMapperFromData(data *schema.ResourceData) *keycloak.LdapMsadLdsUserAccountControlMapper {
 	return &keycloak.LdapMsadLdsUserAccountControlMapper{
-		Id:                   data.Id(),
+		ComponentType: keycloak.ComponentType{
+			Id: data.Id(),
+		},
 		Name:                 data.Get("name").(string),
 		RealmId:              data.Get("realm_id").(string),
 		LdapUserFederationId: data.Get("ldap_user_federation_id").(string),

--- a/provider/resource_keycloak_ldap_msad_user_account_control_mapper.go
+++ b/provider/resource_keycloak_ldap_msad_user_account_control_mapper.go
@@ -46,7 +46,9 @@ func resourceKeycloakLdapMsadUserAccountControlMapper() *schema.Resource {
 
 func getLdapMsadUserAccountControlMapperFromData(data *schema.ResourceData) *keycloak.LdapMsadUserAccountControlMapper {
 	return &keycloak.LdapMsadUserAccountControlMapper{
-		Id:                   data.Id(),
+		ComponentType: keycloak.ComponentType{
+			Id: data.Id(),
+		},
 		Name:                 data.Get("name").(string),
 		RealmId:              data.Get("realm_id").(string),
 		LdapUserFederationId: data.Get("ldap_user_federation_id").(string),

--- a/provider/resource_keycloak_ldap_role_mapper.go
+++ b/provider/resource_keycloak_ldap_role_mapper.go
@@ -114,7 +114,9 @@ func getLdapRoleMapperFromData(data *schema.ResourceData) *keycloak.LdapRoleMapp
 	}
 
 	return &keycloak.LdapRoleMapper{
-		Id:                   data.Id(),
+		ComponentType: keycloak.ComponentType{
+			Id: data.Id(),
+		},
 		Name:                 data.Get("name").(string),
 		RealmId:              data.Get("realm_id").(string),
 		LdapUserFederationId: data.Get("ldap_user_federation_id").(string),

--- a/provider/resource_keycloak_ldap_user_attribute_mapper.go
+++ b/provider/resource_keycloak_ldap_user_attribute_mapper.go
@@ -69,7 +69,9 @@ func resourceKeycloakLdapUserAttributeMapper() *schema.Resource {
 
 func getLdapUserAttributeMapperFromData(data *schema.ResourceData) *keycloak.LdapUserAttributeMapper {
 	return &keycloak.LdapUserAttributeMapper{
-		Id:                   data.Id(),
+		ComponentType: keycloak.ComponentType{
+			Id: data.Id(),
+		},
 		Name:                 data.Get("name").(string),
 		RealmId:              data.Get("realm_id").(string),
 		LdapUserFederationId: data.Get("ldap_user_federation_id").(string),

--- a/provider/resource_keycloak_ldap_user_federation.go
+++ b/provider/resource_keycloak_ldap_user_federation.go
@@ -285,6 +285,13 @@ func resourceKeycloakLdapUserFederation() *schema.Resource {
 					},
 				},
 			},
+			"default_mappers": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				ForceNew:    true,
+				Description: "If disabled, all default mappers will be deleted.",
+			},
 		},
 	}
 }
@@ -345,6 +352,8 @@ func getLdapUserFederationFromData(data *schema.ResourceData, realmInternalId st
 		BatchSizeForSync:  data.Get("batch_size_for_sync").(int),
 		FullSyncPeriod:    data.Get("full_sync_period").(int),
 		ChangedSyncPeriod: data.Get("changed_sync_period").(int),
+
+		DefaultMappers: data.Get("default_mappers").(bool),
 	}
 
 	if cache, ok := data.GetOk("cache"); ok {
@@ -451,6 +460,8 @@ func setLdapUserFederationData(data *schema.ResourceData, ldap *keycloak.LdapUse
 
 		data.Set("cache", []interface{}{cachePolicySettings})
 	}
+
+	data.Set("default_mappers", ldap.DefaultMappers)
 }
 
 func resourceKeycloakLdapUserFederationCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -473,6 +484,13 @@ func resourceKeycloakLdapUserFederationCreate(ctx context.Context, data *schema.
 	err = keycloakClient.NewLdapUserFederation(ctx, realmId, ldap)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	if !ldap.DefaultMappers {
+		err = deleteDefaultMappers(ctx, realmId, ldap.Id, keycloakClient)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	setLdapUserFederationData(data, ldap, realmId)
@@ -565,4 +583,21 @@ func resourceKeycloakLdapUserFederationImport(ctx context.Context, d *schema.Res
 	}
 
 	return []*schema.ResourceData{d}, nil
+}
+
+func deleteDefaultMappers(ctx context.Context, realmId string, ldapUserFederationId string, keycloakClient *keycloak.KeycloakClient) error {
+	mappers, _ := keycloakClient.GetLdapUserFederationMappers(ctx, realmId, ldapUserFederationId)
+	if mappers != nil {
+		for _, mapper := range *mappers {
+			component, ok := mapper.(*keycloak.ComponentType)
+			if !ok {
+				return fmt.Errorf("invalid mapper type: %T", mapper)
+			}
+			err := keycloakClient.DeleteComponent(ctx, realmId, component.Id)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This pull requests resolve the issue https://github.com/mrparkers/terraform-provider-keycloak/issues/729.

The property `default_mappers` was added to the `keycloak_ldap_user_federation` indicating whether the default mappers should be created or not. The default is true.

Closes https://github.com/mrparkers/terraform-provider-keycloak/issues/729