### PR TITLE
feat: Add allowutf8 field to realm SMTP configuration

### DIFF
--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -171,6 +171,7 @@ type SmtpServer struct {
 	FromDisplayName       string                   `json:"fromDisplayName,omitempty"`
 	EnvelopeFrom          string                   `json:"envelopeFrom,omitempty"`
 	Ssl                   types.KeycloakBoolQuoted `json:"ssl,omitempty"`
+	AllowUtf8             types.KeycloakBoolQuoted `json:"allowutf8,omitempty"`
 	User                  string                   `json:"user,omitempty"`
 	Password              string                   `json:"password,omitempty"`
 	AuthType              string                   `json:"authType,omitempty"`

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -285,6 +285,10 @@ func resourceKeycloakRealm() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"allow_utf8": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"auth": {
 							Type:          schema.TypeList,
 							Optional:      true,
@@ -846,6 +850,7 @@ func getRealmFromData(data *schema.ResourceData, keycloakVersion *version.Versio
 			FromDisplayName:    smtpSettings["from_display_name"].(string),
 			EnvelopeFrom:       smtpSettings["envelope_from"].(string),
 			Ssl:                types.KeycloakBoolQuoted(smtpSettings["ssl"].(bool)),
+			AllowUtf8:          types.KeycloakBoolQuoted(smtpSettings["allow_utf8"].(bool)),
 		}
 
 		authConfig := smtpSettings["auth"].([]interface{})
@@ -1295,6 +1300,7 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm, keycloakVers
 		smtpSettings["from_display_name"] = realm.SmtpServer.FromDisplayName
 		smtpSettings["envelope_from"] = realm.SmtpServer.EnvelopeFrom
 		smtpSettings["ssl"] = realm.SmtpServer.Ssl
+		smtpSettings["allow_utf8"] = realm.SmtpServer.AllowUtf8
 
 		if realm.SmtpServer.Auth {
 			if realm.SmtpServer.AuthType == "token" {


### PR DESCRIPTION
This allows having non-ASCII characters in the non-domain (local) part of email addresses. It's a new option on the realm's SMTP settings ([Migration docs](https://www.keycloak.org/docs/latest/upgrading/#migrating-to-26-3-3)).

Closes #1324.
See also: https://github.com/keycloak/keycloak/issues/41994