### PR TITLE
Add `add_to_token_introspection` field to `keycloak_openid_user_attribute_protocol_mapper`

### DIFF
--- a/docs/resources/openid_user_attribute_protocol_mapper.md
+++ b/docs/resources/openid_user_attribute_protocol_mapper.md
@@ -78,6 +78,7 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "user_attribute_mapper
 - `add_to_id_token` - (Optional) Indicates if the attribute should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the attribute should be added as a claim to the access token. Defaults to `true`.
 - `add_to_userinfo` - (Optional) Indicates if the attribute should be added as a claim to the UserInfo response body. Defaults to `true`.
+- `add_to_token_introspection` - (Optional) Indicates if the attribute should be added as a claim to the token introspection response. Defaults to `true`.
 - `aggregate_attributes`- (Optional) Indicates whether this attribute is a single value or an array of values. Defaults to `false`.
 
 ## Import

--- a/keycloak/openid_user_attribute_protocol_mapper.go
+++ b/keycloak/openid_user_attribute_protocol_mapper.go
@@ -13,9 +13,10 @@ type OpenIdUserAttributeProtocolMapper struct {
 	ClientId      string
 	ClientScopeId string
 
-	AddToIdToken     bool
-	AddToAccessToken bool
-	AddToUserInfo    bool
+	AddToIdToken            bool
+	AddToAccessToken        bool
+	AddToUserInfo           bool
+	AddToTokenIntrospection bool
 
 	UserAttribute  string
 	ClaimName      string
@@ -35,6 +36,7 @@ func (mapper *OpenIdUserAttributeProtocolMapper) convertToGenericProtocolMapper(
 			addToIdTokenField:             strconv.FormatBool(mapper.AddToIdToken),
 			addToAccessTokenField:         strconv.FormatBool(mapper.AddToAccessToken),
 			addToUserInfoField:            strconv.FormatBool(mapper.AddToUserInfo),
+			addToTokenIntrospectionField:  strconv.FormatBool(mapper.AddToTokenIntrospection),
 			userAttributeField:            mapper.UserAttribute,
 			claimNameField:                mapper.ClaimName,
 			claimValueTypeField:           mapper.ClaimValueType,
@@ -60,6 +62,11 @@ func (protocolMapper *protocolMapper) convertToOpenIdUserAttributeProtocolMapper
 		return nil, err
 	}
 
+	addToTokenIntrospection, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToTokenIntrospectionField])
+	if err != nil {
+		return nil, err
+	}
+
 	// multivalued's default is "", this is an issue when importing an existing mapper
 	multivalued, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[multivaluedField])
 	if err != nil {
@@ -78,9 +85,10 @@ func (protocolMapper *protocolMapper) convertToOpenIdUserAttributeProtocolMapper
 		ClientId:      clientId,
 		ClientScopeId: clientScopeId,
 
-		AddToIdToken:     addToIdToken,
-		AddToAccessToken: addToAccessToken,
-		AddToUserInfo:    addToUserInfo,
+		AddToIdToken:            addToIdToken,
+		AddToAccessToken:        addToAccessToken,
+		AddToUserInfo:           addToUserInfo,
+		AddToTokenIntrospection: addToTokenIntrospection,
 
 		UserAttribute:            protocolMapper.Config[userAttributeField],
 		ClaimName:                protocolMapper.Config[claimNameField],

--- a/provider/resource_keycloak_openid_user_attribute_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_attribute_protocol_mapper.go
@@ -66,6 +66,12 @@ func resourceKeycloakOpenIdUserAttributeProtocolMapper() *schema.Resource {
 				Default:     true,
 				Description: "Indicates if the attribute should appear in the userinfo response body.",
 			},
+			"add_to_token_introspection": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Indicates if the attribute should be a claim in the token introspection response.",
+			},
 			"multivalued": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -99,14 +105,15 @@ func resourceKeycloakOpenIdUserAttributeProtocolMapper() *schema.Resource {
 
 func mapFromDataToOpenIdUserAttributeProtocolMapper(data *schema.ResourceData) *keycloak.OpenIdUserAttributeProtocolMapper {
 	return &keycloak.OpenIdUserAttributeProtocolMapper{
-		Id:               data.Id(),
-		Name:             data.Get("name").(string),
-		RealmId:          data.Get("realm_id").(string),
-		ClientId:         data.Get("client_id").(string),
-		ClientScopeId:    data.Get("client_scope_id").(string),
-		AddToIdToken:     data.Get("add_to_id_token").(bool),
-		AddToAccessToken: data.Get("add_to_access_token").(bool),
-		AddToUserInfo:    data.Get("add_to_userinfo").(bool),
+		Id:                      data.Id(),
+		Name:                    data.Get("name").(string),
+		RealmId:                 data.Get("realm_id").(string),
+		ClientId:                data.Get("client_id").(string),
+		ClientScopeId:           data.Get("client_scope_id").(string),
+		AddToIdToken:            data.Get("add_to_id_token").(bool),
+		AddToAccessToken:        data.Get("add_to_access_token").(bool),
+		AddToUserInfo:           data.Get("add_to_userinfo").(bool),
+		AddToTokenIntrospection: data.Get("add_to_token_introspection").(bool),
 
 		UserAttribute:            data.Get("user_attribute").(string),
 		ClaimName:                data.Get("claim_name").(string),
@@ -130,6 +137,7 @@ func mapFromOpenIdUserAttributeMapperToData(mapper *keycloak.OpenIdUserAttribute
 	data.Set("add_to_id_token", mapper.AddToIdToken)
 	data.Set("add_to_access_token", mapper.AddToAccessToken)
 	data.Set("add_to_userinfo", mapper.AddToUserInfo)
+	data.Set("add_to_token_introspection", mapper.AddToTokenIntrospection)
 	data.Set("user_attribute", mapper.UserAttribute)
 	data.Set("claim_name", mapper.ClaimName)
 	data.Set("claim_value_type", mapper.ClaimValueType)


### PR DESCRIPTION
The implementation introduces the `add_to_token_introspection` field to the `keycloak_openid_user_attribute_protocol_mapper`, allowing users to specify whether the attribute should be included in the token introspection response. This addition addresses the missing functionality reported in issue #1081. The field is optional and defaults to true.

The implementation is similar to the pre-existing support for the `resource_keycloak_openid_sub_protocol_mapper`. It was tested locally to ensure correct behaviour.

Closes #1081

AI Disclosure: AI Assistance was used to generate parts of this PR. The code was reviewed by a human.