### PR TITLE
Added missing mode 'IMPORT' in 'resource_keycloak_ldap_role_mapper'

### DIFF
--- a/provider/resource_keycloak_ldap_role_mapper.go
+++ b/provider/resource_keycloak_ldap_role_mapper.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	keycloakLdapRoleMapperModes                       = []string{"READ_ONLY", "LDAP_ONLY"}
+	keycloakLdapRoleMapperModes                       = []string{"READ_ONLY", "LDAP_ONLY", "IMPORT"}
 	keycloakLdapRoleMapperMembershipAttributeTypes    = []string{"DN", "UID"}
 	keycloakLdapRoleMapperUserRolesRetrieveStrategies = []string{"LOAD_ROLES_BY_MEMBER_ATTRIBUTE", "GET_ROLES_FROM_USER_MEMBEROF_ATTRIBUTE", "LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY"}
 )


### PR DESCRIPTION
This PR fixes issue #767 https://github.com/mrparkers/terraform-provider-keycloak/issues/767