### PR TITLE
Change OpenLDAP image to bitnamilegacy version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
     - postgres:/var/lib/postgresql
   openldap:
-    image: bitnami/openldap:2.6
+    image: bitnamilegacy/openldap:2.6
     environment:
       LDAP_PORT_NUMBER: 389
   keycloak:


### PR DESCRIPTION
See https://github.com/bitnami/containers/issues/83267 Bitnami Containers have moved to a subscription model. openldap is still available at version 2.6 in the bitnamilegacy repository