### PR TITLE
feat: allow users to set 'referrer_policy' header in the 'security_defenses' realm section

### DIFF
--- a/docs/resources/realm.md
+++ b/docs/resources/realm.md
@@ -181,6 +181,7 @@ The `headers` block supports the following arguments:
 - `x_robots_tag` - (Optional) Prevent pages from appearing in search engines.
 - `x_xss_protection` - (Optional) This header configures the Cross-site scripting (XSS) filter in your browser.
 - `strict_transport_security` - (Optional) The Script-Transport-Security HTTP header tells browsers to always use HTTPS.
+- `referrer_policy` - (Optional) The Referrer-Policy HTTP header controls how much referrer information (sent with the Referer header) should be included with requests.
 
 The `brute_force_detection` block supports the following arguments:
 

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -150,6 +150,7 @@ type BrowserSecurityHeaders struct {
 	XFrameOptions                   string `json:"xFrameOptions"`
 	XRobotsTag                      string `json:"xRobotsTag"`
 	XXSSProtection                  string `json:"xXSSProtection"`
+	ReferrerPolicy                  string `json:"referrerPolicy"`
 }
 
 type SmtpServer struct {

--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -390,6 +390,10 @@ func dataSourceKeycloakRealm() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"referrer_policy": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 								},
 							},
 						},

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -505,6 +505,11 @@ func resourceKeycloakRealm() *schema.Resource {
 										Optional: true,
 										Default:  "max-age=31536000; includeSubDomains",
 									},
+									"referrer_policy": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "no-referrer",
+									},
 								},
 							},
 						},
@@ -972,6 +977,7 @@ func getRealmFromData(data *schema.ResourceData) (*keycloak.Realm, error) {
 				XFrameOptions:                   headerSettings["x_frame_options"].(string),
 				XRobotsTag:                      headerSettings["x_robots_tag"].(string),
 				XXSSProtection:                  headerSettings["x_xss_protection"].(string),
+				ReferrerPolicy:                  headerSettings["referrer_policy"].(string),
 			}
 		} else {
 			setDefaultSecuritySettingHeaders(realm)
@@ -1149,6 +1155,7 @@ func setDefaultSecuritySettingHeaders(realm *keycloak.Realm) {
 		XFrameOptions:                   "SAMEORIGIN",
 		XRobotsTag:                      "none",
 		XXSSProtection:                  "1; mode=block",
+		ReferrerPolicy:                  "no-referrer",
 	}
 }
 
@@ -1355,6 +1362,7 @@ func getHeaderSettings(realm *keycloak.Realm) map[string]interface{} {
 	headersSettings["x_frame_options"] = realm.BrowserSecurityHeaders.XFrameOptions
 	headersSettings["x_robots_tag"] = realm.BrowserSecurityHeaders.XRobotsTag
 	headersSettings["x_xss_protection"] = realm.BrowserSecurityHeaders.XXSSProtection
+	headersSettings["referrer_policy"] = realm.BrowserSecurityHeaders.ReferrerPolicy
 	return headersSettings
 }
 

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -1640,6 +1640,7 @@ resource "keycloak_realm" "realm" {
 			x_robots_tag = "none"
 			x_xss_protection = "1; mode=block"
 			strict_transport_security = "max-age=31536000; includeSubDomains"
+			referrer_policy = "origin"
 		}
 		brute_force_detection {
             permanent_lockout                 = false


### PR DESCRIPTION
Add an option to set `referrer_policy` header option to a realm, like this:

```yaml
resource "keycloak_realm" "realm" {
  realm = "Realm Name"

  security_defenses {
    headers {
      referrer_policy = "origin"
    }
  }
}
```

Close #878 