### PR TITLE
Add additional RSA Algorithms for rsa-enc provider

### DIFF
--- a/provider/resource_keycloak_realm_keystore_rsa.go
+++ b/provider/resource_keycloak_realm_keystore_rsa.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	keycloakRealmKeystoreRsaAlgorithm = []string{"RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "RSA-OAEP"}
+	keycloakRealmKeystoreRsaAlgorithm = []string{"RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "RSA1_5", "RSA-OAEP", "RSA-OAEP-256"}
 )
 
 func resourceKeycloakRealmKeystoreRsa() *schema.Resource {


### PR DESCRIPTION
Since there is already pushed fix for #857 this just adds additional algorithm options, so it can be succesfully created rsa-enc provider with RSA1_5 algorithm