### PR TITLE
feat: add id_token_signed_response_alg to oidc client

### DIFF
--- a/docs/resources/openid_client.md
+++ b/docs/resources/openid_client.md
@@ -68,6 +68,7 @@ resource "keycloak_openid_client" "openid_client" {
 wildcards in the form of an asterisk can be used here. This attribute must be set if either `standard_flow_enabled` or `implicit_flow_enabled`
 is set to `true`.
 - `valid_post_logout_redirect_uris` - (Optional) A list of valid URIs a browser is permitted to redirect to after a successful logout.
+- `id_token_signed_response_alg` - (Optional) the algorithm of the ID token signature
 - `web_origins` - (Optional) A list of allowed CORS origins. To permit all valid redirect URIs, add `+`. Note that this will not include the `*` wildcard. To permit all origins, explicitly add `*`."
 - `root_url` - (Optional) When specified, this URL is prepended to any relative URLs found within `valid_redirect_uris`, `web_origins`, and `admin_url`. NOTE: Due to limitations in the Keycloak API, when the `root_url` attribute is used, the `valid_redirect_uris`, `web_origins`, and `admin_url` attributes will be required.
 - `admin_url` - (Optional) URL to the admin interface of the client.

--- a/keycloak/openid_client.go
+++ b/keycloak/openid_client.go
@@ -80,6 +80,7 @@ type OpenidClientAttributes struct {
 	Oauth2DeviceCodeLifespan              string                           `json:"oauth2.device.code.lifespan,omitempty"`
 	Oauth2DevicePollingInterval           string                           `json:"oauth2.device.polling.interval,omitempty"`
 	PostLogoutRedirectUris                types.KeycloakSliceHashDelimited `json:"post.logout.redirect.uris,omitempty"`
+	IdTokenSignatureAlgorithm             string                           `json:"id.token.signed.response.alg,omitempty"`
 }
 
 type OpenidAuthenticationFlowBindingOverrides struct {

--- a/makefile
+++ b/makefile
@@ -6,14 +6,19 @@ MAKEFLAGS += --silent
 
 VERSION=$$(git describe --tags)
 
-build:
+clean:
+	rm -f terraform-provider-keycloak_*
+	rm -rf example/.terraform/ example/terraform.d/
+
+build: clean
 	CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$(VERSION)" -o terraform-provider-keycloak_$(VERSION)
 
 build-example: build
-	mkdir -p example/.terraform/plugins/terraform.local/mrparkers/keycloak/4.0.0/$(GOOS)_$(GOARCH)
-	mkdir -p example/terraform.d/plugins/terraform.local/mrparkers/keycloak/4.0.0/$(GOOS)_$(GOARCH)
-	cp terraform-provider-keycloak_* example/.terraform/plugins/terraform.local/mrparkers/keycloak/4.0.0/$(GOOS)_$(GOARCH)/
-	cp terraform-provider-keycloak_* example/terraform.d/plugins/terraform.local/mrparkers/keycloak/4.0.0/$(GOOS)_$(GOARCH)/
+	rm -rf example/.terraform/ example/terraform.d/
+	mkdir -p example/.terraform/plugins/terraform.local/mrparkers/keycloak/4.4.0/$(GOOS)_$(GOARCH)
+	mkdir -p example/terraform.d/plugins/terraform.local/mrparkers/keycloak/4.4.0/$(GOOS)_$(GOARCH)
+	cp terraform-provider-keycloak_* example/.terraform/plugins/terraform.local/mrparkers/keycloak/4.4.0/$(GOOS)_$(GOARCH)/
+	cp terraform-provider-keycloak_* example/terraform.d/plugins/terraform.local/mrparkers/keycloak/4.4.0/$(GOOS)_$(GOARCH)/
 
 local: deps
 	docker compose up --build -d

--- a/provider/data_source_keycloak_openid_client.go
+++ b/provider/data_source_keycloak_openid_client.go
@@ -78,6 +78,10 @@ func dataSourceKeycloakOpenidClient() *schema.Resource {
 				Set:      schema.HashString,
 				Computed: true,
 			},
+			"id_token_signed_response_alg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"web_origins": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},

--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -115,6 +115,11 @@ func resourceKeycloakOpenidClient() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"id_token_signed_response_alg": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"web_origins": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -376,6 +381,7 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 			ConsentScreenText:                     data.Get("consent_screen_text").(string),
 			DisplayOnConsentScreen:                types.KeycloakBoolQuoted(data.Get("display_on_consent_screen").(bool)),
 			PostLogoutRedirectUris:                types.KeycloakSliceHashDelimited(validPostLogoutRedirectUris),
+			IdTokenSignatureAlgorithm:             data.Get("id_token_signed_response_alg").(string),
 		},
 		ValidRedirectUris: validRedirectUris,
 		WebOrigins:        webOrigins,
@@ -457,6 +463,7 @@ func setOpenidClientData(ctx context.Context, keycloakClient *keycloak.KeycloakC
 	data.Set("frontchannel_logout_enabled", client.FrontChannelLogoutEnabled)
 	data.Set("valid_redirect_uris", client.ValidRedirectUris)
 	data.Set("valid_post_logout_redirect_uris", client.Attributes.PostLogoutRedirectUris)
+	data.Set("id_token_signed_response_alg", client.Attributes.IdTokenSignatureAlgorithm)
 	data.Set("web_origins", client.WebOrigins)
 	data.Set("admin_url", client.AdminUrl)
 	data.Set("base_url", client.BaseUrl)

--- a/provider/resource_keycloak_openid_client_test.go
+++ b/provider/resource_keycloak_openid_client_test.go
@@ -1479,8 +1479,10 @@ resource "keycloak_openid_client" "client" {
 	backchannel_logout_url                     = "%s"
 	backchannel_logout_session_required        = %t
 	backchannel_logout_revoke_offline_sessions = %t
+
+	id_token_signed_response_alg = %s
 }
-	`, testAccRealm.Realm, openidClient.ClientId, openidClient.Name, openidClient.Enabled, openidClient.Description, openidClient.ClientSecret, openidClient.StandardFlowEnabled, openidClient.ImplicitFlowEnabled, openidClient.DirectAccessGrantsEnabled, openidClient.ServiceAccountsEnabled, arrayOfStringsForTerraformResource(openidClient.ValidRedirectUris), arrayOfStringsForTerraformResource(openidClient.Attributes.PostLogoutRedirectUris), arrayOfStringsForTerraformResource(openidClient.WebOrigins), openidClient.AdminUrl, openidClient.BaseUrl, *openidClient.RootUrl, openidClient.Attributes.BackchannelLogoutUrl, openidClient.Attributes.BackchannelLogoutSessionRequired, openidClient.Attributes.BackchannelLogoutRevokeOfflineTokens)
+	`, testAccRealm.Realm, openidClient.ClientId, openidClient.Name, openidClient.Enabled, openidClient.Description, openidClient.ClientSecret, openidClient.StandardFlowEnabled, openidClient.ImplicitFlowEnabled, openidClient.DirectAccessGrantsEnabled, openidClient.ServiceAccountsEnabled, arrayOfStringsForTerraformResource(openidClient.ValidRedirectUris), arrayOfStringsForTerraformResource(openidClient.Attributes.PostLogoutRedirectUris), arrayOfStringsForTerraformResource(openidClient.WebOrigins), openidClient.AdminUrl, openidClient.BaseUrl, *openidClient.RootUrl, openidClient.Attributes.BackchannelLogoutUrl, openidClient.Attributes.BackchannelLogoutSessionRequired, openidClient.Attributes.BackchannelLogoutRevokeOfflineTokens, openidClient.Attributes.IdTokenSignatureAlgorithm)
 }
 
 func testKeycloakOpenidClient_backchannel(clientId, backchannelLogoutUrl string, backchannelLogoutSessionRequired, backchannelLogoutRevokeOfflineSessions bool) string {

--- a/provider/resource_keycloak_openid_client_test.go
+++ b/provider/resource_keycloak_openid_client_test.go
@@ -208,6 +208,7 @@ func TestAccKeycloakOpenidClient_updateInPlace(t *testing.T) {
 			BackchannelLogoutSessionRequired:     types.KeycloakBoolQuoted(randomBool()),
 			BackchannelLogoutRevokeOfflineTokens: types.KeycloakBoolQuoted(randomBool()),
 			PostLogoutRedirectUris:               []string{acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10)},
+			IdTokenSignatureAlgorithm:            "ES256",
 		},
 	}
 
