### PR TITLE
Updated keycloak_client.go to support keycloak 22

### DIFF
--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -13,6 +13,7 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -167,6 +168,19 @@ func (keycloakClient *KeycloakClient) login(ctx context.Context) error {
 	serverVersion := info.SystemInfo.ServerVersion
 	if strings.Contains(serverVersion, ".GA") {
 		serverVersion = strings.ReplaceAll(info.SystemInfo.ServerVersion, ".GA", "")
+	} else {
+		regex, err := regexp.Compile(`\.redhat-\w+`)
+
+		if err != nil {
+			fmt.Println("Error compiling regex:", err)
+			return err
+		}
+
+		// Check if the pattern is found in serverVersion
+		if regex.MatchString(serverVersion) {
+			// Replace the matched pattern with an empty string
+			serverVersion = regex.ReplaceAllString(serverVersion, "")
+		}
 	}
 
 	v, err := version.NewVersion(serverVersion)


### PR DESCRIPTION
RH SSO changed the ".GA" string at the end of the version to "redhat-00002" with the release of Red Hat Build of Keycloak.  I added a more generic approach in case Red Hat changes the number at the end of the version string.

Sample string from the latest release: 22.0.6.redhat-00002

With the provided change we were able to run our Keycloak provisioning successfully without the following error that we see in the 4.3.1:

```
Error: error initializing keycloak provider
│
│   with provider["registry.terraform.io/mrparkers/keycloak"],
│   on main.tf line 7, in provider "keycloak":
│    7: provider "keycloak" {
│
│ failed to perform initial login to Keycloak: Malformed version: 22.0.6.redhat-00002
```