### PR TITLE
feat: Add required_actions attribute to keycloak_user

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -62,6 +62,7 @@ resource "keycloak_user" "user_with_initial_password" {
 - `first_name` - (Optional) The user's first name.
 - `last_name` - (Optional) The user's last name.
 - `attributes` - (Optional) A map representing attributes for the user. In order to add multivalue attributes, use `##` to seperate the values. Max length for each value is 255 chars
+- `required_actions` - (Optional) A list of required user actions. 
 - `federated_identity` - (Optional) When specified, the user will be linked to a federated identity provider. Refer to the [federated user example](https://github.com/mrparkers/terraform-provider-keycloak/blob/master/example/federated_user_example.tf) for more details.
   - `identity_provider` - (Required) The name of the identity provider
   - `user_id` - (Required) The ID of the user defined in the identity provider

--- a/keycloak/user.go
+++ b/keycloak/user.go
@@ -25,6 +25,7 @@ type User struct {
 	Enabled             bool                `json:"enabled"`
 	Attributes          map[string][]string `json:"attributes"`
 	FederatedIdentities FederatedIdentities `json:"federatedIdentities"`
+	RequiredActions     []string            `json:"requiredActions"`
 }
 
 type PasswordCredentials struct {
@@ -35,15 +36,16 @@ type PasswordCredentials struct {
 
 func (keycloakClient *KeycloakClient) NewUser(ctx context.Context, user *User) error {
 	newUser := User{
-		Id:            user.Id,
-		RealmId:       user.RealmId,
-		Username:      user.Username,
-		Email:         user.Email,
-		EmailVerified: user.EmailVerified,
-		FirstName:     user.FirstName,
-		LastName:      user.LastName,
-		Enabled:       user.Enabled,
-		Attributes:    user.Attributes,
+		Id:              user.Id,
+		RealmId:         user.RealmId,
+		Username:        user.Username,
+		Email:           user.Email,
+		EmailVerified:   user.EmailVerified,
+		FirstName:       user.FirstName,
+		LastName:        user.LastName,
+		Enabled:         user.Enabled,
+		Attributes:      user.Attributes,
+		RequiredActions: user.RequiredActions,
 	}
 	_, location, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/users", user.RealmId), newUser)
 	if err != nil {

--- a/provider/data_source_keycloak_openid_client_service_account_user.go
+++ b/provider/data_source_keycloak_openid_client_service_account_user.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
@@ -45,6 +46,11 @@ func dataSourceKeycloakOpenidClientServiceAccountUser() *schema.Resource {
 			},
 			"attributes": {
 				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"required_actions": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
 			},
 			"federated_identity": {

--- a/provider/data_source_keycloak_user.go
+++ b/provider/data_source_keycloak_user.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
@@ -37,6 +38,11 @@ func dataSourceKeycloakUser() *schema.Resource {
 			},
 			"attributes": {
 				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"required_actions": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
 			},
 			"federated_identity": {


### PR DESCRIPTION
Add an option to set Required Actions on a per-user basis, like this:

```
resource "keycloak_user" "this" {
  username = "my-user"

  required_actions = ["CONFIGURE_TOTP"]
}
```