### PR TITLE
doc: add example on how to retrieve realm management role

### DIFF
--- a/docs/data-sources/role.md
+++ b/docs/data-sources/role.md
@@ -7,7 +7,7 @@ page_title: "keycloak_role Data Source"
 This data source can be used to fetch properties of a Keycloak role for
 usage with other resources, such as `keycloak_group_roles`.
 
-## Example Usage
+## Example Usage (Keycloak Role)
 
 ```hcl
 resource "keycloak_realm" "realm" {
@@ -34,6 +34,43 @@ resource "keycloak_group_roles" "group_roles" {
     role_ids = [
       data.keycloak_role.offline_access.id
     ]
+}
+```
+
+## Example Usage (Realm Management Role)
+
+```hcl
+resource "keycloak_realm" "realm" {
+  realm   = "my-realm"
+  enabled = true
+}
+
+data "keycloak_openid_client" "realm_management" {
+  realm_id  = keycloak_realm.realm.id
+  client_id = "realm-management"
+}
+
+data "keycloak_role" "query-users" {
+  realm_id  = keycloak_realm.realm.id
+  client_id = data.keycloak_openid_client.realm_management.id
+  name      = "query-users"
+}
+
+# use the data source
+
+resource "keycloak_user" "user" {
+  realm_id = keycloak_realm.realm.id
+  username = "user"
+  enabled  = true
+}
+
+resource "keycloak_user_roles" "demo-hub-prod-realm-admin" {
+  realm_id = keycloak_realm.realm.id
+  user_id  = keycloak_user.user.id
+
+  role_ids = [
+    data.keycloak_role.query-users.id,
+  ]
 }
 ```
 


### PR DESCRIPTION
# Context

I had hard time finding out how to retrieve them. I was losing faith, believing that it was not possible with this provider. 

I tried one last time, searched a different way, and discovered how to do it with [this comment](https://github.com/mrparkers/terraform-provider-keycloak/issues/329#issuecomment-649613833).

# Motivation

The goal of this PR is to help other users to find this information more easily.