### PR TITLE
fix: handles arrays and maps in client policy conditions (#1256)

### DIFF
--- a/provider/resource_keycloak_realm_client_policy_profile_test.go
+++ b/provider/resource_keycloak_realm_client_policy_profile_test.go
@@ -1,7 +1,9 @@
 package provider
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -31,14 +33,39 @@ func TestAccKeycloakRealmClientPolicyProfile_basicWithExecutor(t *testing.T) {
 	resourceName := "test-profile-with-executor"
 	description := "Test description with executor"
 	executorName := "pkce-enforcer"
+	configuration := map[string]interface{}{
+		"auto-configure": "true",
+	}
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakRealmClientPolicyProfile_basicWithExecutor(realmName, resourceName, description, executorName),
+				Config: testKeycloakRealmClientPolicyProfile_basicWithExecutor(realmName, resourceName, description, executorName, testKeycloakRealmClientPolicyProfile_mapConfig(configuration)),
 				Check:  testAccCheckKeycloakRealmClientPolicyProfileWithExecutorExists(realmName, resourceName, executorName),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakRealmClientPolicyProfile_basicWithExecutorAndJSON(t *testing.T) {
+	realmName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "test-profile-with-executor-and-configuration"
+	description := "Test description with executor and configuration"
+	executorName := "secure-client-authenticator"
+	configuration := map[string]interface{}{
+		"allowed-client-authenticators": []string{"client-secret", "client-secret-jwt"},
+		"default-client-authenticator":  "client-secret",
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakRealmClientPolicyProfile_basicWithExecutor(realmName, resourceName, description, executorName, testKeycloakRealmClientPolicyProfile_mapConfig(configuration)),
+				Check:  testAccCheckKeycloakRealmClientPolicyProfileWithExecutorMatches(realmName, resourceName, executorName, configuration),
 			},
 		},
 	})
@@ -51,17 +78,67 @@ func TestAccKeycloakRealmClientPolicyProfile_basicWithPolicy(t *testing.T) {
 	policyName := "test-policy"
 	policyDescription := "Test policy description"
 	conditionName := "client-updater-source-roles"
+	configuration := map[string]interface{}{
+		"is_negative_logic": false,
+		"attributes": []map[string]string{
+			{
+				"key":   "test-key",
+				"value": "test-value",
+			},
+		},
+	}
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakRealmClientPolicyProfile_basicWithPolicy(realmName, profileName, profileDescription, policyName, policyDescription, conditionName),
+				Config: testKeycloakRealmClientPolicyProfile_basicWithPolicy(realmName, profileName, profileDescription, policyName, policyDescription, conditionName, testKeycloakRealmClientPolicyProfile_mapConfig(configuration)),
 				Check:  testAccCheckKeycloakRealmClientPolicyProfilePolicyExists(realmName, policyName),
 			},
 		},
 	})
