### PR TITLE
feat: Add aggregate attributes flag to keycloak_saml_user_attribute_protocol_mapper (#942)

### DIFF
--- a/docs/resources/saml_user_attribute_protocol_mapper.md
+++ b/docs/resources/saml_user_attribute_protocol_mapper.md
@@ -47,6 +47,7 @@ resource "keycloak_saml_user_attribute_protocol_mapper" "saml_user_attribute_map
 - `client_id` - (Optional) The client this protocol mapper should be attached to. Conflicts with `client_scope_id`. One of `client_id` or `client_scope_id` must be specified.
 - `client_scope_id` - (Optional) The client scope this protocol mapper should be attached to. Conflicts with `client_id`. One of `client_id` or `client_scope_id` must be specified.
 - `friendly_name` - (Optional) An optional human-friendly name for this attribute.
+- `aggregate_attributes`- (Optional) Indicates whether this attribute is a single value or an array of values. Defaults to `false`.
 
 ## Import
 

--- a/provider/resource_keycloak_saml_user_attribute_protocol_mapper.go
+++ b/provider/resource_keycloak_saml_user_attribute_protocol_mapper.go
@@ -62,6 +62,12 @@ func resourceKeycloakSamlUserAttributeProtocolMapper() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringInSlice(keycloakSamlUserAttributeProtocolMapperNameFormats, false),
 			},
+			"aggregate_attributes": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Indicates if attribute values should be aggregated within the group attributes",
+			},
 		},
 	}
 }
@@ -74,10 +80,11 @@ func mapFromDataToSamlUserAttributeProtocolMapper(data *schema.ResourceData) *ke
 		ClientId:      data.Get("client_id").(string),
 		ClientScopeId: data.Get("client_scope_id").(string),
 
-		UserAttribute:           data.Get("user_attribute").(string),
-		FriendlyName:            data.Get("friendly_name").(string),
-		SamlAttributeName:       data.Get("saml_attribute_name").(string),
-		SamlAttributeNameFormat: data.Get("saml_attribute_name_format").(string),
+		UserAttribute:            data.Get("user_attribute").(string),
+		FriendlyName:             data.Get("friendly_name").(string),
+		SamlAttributeName:        data.Get("saml_attribute_name").(string),
+		SamlAttributeNameFormat:  data.Get("saml_attribute_name_format").(string),
+		AggregateAttributeValues: data.Get("aggregate_attributes").(bool),
 	}
 }
 
@@ -96,6 +103,7 @@ func mapFromSamlUserAttributeMapperToData(mapper *keycloak.SamlUserAttributeProt
 	data.Set("friendly_name", mapper.FriendlyName)
 	data.Set("saml_attribute_name", mapper.SamlAttributeName)
 	data.Set("saml_attribute_name_format", mapper.SamlAttributeNameFormat)
+	data.Set("aggregate_attributes", mapper.AggregateAttributeValues)
 }
 
 func resourceKeycloakSamlUserAttributeProtocolMapperCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
This PR introduces a new attribute for the keycloak_saml_user_attribute_protocol_mapper. It aims to support aggregation of attributes.

Disclaimer: This is my first contribution to a Go project, and I have focused on ensuring that the code adheres to the project's standards and Go best practices to the best of my understanding.