### PR TITLE
fix: allow users with backslashes in their name to be assigned to groups via keycloak_group_memberships

### DIFF
--- a/keycloak/user.go
+++ b/keycloak/user.go
@@ -138,7 +138,7 @@ func (keycloakClient *KeycloakClient) GetUserByUsername(ctx context.Context, rea
 	var users []*User
 
 	params := map[string]string{
-		"username": username,
+		"username": escapeBackslashes(username),
 	}
 
 	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/users", realmId), &users, params)

--- a/keycloak/util.go
+++ b/keycloak/util.go
@@ -49,3 +49,7 @@ func atoiAndTreatEmptyStringAsZero(s string) (int, error) {
 
 	return strconv.Atoi(s)
 }
+
+func escapeBackslashes(s string) string {
+	return strings.ReplaceAll(s, "\\", "\\\\")
+}

--- a/provider/resource_keycloak_group_memberships_test.go
+++ b/provider/resource_keycloak_group_memberships_test.go
@@ -35,6 +35,24 @@ func TestAccKeycloakGroupMemberships_basic(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakGroupMemberships_basicUserWithBackslash(t *testing.T) {
+	t.Parallel()
+
+	groupName := acctest.RandomWithPrefix("tf-acc")
+	username := acctest.RandString(5) + `\\` + acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakGroupMemberships_basic(groupName, username),
+				Check:  testAccCheckUserBelongsToGroup("keycloak_group_memberships.group_members", strings.ReplaceAll(username, `\\`, `\`)),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakGroupMemberships_moreThan100members(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #774