### PR TITLE
Manually set realm ID

### DIFF
--- a/docs/resources/realm.md
+++ b/docs/resources/realm.md
@@ -82,7 +82,7 @@ resource "keycloak_realm" "realm" {
 - `enabled` - (Optional) When `false`, users and clients will not be able to access this realm. Defaults to `true`.
 - `display_name` - (Optional) The display name for the realm that is shown when logging in to the admin console.
 - `display_name_html` - (Optional) The display name for the realm that is rendered as HTML on the screen when logging in to the admin console.
-- `user_managed_access` - (Optional) When `true`, users are allowed to manage their own resources. Defaults to `false`. 
+- `user_managed_access` - (Optional) When `true`, users are allowed to manage their own resources. Defaults to `false`.
 - `attributes` - (Optional) A map of custom attributes to add to the realm.
 
 ### Login Settings
@@ -240,7 +240,7 @@ Each of these attributes are blocks with the following attributes:
 
 ## Attributes Reference
 
-- `internal_id` - (Computed) When importing realms created outside of this terraform provider, they could use generated arbitrary IDs for the internal realm id. Realms created by this provider always use the realm's name for its internal id.
+- `internal_id` - (Optional) When importing realms created outside of this terraform provider, they could use generated arbitrary IDs for the internal realm id. Realms created by this provider use the realm's name for its internal id unless the internal id is explicitly set.
 
 ## Default Client Scopes
 

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -157,7 +157,7 @@ func resourceKeycloakRealm() *schema.Resource {
 			},
 			"internal_id": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,
@@ -1165,7 +1165,9 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm) {
 	data.SetId(realm.Realm)
 
 	data.Set("realm", realm.Realm)
-	data.Set("internal_id", realm.Id)
+	if realm.Id != realm.Realm {
+		data.Set("internal_id", realm.Id)
+	}
 	data.Set("enabled", realm.Enabled)
 	data.Set("display_name", realm.DisplayName)
 	data.Set("display_name_html", realm.DisplayNameHtml)
@@ -1423,5 +1425,10 @@ func resourceKeycloakRealmUpdate(ctx context.Context, data *schema.ResourceData,
 func resourceKeycloakRealmDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
-	return diag.FromErr(keycloakClient.DeleteRealm(ctx, data.Id()))
+	realm, err := getRealmFromData(data)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.FromErr(keycloakClient.DeleteRealm(ctx, realm.Realm))
 }


### PR DESCRIPTION
A step forward to address issue #634 

I want to allow the usage of all realm names that are currently not used. Due to Keycloaks "feature" to use the realm names for the ID, I'd additionally need to deny the usage of all realm names that were used at creation time and I'd like to avoid that.

* Changes the internal_id from 'Computed' to 'Optional' to allow setting it externally to a UUID
* Avoids setting ResourceData's internal_id to null when it is not passed in setRealmData() to avoid endless updates from the ID to null
* Retrieves the realm name when deleting realms since the Keycloak API relies on it and with the change the realm ID might differ from the name

Successfully tested with 

```go
locals {
  realms = {
    "abc" = {},
    "def" = {}
  }
}

resource "keycloak_realm" "id_realm" {
  for_each     = local.realms
  internal_id  = "my-${each.key}-id"
  realm        = "my-id-${each.key}-realm-name"
}

resource "keycloak_realm" "name_realm" {
  for_each     = local.realms
  realm        = "my-named-${each.key}-realm"
}
```

@mrparkers @dmeyerholt please have a look