### PR TITLE
added support for SAML want_authn_request_signed manual override

### DIFF
--- a/provider/resource_keycloak_saml_identity_provider.go
+++ b/provider/resource_keycloak_saml_identity_provider.go
@@ -232,8 +232,8 @@ func getSamlIdentityProviderFromData(data *schema.ResourceData, keycloakVersion 
 		//since keycloak v26 moved to IdentityProvider - still here fore backward compatibility
 		HideOnLoginPage: types.KeycloakBoolQuoted(data.Get("hide_on_login_page").(bool)),
 	}
-	
-	if _, explicitlySet := data.getOkExists("want_authn_requests_signed"); !explicitlySet {
+
+	if _, explicitlySet := data.GetOkExists("want_authn_requests_signed"); !explicitlySet {
 		if _, ok := data.GetOk("signature_algorithm"); ok {
 			samlIdentityProviderConfig.WantAuthnRequestsSigned = true
 		}


### PR DESCRIPTION
After having trouble with trying to apply a converted realm export JSON I found that there is a hard coded default behaviour for `wan_authn_requests_signed`. 

Having it set to true when `signature_algorithm` is set, may be a sensible default. So to give admins the choice, I kept the default behaviour but added a check for a manual override.