### PR TITLE
feat: update go toolchain to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,4 +61,4 @@ require (
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.24.4


### PR DESCRIPTION
Go 1.23 has several CVEs. Updating toolchain to 1.24.4 mitigates these.

- [CVE-2025-22871](https://www.cve.org/CVERecord?id=CVE-2025-22871)
- [CVE-2025-22874](https://www.cve.org/CVERecord?id=CVE-2025-22874)
- [CVE-2025-4673](https://www.cve.org/CVERecord?id=CVE-2025-4673)
- [CVE-2025-0913](https://www.cve.org/CVERecord?id=CVE-2025-0913)