### PR TITLE
force new resource when IDP Mapper Type changes

### DIFF
--- a/provider/resource_keycloak_custom_identity_provider_mapper.go
+++ b/provider/resource_keycloak_custom_identity_provider_mapper.go
@@ -39,6 +39,7 @@ func resourceKeycloakCustomIdentityProviderMapper() *schema.Resource {
 			"identity_provider_mapper": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "IDP Mapper Type",
 			},
 			"extra_config": {


### PR DESCRIPTION
This fixes #901 by having Terraform replace resource when the IDP Mapper Type. Keycloak's API does not seem to support changing this field on an existing resource, and this operation isn't supported by the admin UI.