### PR TITLE
Add sub_groups to group resource

### DIFF
--- a/provider/data_source_keycloak_group.go
+++ b/provider/data_source_keycloak_group.go
@@ -31,6 +31,22 @@ func dataSourceKeycloakGroup() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
+			"sub_groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/provider/resource_keycloak_group.go
+++ b/provider/resource_keycloak_group.go
@@ -44,6 +44,22 @@ func resourceKeycloakGroup() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 			},
+			"sub_groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -77,6 +93,15 @@ func mapFromGroupToData(data *schema.ResourceData, group *keycloak.Group) {
 	data.Set("name", group.Name)
 	data.Set("path", group.Path)
 	data.Set("attributes", attributes)
+	var subgroups []map[string]interface{}
+	for _, sg := range group.SubGroups {
+		subgroup := map[string]interface{}{
+			"id": sg.Id,
+			"name": sg.Name,
+		}
+		subgroups = append(subgroups, subgroup)
+	}
+	data.Set("sub_groups", subgroups)
 	if group.ParentId != "" {
 		data.Set("parent_id", group.ParentId)
 	}


### PR DESCRIPTION
When trying to do a merge operation between "what we want in keycloak" and "what we have in keycloak" using the fancy new import blocks I stubbed my toe on trying to merge subgroups where there were many identically named subgroups that were unique only on their `parentId` (and `Id`, of course). The million dollar question is: "What is the id of the subgroup (with a given name) of a given group, if it exists?"

Keycloak's rest APIs are extraordinarily obnoxious - if there's a better way of solving this problem I'd love to know. My solution was to expose the subgroups on the resource so we can search for our name and then get the id from there.

This has a bit of a footgun; the groups search endpoint in keycloak returns an empty array for the subgroups (you can get it to return the subgroups if you search for the subgroup though.. So you can either search for the subgroup or the group, but not both! Gah!).

Because of that the data_source doesn't actually contain sub groups. I hate this; might need to compromise here, strip it from the data_source impl. and then I guess we need to conditionally map the SubGroups -> sub_groups only for the resource.

This Works On My Machine™ but marking it as a draft since its got footguns and hopefully there's a better way to do this altogether.