### PR TITLE
docs: add documentation for importing oidc_google_identity_provider.md

### DIFF
--- a/docs/resources/oidc_google_identity_provider.md
+++ b/docs/resources/oidc_google_identity_provider.md
@@ -62,4 +62,10 @@ resource "keycloak_oidc_google_identity_provider" "google" {
 
 ## Import
 
-This resource does not yet support importing.
+Google Identity providers can be imported using the format {{realm_id}}/{{idp_alias}}, where idp_alias is the identity provider alias.
+
+Example:
+
+```bash
+$ terraform import keycloak_oidc_google_identity_provider.google.google_identity_provider my-realm/my-google-idp
+```


### PR DESCRIPTION
I did import successfully my Google IDP while the documentation states it is not supported.

This PR updates the `Import` chapter to add instructions.

Note: reading the code, it looks like the Google IDP resource is using the Generic IDP importer (cf https://github.com/mrparkers/terraform-provider-keycloak/blob/bfee4d7cd1591b015f4db84cce12bea36b6e871f/provider/resource_keycloak_oidc_google_identity_provider.go#L81C32-L81C32 and https://github.com/mrparkers/terraform-provider-keycloak/blob/bfee4d7cd1591b015f4db84cce12bea36b6e871f/provider/generic_keycloak_identity_provider.go#L26C4-L26C4)