### PR TITLE
Building acc. test images for Keycloak v22 and v23

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -13,6 +13,8 @@ jobs:
     strategy:
       matrix:
         keycloak-version:
+          - '23.0.4'
+          - '22.0.5'
           - '21.0.1'
           - '20.0.5'
           - '19.0.2'


### PR DESCRIPTION
Added new Keycloak versions for acceptance tests.

(Ran into need for this while working on #919, which seems to be specific to Keycloak v22)
