### PR TITLE
Handle nested group paths as names

### DIFF
--- a/provider/data_source_keycloak_group_test.go
+++ b/provider/data_source_keycloak_group_test.go
@@ -152,5 +152,15 @@ data "keycloak_group" "group_nested" {
 		keycloak_group.group_nested
 	]
 }
+
+data "keycloak_group" "group_nested_by_path" {
+	realm_id = data.keycloak_realm.realm.id
+	name = "/${keycloak_group.group.name}/${keycloak_group.group_nested.name}"
+
+	depends_on = [
+		keycloak_group.group,
+		keycloak_group.group_nested
+	]
+}
 	`, testAccRealm.Realm, group, groupNested)
 }


### PR DESCRIPTION
We're trying to manage nested groups via Terraform. Our nested group hierarchy mirrored by this YAML:

``` yaml
teams:
 team-foo:
   read-only:
   developer:
   admin:
 team-bar:
   read-only:
   developer:
   admin:
```

Unfortunately, when attempting to query a group by path with provider 3.10.0 and 4.1.0 fails with the following message:

```
│ Error: no group with name /teams/team-foo/admin found
│ 
│   with data.keycloak_group.admin_groups["/teams/team-foo/admin"],
│   on .terraform/modules/dummy/main.tf line 1, in data "keycloak_group" "admin_groups":
│    1: data "keycloak_group" "admin_groups" {
│ 
```

Digging deeper it seems that the `search` parameter used [here](https://github.com/mrparkers/terraform-provider-keycloak/blob/aec21154d7ae77fcfc14db303bef5e1cc2e07036/keycloak/group.go#L135) is not returning any results when searching for the group by path.

I followed along with [#333](https://github.com/mrparkers/terraform-provider-keycloak/issues/333) and [#334](https://github.com/mrparkers/terraform-provider-keycloak/pull/334) but in our case we can't search by 'group name' as there will be multiple indistinguishable yet unique groups returned.

This is a possibly inefficient implementation of handling group paths - if `name` starts with a backslash it assumes that `name` is actually a `path` and to search subgroups downward from the first group specified in the path until it either finds the group specified at the end of the path or comes up empty handed.