### PR TITLE
fix: Use normalized Keycloak API path when querying group by path

### DIFF
--- a/keycloak/group.go
+++ b/keycloak/group.go
@@ -30,7 +30,7 @@ func (keycloakClient *KeycloakClient) groupParentId(ctx context.Context, group *
 
 	var parentGroup Group
 
-	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/group-by-path/%s", group.RealmId, parentPath), &parentGroup, nil)
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/group-by-path/%s", group.RealmId, strings.TrimPrefix(parentPath, "/")), &parentGroup, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Closes #1379. Newer Keycloak versions [no longer accept](https://www.keycloak.org/docs/latest/upgrading/index.html#migrating-to-26-4-3:~:text=Accepting%20only%20normalized%20paths%20in%20requests) paths like `/admin/realms/example/group-by-path//Management` (for a group named _Management_ directly underneath the root).

Not quite sure if there are any other places that could benefit from normalization, but the group-by-path API seems to be the biggest low hanging fruit. Some quick grepping didn't yield any other results – I couldn't anything else that references things through a `/`-delimited path scheme instead of IDs.