### PR TITLE
feat(protocol-mapper): add "add to token introspection" flag for realm role protocol mapper

### DIFF
--- a/keycloak/openid_user_realm_role_protocol_mapper.go
+++ b/keycloak/openid_user_realm_role_protocol_mapper.go
@@ -13,9 +13,10 @@ type OpenIdUserRealmRoleProtocolMapper struct {
 	ClientId      string
 	ClientScopeId string
 
-	AddToIdToken     bool
-	AddToAccessToken bool
-	AddToUserInfo    bool
+	AddToIdToken            bool
+	AddToAccessToken        bool
+	AddToUserInfo           bool
+	AddToTokenIntrospection bool
 
 	RealmRolePrefix string
 	Multivalued     bool
@@ -33,6 +34,7 @@ func (mapper *OpenIdUserRealmRoleProtocolMapper) convertToGenericProtocolMapper(
 			addToIdTokenField:                   strconv.FormatBool(mapper.AddToIdToken),
 			addToAccessTokenField:               strconv.FormatBool(mapper.AddToAccessToken),
 			addToUserInfoField:                  strconv.FormatBool(mapper.AddToUserInfo),
+			addToTokenIntrospectionField:        strconv.FormatBool(mapper.AddToTokenIntrospection),
 			claimNameField:                      mapper.ClaimName,
 			claimValueTypeField:                 mapper.ClaimValueType,
 			multivaluedField:                    strconv.FormatBool(mapper.Multivalued),
@@ -57,6 +59,11 @@ func (protocolMapper *protocolMapper) convertToOpenIdUserRealmRoleProtocolMapper
 		return nil, err
 	}
 
+	addToTokenIntrospection, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToTokenIntrospectionField])
+	if err != nil {
+		return nil, err
+	}
+
 	multivalued, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[multivaluedField])
 	if err != nil {
 		return nil, err
@@ -69,9 +76,10 @@ func (protocolMapper *protocolMapper) convertToOpenIdUserRealmRoleProtocolMapper
 		ClientId:      clientId,
 		ClientScopeId: clientScopeId,
 
-		AddToIdToken:     addToIdToken,
-		AddToAccessToken: addToAccessToken,
-		AddToUserInfo:    addToUserInfo,
+		AddToIdToken:            addToIdToken,
+		AddToAccessToken:        addToAccessToken,
+		AddToUserInfo:           addToUserInfo,
+		AddToTokenIntrospection: addToTokenIntrospection,
 
 		ClaimName:       protocolMapper.Config[claimNameField],
 		ClaimValueType:  protocolMapper.Config[claimValueTypeField],

--- a/keycloak/protocol_mapper.go
+++ b/keycloak/protocol_mapper.go
@@ -18,6 +18,7 @@ var (
 	addToAccessTokenField                = "access.token.claim"
 	addToIdTokenField                    = "id.token.claim"
 	addToUserInfoField                   = "userinfo.token.claim"
+	addToTokenIntrospectionField         = "introspection.token.claim"
 	attributeNameField                   = "attribute.name"
 	attributeNameFormatField             = "attribute.nameformat"
 	claimNameField                       = "claim.name"

--- a/provider/resource_keycloak_openid_user_realm_role_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_realm_role_protocol_mapper.go
@@ -65,6 +65,12 @@ func resourceKeycloakOpenIdUserRealmRoleProtocolMapper() *schema.Resource {
 				Default:     true,
 				Description: "Indicates if the attribute should appear in the userinfo response body.",
 			},
+			"add_to_token_introspection": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Indicates if the attribute should be a claim in the token introspection.",
+			},
 			"claim_name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -93,14 +99,15 @@ func resourceKeycloakOpenIdUserRealmRoleProtocolMapper() *schema.Resource {
 
 func mapFromDataToOpenIdUserRealmRoleProtocolMapper(data *schema.ResourceData) *keycloak.OpenIdUserRealmRoleProtocolMapper {
 	return &keycloak.OpenIdUserRealmRoleProtocolMapper{
-		Id:               data.Id(),
-		Name:             data.Get("name").(string),
-		RealmId:          data.Get("realm_id").(string),
-		ClientId:         data.Get("client_id").(string),
-		ClientScopeId:    data.Get("client_scope_id").(string),
-		AddToIdToken:     data.Get("add_to_id_token").(bool),
-		AddToAccessToken: data.Get("add_to_access_token").(bool),
-		AddToUserInfo:    data.Get("add_to_userinfo").(bool),
+		Id:                      data.Id(),
+		Name:                    data.Get("name").(string),
+		RealmId:                 data.Get("realm_id").(string),
+		ClientId:                data.Get("client_id").(string),
+		ClientScopeId:           data.Get("client_scope_id").(string),
+		AddToIdToken:            data.Get("add_to_id_token").(bool),
+		AddToAccessToken:        data.Get("add_to_access_token").(bool),
+		AddToUserInfo:           data.Get("add_to_userinfo").(bool),
+		AddToTokenIntrospection: data.Get("add_to_token_introspection").(bool),
 
 		ClaimName:       data.Get("claim_name").(string),
 		ClaimValueType:  data.Get("claim_value_type").(string),
@@ -123,6 +130,7 @@ func mapFromOpenIdUserRealmRoleMapperToData(mapper *keycloak.OpenIdUserRealmRole
 	data.Set("add_to_id_token", mapper.AddToIdToken)
 	data.Set("add_to_access_token", mapper.AddToAccessToken)
 	data.Set("add_to_userinfo", mapper.AddToUserInfo)
+	data.Set("add_to_token_introspection", mapper.AddToTokenIntrospection)
 	data.Set("claim_name", mapper.ClaimName)
 	data.Set("claim_value_type", mapper.ClaimValueType)
 	data.Set("realm_role_prefix", mapper.RealmRolePrefix)


### PR DESCRIPTION
This change adds the `add_to_token_introspection` flag to the `keycloak_openid_user_realm_role_protocol_mapper` resource.