+}
+
+func TestAccKeycloakRealmClientPolicyProfile_basicWithPolicyAndJSON(t *testing.T) {
+	realmName := acctest.RandomWithPrefix("tf-acc")
+	profileName := "test-profile"
+	profileDescription := "Test profile description"
+	policyName := "test-policy"
+	policyDescription := "Test policy description"
+	conditionName := "client-updater-context"
+	configuration := map[string]interface{}{
+		"is_negative_logic":    false,
+		"update-client-source": []string{"ByInitialAccessToken", "ByRegistrationAccessToken"},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakRealmClientPolicyProfile_basicWithPolicy(realmName, profileName, profileDescription, policyName, policyDescription, conditionName, testKeycloakRealmClientPolicyProfile_mapConfig(configuration)),
+				Check:  testAccCheckKeycloakRealmClientPolicyProfilePolicyMatches(realmName, policyName, conditionName, configuration),
+			},
+		},
+	})
+}
+
+func testKeycloakRealmClientPolicyProfile_mapConfig(configuration map[string]interface{}) string {
+	var s string = "{"
+	for k, v := range configuration {
+		switch reflect.TypeOf(v).Kind() {
+		case reflect.Map, reflect.Slice:
+			jsonStr, _ := json.Marshal(v)
+			s += fmt.Sprintf("%s = jsonencode(%s)\n", k, string(jsonStr))
+		case reflect.String:
+			s += fmt.Sprintf("%s = \"%v\"\n", k, v)
+		default:
+			s += fmt.Sprintf("%s = %v\n", k, v)
+		}
+	}
+	s += "}"
+	return s
 }
 
 func testKeycloakRealmClientPolicyProfile_basic(realm string, name string, description string) string {
@@ -78,7 +155,7 @@ resource "keycloak_realm_client_policy_profile" "profile" {
 	`, realm, name, description)
 }
 
-func testKeycloakRealmClientPolicyProfile_basicWithExecutor(realm string, name string, description string, executorName string) string {
+func testKeycloakRealmClientPolicyProfile_basicWithExecutor(realm string, name string, description string, executorName string, configuration string) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
 	realm = "%s"
@@ -91,15 +168,13 @@ resource "keycloak_realm_client_policy_profile" "profile" {
 
 	executor {
 		name = "%s"
-		configuration = {
-			auto-configure = "true"
-		}
+		configuration = %s
 	}
 }
-	`, realm, name, description, executorName)
+	`, realm, name, description, executorName, configuration)
 }
 
-func testKeycloakRealmClientPolicyProfile_basicWithPolicy(realm string, profileName string, profileDescription string, policyName string, policyDescription string, conditionName string) string {
+func testKeycloakRealmClientPolicyProfile_basicWithPolicy(realm string, profileName string, profileDescription string, policyName string, policyDescription string, conditionName string, configuration string) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
 	realm = "%s"
@@ -122,13 +197,10 @@ resource "keycloak_realm_client_policy_profile_policy" "policy" {
 
   condition {
     name = "%s"
-    configuration = {
-			is_negative_logic = false
-			attributes        = jsonencode([{"key": "test-key", "value": "test-value"}])
-			}
+    configuration = %s
   }
 }
-	`, realm, profileName, profileDescription, policyName, policyDescription, conditionName)
+	`, realm, profileName, profileDescription, policyName, policyDescription, conditionName, configuration)
 }
 
 func testAccCheckKeycloakRealmClientPolicyProfileExists(realm string, profileName string) resource.TestCheckFunc {
@@ -157,11 +229,57 @@ func testAccCheckKeycloakRealmClientPolicyProfileWithExecutorExists(realm string
 	}
 }
 
+func testAccCheckKeycloakRealmClientPolicyProfileWithExecutorMatches(realm string, profileName string, executorName string, configuration map[string]interface{}) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		profile, err := keycloakClient.GetRealmClientPolicyProfileByName(testCtx, realm, profileName)
+		if err != nil {
+			return fmt.Errorf("Client policy profile not found: %s", profileName)
+		}
+
+		if profile.Executors[0].Name != executorName {
+			return fmt.Errorf("Client policy profile executor not found: %s", executorName)
+		}
+
+		for k, got := range profile.Executors[0].Configuration {
+			want := configuration[k]
+
+			if !equalsIgnoreType(got, want) {
+				return fmt.Errorf("Client policy profile executor configuration does not match: want %v, got %v", want, got)
+			}
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckKeycloakRealmClientPolicyProfilePolicyExists(realm string, policyName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, err := keycloakClient.GetRealmClientPolicyProfilePolicyByName(testCtx, realm, policyName)
 		if err != nil {
 			return fmt.Errorf("Client policy profile policy not found: %s", policyName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckKeycloakRealmClientPolicyProfilePolicyMatches(realm string, policyName string, conditionName string, configuration map[string]interface{}) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		policy, err := keycloakClient.GetRealmClientPolicyProfilePolicyByName(testCtx, realm, policyName)
+		if err != nil {
+			return fmt.Errorf("Client policy profile policy not found: %s", policyName)
+		}
+
+		if policy.Conditions[0].Name != conditionName {
+			return fmt.Errorf("Client policy profile policy condition not found: %s", conditionName)
+		}
+
+		for k, got := range policy.Conditions[0].Configuration {
+			want := configuration[k]
+
+			if !equalsIgnoreType(got, want) {
+				return fmt.Errorf("Client policy profile policy condition configuration does not match: want %v, got %v", want, got)
+			}
 		}
 
 		return nil

--- a/provider/test_utils.go
+++ b/provider/test_utils.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -110,4 +112,25 @@ func TestCheckResourceAttrNot(name, key, value string) resource.TestCheckFunc {
 
 		return nil
 	}
+}
+
+func equalsIgnoreType(want, got interface{}) bool {
+	if reflect.DeepEqual(want, got) {
+		return true
+	}
+
+	// TODO this should be replaced with an actual comparison the json == json is a quick fix.
+	wantJSON, _ := json.Marshal(want)
+	gotJSON, _ := json.Marshal(got)
+
+	if string(wantJSON) == string(gotJSON) {
+		return true
+	}
+
+	// compare as strings (this handles "false" == false and "0" == 0)
+	if fmt.Sprintf("%v", want) == fmt.Sprintf("%v", got) {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
Correctly allows passing JSON arrays and objects as values to configuration fields of conditions in client policies.

Unmarshals and marshals JSON strings similar to how this is done in the `keycloak_realm_user_profile` resource.

In order to allow the flexible typing of the configuration fields that is required, I added a function to compare values regardless of their type.

Closes #1256 