### PR TITLE
feat(data-source): Add keycloak group membership datasource

### DIFF
--- a/provider/data_source_keycloak_group_members.go
+++ b/provider/data_source_keycloak_group_members.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
+)
+
+func dataSourceKeycloakGroupMembers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceKeycloakGroupMembersRead,
+		Schema: map[string]*schema.Schema{
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"users": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceKeycloakGroupMembersRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	groupName := data.Get("name").(string)
+
+	users, err := keycloakClient.GetGroupMembers(ctx, realmId, groupName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	usernames := make([]string, len(users))
+	for num, user := range users {
+		usernames[num] = user.Username
+	}
+
+	data.SetId(groupName)
+	data.Set("realm_id", realmId)
+	data.Set("name", groupName)
+	data.Set("users", usernames)
+
+	return nil
+}

--- a/provider/data_source_keycloak_group_members_test.go
+++ b/provider/data_source_keycloak_group_members_test.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccKeycloakDataSourceGroupMembers(t *testing.T) {
+	t.Parallel()
+	username := acctest.RandomWithPrefix("tf-acc")
+	groupName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceKeycloakGroupMembers(groupName, username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.keycloak_group_members.group_members", "users.0", username),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceKeycloakGroupMembers(groupName, username string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_group" "group" {
+	name     = "%s"
+	realm_id = data.keycloak_realm.realm.id
+}
+
+resource "keycloak_user" "user" {
+	username    = "%s"
+	realm_id 	= data.keycloak_realm.realm.id
+	enabled    	= true
+
+	first_name 	= "Bob"
+	last_name  	= "Bobson"
+}
+
+resource "keycloak_group_memberships" "group_members" {
+	realm_id = data.keycloak_realm.realm.id
+	group_id = keycloak_group.group.id
+
+	members = [keycloak_user.user.username]
+}
+	`, testAccRealm.Realm, groupName, username)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -14,6 +14,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 	provider := &schema.Provider{
 		DataSourcesMap: map[string]*schema.Resource{
 			"keycloak_group":                              dataSourceKeycloakGroup(),
+			"keycloak_group_members":                      dataSourceKeycloakGroupMembers(),
 			"keycloak_openid_client":                      dataSourceKeycloakOpenidClient(),
 			"keycloak_openid_client_authorization_policy": dataSourceKeycloakOpenidClientAuthorizationPolicy(),
 			"keycloak_openid_client_scope":                dataSourceKeycloakOpenidClientScope(),


### PR DESCRIPTION
# Why?

We are attempting to make Keycloak our single-source of truth for various systems. To do this we needed to be able to fetch the members of a group so we can, for example, sync a GitHub Team to a Keycloak groups membership.

# How?

We added a new data-source `keycloak_group_members` to return the members of a particular group.

```hcl
data "keycloak_group_members" "my-group" {
  realm_id   = "my-realm"
  group_name = "my-group"
}
```

We have also added test coverage for this new functionality.

Thanks for your time considering this pull-request.