@@ -234,6 +235,7 @@ func TestAccKeycloakOpenidClient_updateInPlace(t *testing.T) {
 			BackchannelLogoutSessionRequired:     types.KeycloakBoolQuoted(randomBool()),
 			BackchannelLogoutRevokeOfflineTokens: types.KeycloakBoolQuoted(randomBool()),
 			PostLogoutRedirectUris:               []string{acctest.RandString(10), acctest.RandString(10)},
+			IdTokenSignatureAlgorithm:            "RS256",
 		},
 	}
 
@@ -1480,7 +1482,7 @@ resource "keycloak_openid_client" "client" {
 	backchannel_logout_session_required        = %t
 	backchannel_logout_revoke_offline_sessions = %t
 
-	id_token_signed_response_alg = %s
+	id_token_signed_response_alg = "%s"
 }
 	`, testAccRealm.Realm, openidClient.ClientId, openidClient.Name, openidClient.Enabled, openidClient.Description, openidClient.ClientSecret, openidClient.StandardFlowEnabled, openidClient.ImplicitFlowEnabled, openidClient.DirectAccessGrantsEnabled, openidClient.ServiceAccountsEnabled, arrayOfStringsForTerraformResource(openidClient.ValidRedirectUris), arrayOfStringsForTerraformResource(openidClient.Attributes.PostLogoutRedirectUris), arrayOfStringsForTerraformResource(openidClient.WebOrigins), openidClient.AdminUrl, openidClient.BaseUrl, *openidClient.RootUrl, openidClient.Attributes.BackchannelLogoutUrl, openidClient.Attributes.BackchannelLogoutSessionRequired, openidClient.Attributes.BackchannelLogoutRevokeOfflineTokens, openidClient.Attributes.IdTokenSignatureAlgorithm)
 }


### PR DESCRIPTION

```
resource "keycloak_openid_client" "oidc_client" {
  realm_id            = data.keycloak_realm.realm.id
  client_id           = "example-oidc-client"
  name                = "Example OIDC Client
  enabled             = true
  ... ...
  // the new property
  id_token_signed_response_alg = "RS256"
}

```