### PR TITLE
feat: support role IDs in default role resource

### DIFF
--- a/keycloak/default_roles.go
+++ b/keycloak/default_roles.go
@@ -6,14 +6,15 @@ import (
 )
 
 type DefaultRoles struct {
-	Id           string   `json:"id,omitempty"`
-	RealmId      string   `json:"-"`
-	DefaultRoles []string `json:"-"`
+	Id             string   `json:"id,omitempty"`
+	RealmId        string   `json:"-"`
+	DefaultRoles   []string `json:"-"`
+	DefaultRoleIds []string `json:"-"`
 }
 
 func (keycloakClient *KeycloakClient) GetDefaultRoles(ctx context.Context, realmId, id string) ([]*Role, error) {
 	var composites []*Role
-	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/roles-by-id/%s/composites/realm", realmId, id), &composites, nil)
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/roles-by-id/%s/composites", realmId, id), &composites, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/resource_keycloak_default_roles_test.go
+++ b/provider/resource_keycloak_default_roles_test.go
@@ -2,11 +2,12 @@ package provider
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
-	"testing"
 )
 
 func TestAccKeycloakDefaultRoles_basic(t *testing.T) {
@@ -84,7 +85,7 @@ func testAccCheckKeycloakDefaultRolesDestroy(realmId string) resource.TestCheckF
 			return fmt.Errorf("error getting defaultRoles with id %s: %s", realm.DefaultRole.Id, err)
 		}
 
-		defaultRoles := getDefaultRoleNames(composites)
+		defaultRoles, _ := getDefaultRoles(composites)
 		if err != nil {
 			return err
 		}
@@ -110,7 +111,7 @@ func getKeycloakDefaultRolesFromState(s *terraform.State, resourceName string) (
 		return nil, fmt.Errorf("error getting defaultRoles with id %s: %s", id, err)
 	}
 
-	defaultRoleNamesList := getDefaultRoleNames(composites)
+	defaultRoleNamesList, _ := getDefaultRoles(composites)
 
 	defaultRoles := &keycloak.DefaultRoles{
 		Id:           id,


### PR DESCRIPTION
Currently only the realm roles are allowed to be added, however some of the client roles could be found in a fresh installation, taking this as an example:

<img width="885" alt="Screenshot 2022-11-09 at 16 37 05" src="https://user-images.githubusercontent.com/92146/200780867-16449f1b-f79f-4dc1-896b-fc977c7dd2bb.png">

The last 2 roles are unmanageable with the following configuration:

```hcl
resource "keycloak_default_roles" "default_roles" {
    realm_id      = keycloak_realm.realm.id
    default_roles = ["uma_authorization", "offline_access", "view-profile", "manage-account"]
}
```

This PR, if accepted, will add a new _optional_ attribute called `default_role_ids` which is a list of UUIDs of the specific roles you want to have in your default role:

```hcl
resource "keycloak_default_roles" "default_roles" {
   realm_id      = keycloak_realm.realm.id
   default_roles = ["uma_authorization", "offline_access" ]
   default_role_ids = [
     "8550facd-b29e-4da9-beca-ca2cd5673b20", # view-profile
     "8696cdda-8403-4ab7-bdc9-a1131f02e3ee", # manage-account
   ]
 }
```

We could obtain the original behavior of the resource when omitted (as if it's an empty list).