### PR TITLE
Add RSA_SHA256_MGF1 / RSA_SHA512_MGF1 SignatureAlgorithm to resourceK…

### DIFF
--- a/docs/resources/saml_client.md
+++ b/docs/resources/saml_client.md
@@ -48,7 +48,7 @@ resource "keycloak_saml_client" "saml_client" {
 - `front_channel_logout` - (Optional) When `true`, this client will require a browser redirect in order to perform a logout. Defaults to `true`.
 - `name_id_format` - (Optional) Sets the Name ID format for the subject.
 - `force_name_id_format` - (Optional) Ignore requested NameID subject format and use the one defined in `name_id_format` instead. Defaults to `false`.
-- `signature_algorithm` - (Optional) The signature algorithm used to sign documents. Should be one of "RSA_SHA1", "RSA_SHA256", "RSA_SHA512", or "DSA_SHA1".
+- `signature_algorithm` - (Optional) The signature algorithm used to sign documents. Should be one of "RSA_SHA1", "RSA_SHA256", "RSA_SHA256_MGF1, "RSA_SHA512", "RSA_SHA512_MGF1" or "DSA_SHA1".
 - `signature_key_name` - (Optional) The value of the `KeyName` element within the signed SAML document. Should be one of "NONE", "KEY_ID", or "CERT_SUBJECT". Defaults to "KEY_ID".
 - `canonicalization_method` - (Optional) The Canonicalization Method for XML signatures. Should be one of "EXCLUSIVE", "EXCLUSIVE_WITH_COMMENTS", "INCLUSIVE", or "INCLUSIVE_WITH_COMMENTS". Defaults to "EXCLUSIVE".
 - `root_url` - (Optional) When specified, this value is prepended to all relative URLs.

--- a/provider/resource_keycloak_saml_client.go
+++ b/provider/resource_keycloak_saml_client.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	keycloakSamlClientNameIdFormats           = []string{"username", "email", "transient", "persistent"}
-	keycloakSamlClientSignatureAlgorithms     = []string{"RSA_SHA1", "RSA_SHA256", "RSA_SHA512", "DSA_SHA1"}
+	keycloakSamlClientSignatureAlgorithms     = []string{"RSA_SHA1", "RSA_SHA256", "RSA_SHA256_MGF1", "RSA_SHA512", "RSA_SHA512_MGF1", "DSA_SHA1"}
 	keycloakSamlClientSignatureKeyNames       = []string{"NONE", "KEY_ID", "CERT_SUBJECT"}
 	keycloakSamlClientCanonicalizationMethods = map[string]string{
 		"EXCLUSIVE":               "http://www.w3.org/2001/10/xml-exc-c14n#",


### PR DESCRIPTION
SAML Provider is missing SignatureAlgorithm RSA_SHA256_MGF1 and RSA_SHA512_MGF1

Would be nice to have a new release soon including the two algorithms. 

Thanks,
Sven