### PR TITLE
fix: avoid validation errors during plan for missing realm and openid client resources 

### DIFF
--- a/keycloak/openid_client.go
+++ b/keycloak/openid_client.go
@@ -241,9 +241,7 @@ func (keycloakClient *KeycloakClient) getOpenidClientScopes(ctx context.Context,
 	var scopes []*OpenidClientScope
 
 	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/clients/%s/%s-client-scopes", realmId, clientId, t), &scopes, nil)
-	if err != nil && ErrorIs404(err) {
-		return nil, fmt.Errorf("validation error: client with id %s does not exist", clientId)
-	} else if err != nil {
+	if err != nil {
 		return nil, err
 	}
 

--- a/provider/resource_keycloak_generic_role_mapper.go
+++ b/provider/resource_keycloak_generic_role_mapper.go
@@ -86,7 +86,7 @@ func resourceKeycloakGenericRoleMapperRead(ctx context.Context, data *schema.Res
 
 	role, err := keycloakClient.GetRole(ctx, realmId, roleId)
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(ctx, err, data)
 	}
 
 	mappedRole, err := keycloakClient.GetRoleScopeMapping(ctx, realmId, clientId, clientScopeId, role)

--- a/provider/resource_keycloak_openid_client_default_scopes.go
+++ b/provider/resource_keycloak_openid_client_default_scopes.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
@@ -70,6 +71,9 @@ func resourceKeycloakOpenidClientDefaultScopesReconcile(ctx context.Context, dat
 
 	keycloakOpenidClientDefaultScopes, err := keycloakClient.GetOpenidClientDefaultScopes(ctx, realmId, clientId)
 	if err != nil {
+		if keycloak.ErrorIs404(err) {
+			return diag.FromErr(fmt.Errorf("validation error: client with id %s does not exist", clientId))
+		}
 		return diag.FromErr(err)
 	}
 

--- a/provider/resource_keycloak_openid_client_optional_scopes.go
+++ b/provider/resource_keycloak_openid_client_optional_scopes.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
@@ -70,6 +71,9 @@ func resourceKeycloakOpenidClientOptionalScopesReconcile(ctx context.Context, da
 
 	keycloakOpenidClientOptionalScopes, err := keycloakClient.GetOpenidClientOptionalScopes(ctx, realmId, clientId)
 	if err != nil {
+		if keycloak.ErrorIs404(err) {
+			return diag.FromErr(fmt.Errorf("validation error: client with id %s does not exist", clientId))
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
Fixes #738

This brings the 404 handling of missing OpenID clients in line with the implementation for missing SAML clients when resolving client scopes. Basically, the validation of the 404 response was occurring too early, and the read context was throwing instead of return a blank ID via the `handleNotFound` handler.

This also includes a similar fix for `generic_role_mapper` resources.

The way that I tested these fixes was to configure a realm using these resource types, and run `terraform refresh` after manually deleting the realm.