### PR TITLE
Fix 919 provider crash

### DIFF
--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -3,8 +3,9 @@ package keycloak
 import (
 	"context"
 	"fmt"
-	"github.com/mrparkers/terraform-provider-keycloak/keycloak/types"
 	"strings"
+
+	"github.com/mrparkers/terraform-provider-keycloak/keycloak/types"
 )
 
 type Key struct {
@@ -166,6 +167,12 @@ type SmtpServer struct {
 	Ssl                types.KeycloakBoolQuoted `json:"ssl,omitempty"`
 	User               string                   `json:"user,omitempty"`
 	Password           string                   `json:"password,omitempty"`
+}
+
+func (keycloakClient *KeycloakClient) RefreshAuth(ctx context.Context) error {
+	err := keycloakClient.login(ctx)
+
+	return err
 }
 
 func (keycloakClient *KeycloakClient) NewRealm(ctx context.Context, realm *Realm) error {

--- a/provider/resource_keycloak_default_roles.go
+++ b/provider/resource_keycloak_default_roles.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
 )
@@ -99,18 +98,9 @@ func resourceKeycloakDefaultRolesReconcile(ctx context.Context, data *schema.Res
 
 	defaultRoles := mapFromDataToDefaultRoles(data)
 
-	var realm *keycloak.Realm
-	var err error
-	// realm, err := keycloakClient.GetRealm(ctx, defaultRoles.RealmId)
-	realm, err = keycloakClient.GetRealm(ctx, defaultRoles.RealmId)
+	realm, err := keycloakClient.GetRealm(ctx, defaultRoles.RealmId)
 	if err != nil {
 		return diag.FromErr(err)
-	}
-
-	if realm.DefaultRole == nil {
-		tflog.Warn(ctx, "Realm does not contain DefaultRole property. Renewing access token to bypass any caching in Keycloak.")
-		keycloakClient.RefreshAuth(ctx)
-		realm, err = keycloakClient.GetRealm(ctx, defaultRoles.RealmId)
 	}
 
 	data.SetId(realm.DefaultRole.Id)


### PR DESCRIPTION
Fix for #919 

Always refresh token after create realm.

Rationale is this should not be expensive since:

* Creating a realm is relatively rare
* In a lot of scenarios the token refresh would happen anyway if a new realm is created, when it's referenced elsewhere

Existing acceptance test `testKeycloakDefaultRoles_basic` should cover this, provided the acceptance tests include Keycloak v22 and newer. For that, the following PRs exist:

* #921 Test Keycloak images for v22 & v23
* #920 Include v22 in acc. tests (draft, pending #921)