### PR TITLE
Add missing page_title in docs

### DIFF
--- a/docs/resources/openid_client_authorization_permission.md
+++ b/docs/resources/openid_client_authorization_permission.md
@@ -1,4 +1,8 @@
-# keycloak_openid_client_authorization_permission
+---
+page_title: "keycloak_openid_client_authorization_permission Resource"
+---
+
+# keycloak\_openid\_client\_authorization\_permission Resource
 
 Allows you to manage openid Client Authorization Permissions.
 

--- a/docs/resources/openid_client_permissions.md
+++ b/docs/resources/openid_client_permissions.md
@@ -1,4 +1,8 @@
-# keycloak_openid_client_permissions
+---
+page_title: "keycloak_openid_client_permissions Resource"
+---
+
+# keycloak\_openid\_client\_permissions Resource
 
 Allows you to manage all openid client Scope Based Permissions.
 


### PR DESCRIPTION
This PR adds some missing page_titles in the docs. These are required for the upjet-provider-template. For more details see https://github.com/upbound/upjet-provider-template/issues/32