### PR TITLE
#798 fix for parsing empty bool that leads to error.

### DIFF
--- a/keycloak/custom_user_federation.go
+++ b/keycloak/custom_user_federation.go
@@ -56,7 +56,7 @@ func convertFromCustomUserFederationToComponent(custom *CustomUserFederation) *c
 }
 
 func convertFromComponentToCustomUserFederation(component *component, realmName string) (*CustomUserFederation, error) {
-	enabled, err := strconv.ParseBool(component.getConfig("enabled"))
+	enabled, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("enabled"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Implemented fix for #798 where parsing an empty bool leads to an error. 
Similar error as in #782 and #684