### PR TITLE
fix keycloak_group_permissions - panic: interface conversion: interface {} is nil, not string

### DIFF
--- a/keycloak/group_permissions.go
+++ b/keycloak/group_permissions.go
@@ -10,11 +10,11 @@ type GroupPermissionsInput struct {
 }
 
 type GroupPermissions struct {
-	RealmId          string                 `json:"-"`
-	GroupId          string                 `json:"-"`
-	Enabled          bool                   `json:"enabled"`
-	Resource         string                 `json:"resource"`
-	ScopePermissions map[string]interface{} `json:"scopePermissions"`
+	RealmId          string            `json:"-"`
+	GroupId          string            `json:"-"`
+	Enabled          bool              `json:"enabled"`
+	Resource         string            `json:"resource"`
+	ScopePermissions map[string]string `json:"scopePermissions"`
 }
 
 func (keycloakClient *KeycloakClient) EnableGroupPermissions(ctx context.Context, realmId, groupId string) error {

--- a/provider/resource_keycloak_group_permissions.go
+++ b/provider/resource_keycloak_group_permissions.go
@@ -81,31 +81,31 @@ func resourceKeycloakGroupPermissionsUpdate(ctx context.Context, data *schema.Re
 	}
 
 	if viewScope, ok := data.GetOk("view_scope"); ok {
-		err := setOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["view"].(string), viewScope.(*schema.Set))
+		err := setOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["view"], viewScope.(*schema.Set))
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 	if manageScope, ok := data.GetOk("manage_scope"); ok {
-		err := setOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["manage"].(string), manageScope.(*schema.Set))
+		err := setOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["manage"], manageScope.(*schema.Set))
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 	if viewMembersScope, ok := data.GetOk("view_members_scope"); ok {
-		err := setOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["view-members"].(string), viewMembersScope.(*schema.Set))
+		err := setOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["view-members"], viewMembersScope.(*schema.Set))
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 	if manageMembersScope, ok := data.GetOk("manage_members_scope"); ok {
-		err := setOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["manage-members"].(string), manageMembersScope.(*schema.Set))
+		err := setOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["manage-members"], manageMembersScope.(*schema.Set))
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 	if manageMembershipScope, ok := data.GetOk("manage_membership_scope"); ok {
-		err := setOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["manage-membership"].(string), manageMembershipScope.(*schema.Set))
+		err := setOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["manage-membership"], manageMembershipScope.(*schema.Set))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -135,34 +135,44 @@ func resourceKeycloakGroupPermissionsRead(ctx context.Context, data *schema.Reso
 	data.Set("enabled", groupPermissions.Enabled)
 	data.Set("authorization_resource_server_id", realmManagementClient.Id)
 
-	if viewScope, err := getOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["view"].(string)); err == nil && viewScope != nil {
-		data.Set("view_scope", []interface{}{viewScope})
-	} else if err != nil {
-		return diag.FromErr(err)
+	if scopeId := groupPermissions.ScopePermissions["view"]; scopeId != "" {
+		if viewScope, err := getOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, scopeId); err == nil && viewScope != nil {
+			data.Set("view_scope", []interface{}{viewScope})
+		} else if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
-	if manageScope, err := getOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["manage"].(string)); err == nil && manageScope != nil {
-		data.Set("manage_scope", []interface{}{manageScope})
-	} else if err != nil {
-		return diag.FromErr(err)
+	if scopeId := groupPermissions.ScopePermissions["manage"]; scopeId != "" {
+		if manageScope, err := getOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, scopeId); err == nil && manageScope != nil {
+			data.Set("manage_scope", []interface{}{manageScope})
+		} else if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
-	if viewMembersScope, err := getOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["view-members"].(string)); err == nil && viewMembersScope != nil {
-		data.Set("view_members_scope", []interface{}{viewMembersScope})
-	} else if err != nil {
-		return diag.FromErr(err)
+	if scopeId := groupPermissions.ScopePermissions["view-members"]; scopeId != "" {
+		if viewMembersScope, err := getOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, scopeId); err == nil && viewMembersScope != nil {
+			data.Set("view_members_scope", []interface{}{viewMembersScope})
+		} else if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
-	if manageMembersScope, err := getOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["manage-members"].(string)); err == nil && manageMembersScope != nil {
-		data.Set("manage_members_scope", []interface{}{manageMembersScope})
-	} else if err != nil {
-		return diag.FromErr(err)
+	if scopeId := groupPermissions.ScopePermissions["manage-members"]; scopeId != "" {
+		if manageMembersScope, err := getOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, scopeId); err == nil && manageMembersScope != nil {
+			data.Set("manage_members_scope", []interface{}{manageMembersScope})
+		} else if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
-	if manageMembershipScope, err := getOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, groupPermissions.ScopePermissions["manage-membership"].(string)); err == nil && manageMembershipScope != nil {
-		data.Set("manage_membership_scope", []interface{}{manageMembershipScope})
-	} else if err != nil {
-		return diag.FromErr(err)
+	if scopeId := groupPermissions.ScopePermissions["manage-membership"]; scopeId != "" {
+		if manageMembershipScope, err := getOpenidClientScopePermissionPolicy(ctx, keycloakClient, realmId, realmManagementClient.Id, scopeId); err == nil && manageMembershipScope != nil {
+			data.Set("manage_membership_scope", []interface{}{manageMembershipScope})
+		} else if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return nil

--- a/provider/resource_keycloak_group_permissions_test.go
+++ b/provider/resource_keycloak_group_permissions_test.go
@@ -60,7 +60,7 @@ func testAccCheckKeycloakGroupPermissionExists(resourceName string) resource.Tes
 		manageMembersScopeDescription := rs.Primary.Attributes["manage_members_scope.0.description"]
 		manageMembersScopeDecisionStrategy := rs.Primary.Attributes["manage_members_scope.0.decision_strategy"]
 
-		authzClientManageMembersScope, err := keycloakClient.GetOpenidClientAuthorizationPermission(testCtx, permissions.RealmId, realmManagementId, permissions.ScopePermissions["manage-members"].(string))
+		authzClientManageMembersScope, err := keycloakClient.GetOpenidClientAuthorizationPermission(testCtx, permissions.RealmId, realmManagementId, permissions.ScopePermissions["manage-members"])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
fixes https://github.com/keycloak/terraform-provider-keycloak/issues/1396

the fix is similar to https://github.com/keycloak/terraform-provider-keycloak/pull/591/files