### PR TITLE
fix: use payload when deleting keycloak_generic_role_mapper for realm roles

### DIFF
--- a/keycloak/role_scope_mapping.go
+++ b/keycloak/role_scope_mapping.go
@@ -5,6 +5,15 @@ import (
 	"fmt"
 )
 
+type RealmRoleScopeMapping struct {
+	Id          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Composite   bool   `json:"composite"`
+	ClientRole  bool   `json:"clientRole"`
+	ContainerId string `json:"containerId"`
+}
+
 func roleScopeMappingUrl(realmId, clientId string, clientScopeId string, role *Role) string {
 	if clientId != "" {
 		if role.ClientRole {
@@ -52,5 +61,19 @@ func (keycloakClient *KeycloakClient) GetRoleScopeMapping(ctx context.Context, r
 
 func (keycloakClient *KeycloakClient) DeleteRoleScopeMapping(ctx context.Context, realmId string, clientId string, clientScopeId string, role *Role) error {
 	roleUrl := roleScopeMappingUrl(realmId, clientId, clientScopeId, role)
-	return keycloakClient.delete(ctx, roleUrl, nil)
+	if role.ClientRole {
+		return keycloakClient.delete(ctx, roleUrl, nil)
+	} else {
+		body := [1]RealmRoleScopeMapping{
+			{
+				Id:          role.Id,
+				Name:        role.Name,
+				Description: role.Description,
+				Composite:   role.Composite,
+				ClientRole:  role.ClientRole,
+				ContainerId: role.ContainerId,
+			},
+		}
+		return keycloakClient.delete(ctx, roleUrl, body)
+	}
 }

--- a/keycloak/role_scope_mapping.go
+++ b/keycloak/role_scope_mapping.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-type RealmRoleScopeMapping struct {
+type RealmRoleRepresentation struct {
 	Id          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
@@ -64,7 +64,7 @@ func (keycloakClient *KeycloakClient) DeleteRoleScopeMapping(ctx context.Context
 	if role.ClientRole {
 		return keycloakClient.delete(ctx, roleUrl, nil)
 	} else {
-		body := [1]RealmRoleScopeMapping{
+		body := [1]RealmRoleRepresentation{
 			{
 				Id:          role.Id,
 				Name:        role.Name,


### PR DESCRIPTION
Fixes: #771

Everything I've added here is based on what I've seen Keycloak do when performing this action in the UI.

The test itself indirectly catches the misbehaviour described in the issue by failing due to the fact that there's a non-empty intermediate plan occurring during the test case itself. That plan is the creation of the resources that had never actually been explicitly destroyed in the first place.

I hope this is sufficient. 