### PR TITLE
Compute `extra_config` for data sources

### DIFF
--- a/provider/data_source_keycloak_openid_client.go
+++ b/provider/data_source_keycloak_openid_client.go
@@ -250,6 +250,10 @@ func dataSourceKeycloakOpenidClientRead(ctx context.Context, data *schema.Resour
 	}
 
 	err = setOpenidClientData(ctx, keycloakClient, data, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	data.Set("extra_config", client.Attributes.ExtraConfig)
 
-	return diag.FromErr(err)
+	return nil
 }

--- a/provider/data_source_keycloak_openid_client_test.go
+++ b/provider/data_source_keycloak_openid_client_test.go
@@ -56,7 +56,7 @@ func TestAccKeycloakDataSourceOpenidClient_extraConfig(t *testing.T) {
 			{
 				Config: testAccKeycloakOpenidClientConfig_extraConfig(clientId),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "key1", resourceName, "value1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "extra_config.key1", resourceName, "extra_config.key1"),
 				),
 			},
 		},

--- a/provider/data_source_keycloak_saml_client.go
+++ b/provider/data_source_keycloak_saml_client.go
@@ -197,6 +197,7 @@ func dataSourceKeycloakSamlClientRead(ctx context.Context, data *schema.Resource
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	data.Set("extra_config", client.Attributes.ExtraConfig)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #884

The [build of the first commit](https://github.com/mrparkers/terraform-provider-keycloak/actions/runs/6489290999) shows the expected bug that was originally hidden due to a bad test definition:

```
    data_source_keycloak_openid_client_test.go:52: Step 1/1 error: Check failed: 1 error occurred:
        	* Check 1/1 error: data.keycloak_openid_client.test_extra_config: Attribute "extra_config.key1" not set, but "extra_config.key1" is set in keycloak_openid_client.test_extra_config as "value1"
```

To fix, I modified the data source routines to set `extra_config` to the value directly obtained from the client attributes.