### PR TITLE
Acc. test versions & docker-compose changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
     strategy:
       matrix:
         keycloak-version:
+          - '22.0.5'
           - '21.0.1'
           - '20.0.5'
           - '19.0.2'

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,7 @@ site/
 # releases
 *.zip
 
+# Ability to locally override docker-compose config
+docker-compose.override.yml
+
 .DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
     ports:
     - 8389:389
   keycloak:
-    image: quay.io/keycloak/keycloak:21.0.1
+    # image: quay.io/keycloak/keycloak:21.0.1
+    image: quay.io/keycloak/keycloak:22.0.5
     command: start-dev --features=preview
     depends_on:
     - postgres
@@ -41,3 +42,9 @@ services:
     volumes:
 # Make the custom-user-federation-example extension available to Keycloak. The :z option is required and tells Docker that the volume content will be shared between containers.
     - ./custom-user-federation-example/build/libs/custom-user-federation-example.jar:/opt/jboss/keycloak/standalone/deployments/custom-user-federation-example.jar:z
+  nginx:
+    image: nginx:1.25.3-alpine
+    volumes:
+      - ./scripts/nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "8081:8081"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     ports:
     - 8389:389
   keycloak:
-    # image: quay.io/keycloak/keycloak:21.0.1
-    image: quay.io/keycloak/keycloak:22.0.5
+    image: quay.io/keycloak/keycloak:21.0.1
+    # image: quay.io/keycloak/keycloak:22.0.5
     command: start-dev --features=preview
     depends_on:
     - postgres

--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -1,0 +1,11 @@
+events {}
+
+http {
+    server {
+        listen 8081 default_server;
+
+        location / {
+            proxy_pass http://keycloak:8080;
+        }
+    }
+}


### PR DESCRIPTION
- Added nginx to docker-comose setup for easy access logs
- Now using docker-compose.override to specify alt. keycloak image
- Added Keycloak 22.0.5 to acceptance tests
