### PR TITLE
Fix disabling of admin permissions in fine grained authz v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,9 +88,13 @@ jobs:
           MOUNT_FEDERATION_EXAMPLE_VOLUME=""
           EXTRA_FEATURES=""
           MOUNT_FEDERATION_EXAMPLE_VOLUME="-v $PWD/custom-user-federation-example/build/libs/custom-user-federation-example-all.jar:/opt/keycloak/providers/custom-user-federation-example-all.jar:z"
-          if [[ "${{ matrix.keycloak-version }}" == "26.5.5" || "${{ matrix.keycloak-version }}" == "26.4.7"|| "${{ matrix.keycloak-version }}" == "26.3.5" || "${{ matrix.keycloak-version }}" == "26.2.5" ]]; then
+          if [[ "${{ matrix.keycloak-version }}" == "26.5.5" ]]; then
+            EXTRA_FEATURES=",admin-fine-grained-authz:v2"
+          elif [[ "${{ matrix.keycloak-version }}" == "26.4.7" || "${{ matrix.keycloak-version }}" == "26.3.5" || "${{ matrix.keycloak-version }}" == "26.2.5" ]]; then
             EXTRA_FEATURES=",admin-fine-grained-authz:v1"
+          fi
 
+          if [[ "${{ matrix.keycloak-version }}" == "26.5.5" || "${{ matrix.keycloak-version }}" == "26.4.7" || "${{ matrix.keycloak-version }}" == "26.3.5" || "${{ matrix.keycloak-version }}" == "26.2.5" ]]; then
             EXTRA_HTTP_CLIENT_AUTH="-e KC_HTTPS_CLIENT_AUTH=required"
             EXTRA_HTTPS_CERT="-e KC_HTTPS_CERTIFICATE_FILE=/opt/keycloak/testdata/tls/server-cert.pem"
             EXTRA_HTTPS_KEY="-e KC_HTTPS_CERTIFICATE_KEY_FILE=/opt/keycloak/testdata/tls/server-key.pem"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     - KC_DB_USERNAME=keycloak
     - KC_DB_PASSWORD=password
     - KC_LOG_CONSOLE_COLOR=true
-    - KC_FEATURES=preview,admin-fine-grained-authz:v1
+    - KC_FEATURES=preview,admin-fine-grained-authz:v2
     - KC_HTTPS_CERTIFICATE_FILE=/opt/keycloak/testdata/tls/server-cert.pem
     - KC_HTTPS_CERTIFICATE_KEY_FILE=/opt/keycloak/testdata/tls/server-key.pem
 # Enable for remote java debugging

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -100,7 +100,7 @@ type Realm struct {
 	MaxFailureWaitSeconds        int    `json:"maxFailureWaitSeconds"` //Max Wait
 	MaxDeltaTimeSeconds          int    `json:"maxDeltaTimeSeconds"`   //Failure Reset Time
 
-	AdminPermissionsEnabled bool `json:"adminPermissionsEnabled,omitempty"`
+	AdminPermissionsEnabled *bool `json:"adminPermissionsEnabled,omitempty"`
 
 	PasswordPolicy string `json:"passwordPolicy"`
 

--- a/provider/resource_keycloak_group_permissions_test.go
+++ b/provider/resource_keycloak_group_permissions_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestAccKeycloakGroupPermission_basic(t *testing.T) {
+	// only supported with admin-fine-grained-authz:v1, not v2
+	skipIfVersionIsGreaterThanOrEqualTo(testCtx, t, keycloakClient, keycloak.Version_26_5)
+
 	groupName := acctest.RandomWithPrefix("tf-acc")
 
 	resource.Test(t, resource.TestCase{

--- a/provider/resource_keycloak_identity_provider_token_exchange_scope_permission_test.go
+++ b/provider/resource_keycloak_identity_provider_token_exchange_scope_permission_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccKeycloakIdpTokenExchangeScopePermission_basic(t *testing.T) {
+	// only supported with admin-fine-grained-authz:v1, not v2
+	skipIfVersionIsGreaterThanOrEqualTo(testCtx, t, keycloakClient, keycloak.Version_26_5)
 	t.Parallel()
 
 	providerAlias := acctest.RandomWithPrefix("tf-acc")
@@ -32,6 +34,8 @@ func TestAccKeycloakIdpTokenExchangeScopePermission_basic(t *testing.T) {
 }
 
 func TestAccKeycloakIdpTokenExchangeScopePermission_createAfterManualDestroy(t *testing.T) {
+	// only supported with admin-fine-grained-authz:v1, not v2
+	skipIfVersionIsGreaterThanOrEqualTo(testCtx, t, keycloakClient, keycloak.Version_26_5)
 	t.Parallel()
 
 	var idpPermissions = &keycloak.IdentityProviderPermissions{}
@@ -67,6 +71,8 @@ func TestAccKeycloakIdpTokenExchangeScopePermission_createAfterManualDestroy(t *
 }
 
 func TestAccKeycloakIdpTokenExchangeScopePermission_import(t *testing.T) {
+	// only supported with admin-fine-grained-authz:v1, not v2
+	skipIfVersionIsGreaterThanOrEqualTo(testCtx, t, keycloakClient, keycloak.Version_26_5)
 	t.Parallel()
 
 	providerAlias := acctest.RandomWithPrefix("tf-acc")
@@ -93,6 +99,8 @@ func TestAccKeycloakIdpTokenExchangeScopePermission_import(t *testing.T) {
 }
 
 func TestAccKeycloakIdpTokenExchangeScopePermission_updatePolicyMultipleClients(t *testing.T) {
+	// only supported with admin-fine-grained-authz:v1, not v2
+	skipIfVersionIsGreaterThanOrEqualTo(testCtx, t, keycloakClient, keycloak.Version_26_5)
 	t.Parallel()
 
 	providerAlias := acctest.RandomWithPrefix("tf-acc")

--- a/provider/resource_keycloak_openid_client_permissions_test.go
+++ b/provider/resource_keycloak_openid_client_permissions_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestAccKeycloakOpenidClientPermission_basic(t *testing.T) {
+	// only supported with admin-fine-grained-authz:v1, not v2
+	skipIfVersionIsGreaterThanOrEqualTo(testCtx, t, keycloakClient, keycloak.Version_26_5)
+
 	clientId := acctest.RandomWithPrefix("tf-acc")
 	username := acctest.RandomWithPrefix("tf-acc")
 	email := acctest.RandomWithPrefix("tf-acc") + "@fakedomain.com"

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -1146,7 +1146,9 @@ func getRealmFromData(data *schema.ResourceData, keycloakVersion *version.Versio
 	}
 	realm.DefaultOptionalClientScopes = defaultOptionalClientScopes
 
-	realm.AdminPermissionsEnabled = data.Get("admin_permissions_enabled").(bool)
+	if isAttributeInConfig(data, "admin_permissions_enabled") {
+		realm.AdminPermissionsEnabled = boolPointer(data.Get("admin_permissions_enabled").(bool))
+	}
 
 	//OTPPolicy
 	if v, ok := data.GetOk("otp_policy"); ok {

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -1012,6 +1012,34 @@ func TestAccKeycloakRealm_admin_permissions_enabled(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakRealm_admin_permissions_disabled(t *testing.T) {
+	if ok, _ := keycloakClient.VersionIsGreaterThanOrEqualTo(testCtx, keycloak.Version_26_5); !ok {
+		t.Skip()
+	}
+
+	realmName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakRealmDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakRealm_basic(realmName, realmName, realmName),
+				Check:  testAccCheckKeycloakRealmExists("keycloak_realm.realm"),
+			},
+			{
+				Config: testKeycloakRealm_admin_permission_enabled(realmName),
+				Check:  testAccCheckKeycloakRealm_admin_permissions_enabled("keycloak_realm.realm"),
+			},
+			{
+				Config: testKeycloakRealm_admin_permission_disabled(realmName),
+				Check:  testAccCheckKeycloakRealm_admin_permissions_disabled("keycloak_realm.realm"),
+			},
+		},
+	})
+}
+
 func testKeycloakRealm_admin_permission_enabled(realm string) string {
 
 	return fmt.Sprintf(`
@@ -1023,6 +1051,35 @@ resource "keycloak_realm" "realm" {
 	`, realm)
 }
 
+func testKeycloakRealm_admin_permission_disabled(realm string) string {
+
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm                          = "%s"
+	enabled                        = true
+	admin_permissions_enabled      = false
+}
+	`, realm)
+}
+
+func testAccCheckKeycloakRealm_admin_permissions_disabled(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		realm, err := getRealmFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if realm.AdminPermissionsEnabled == nil {
+			return fmt.Errorf("expected realm %s to have admin permissions explicitly set to false but was nil", realm.Realm)
+		}
+		if *realm.AdminPermissionsEnabled {
+			return fmt.Errorf("expected realm %s to have admin permissions disabled but was true", realm.Realm)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckKeycloakRealm_admin_permissions_enabled(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		realm, err := getRealmFromState(s, resourceName)
@@ -1030,8 +1087,8 @@ func testAccCheckKeycloakRealm_admin_permissions_enabled(resourceName string) re
 			return err
 		}
 
-		if !realm.AdminPermissionsEnabled {
-			return fmt.Errorf("expected realm %s to have admin permissions enabled but was %t", realm.Realm, realm.AdminPermissionsEnabled)
+		if realm.AdminPermissionsEnabled == nil || !*realm.AdminPermissionsEnabled {
+			return fmt.Errorf("expected realm %s to have admin permissions enabled but was %v", realm.Realm, realm.AdminPermissionsEnabled)
 		}
 
 		return nil

--- a/provider/resource_keycloak_users_permissions_test.go
+++ b/provider/resource_keycloak_users_permissions_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestAccKeycloakUsersPermission_basic(t *testing.T) {
+	// only supported with admin-fine-grained-authz:v1, not v2
+	skipIfVersionIsGreaterThanOrEqualTo(testCtx, t, keycloakClient, keycloak.Version_26_5)
+
 	realmName := acctest.RandomWithPrefix("tf-acc")
 	username := acctest.RandomWithPrefix("tf-acc")
 	email := acctest.RandomWithPrefix("tf-acc") + "@fakedomain.com"

--- a/provider/utils.go
+++ b/provider/utils.go
@@ -125,6 +125,19 @@ func stringPointer(s string) *string {
 	return &s
 }
 
+func boolPointer(b bool) *bool {
+	return &b
+}
+
+// isAttributeInConfig returns true if the specified attribute is explicitly present in the user's config
+func isAttributeInConfig(d *schema.ResourceData, attrName string) bool {
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
+		return false
+	}
+	return !rawConfig.GetAttr(attrName).IsNull()
+}
+
 // suppressDiffWhenNotInConfig returns a DiffSuppressFunc that suppresses diffs
 // when the specified attribute is not present in the config (null).
 // This allows:
@@ -132,12 +145,7 @@ func stringPointer(s string) *string {
 // - Keeping the server value when the field is not in the config
 func suppressDiffWhenNotInConfig(attrName string) schema.SchemaDiffSuppressFunc {
 	return func(k, old, new string, d *schema.ResourceData) bool {
-		rawConfig := d.GetRawConfig()
-		if rawConfig.IsNull() || !rawConfig.IsKnown() {
-			return true
-		}
-		configValue := rawConfig.GetAttr(attrName)
-		return configValue.IsNull()
+		return !isAttributeInConfig(d, attrName)
 	}
 }
 


### PR DESCRIPTION
* Closes: https://github.com/keycloak/terraform-provider-keycloak/issues/1509

* Makes sure that `admin_permissions_enabled` is not omitted from PUT when it is explicitly set in `.tf` resource. It is done by distinguishing between true (set explicitly to true), false (set explicitly to false) and nil (unset, hence omitted) I think this might not be the only case, e.g. `organizations_enabled` looks like it behaves same way, but I didn't explore that as I am only fixing the linked issue.

* Conditionally switches `admin-fine-grained-authz` from `v1` to `v2` in docker compose and test CI so that we can test this PR. Currently `admin_permissions_enabled` is not tested because even by the existing test. It is ignored due to the fact that tests are using `admin-fine-grained-authz:v1`. However v1 has been deprecated since Keycloak 26.5.0 https://github.com/keycloak/keycloak/issues/44121. We should test it and make sure that the flag works.

* For version lesser than 26.5.0, 7 tests are disabled due to the fact that v2 does not support these scenarios:
  * https://github.com/keycloak/keycloak/blob/1ca15660f576eec7a81e60a00651d551d5045def/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java#L727
  * https://github.com/keycloak/keycloak/blob/1ca15660f576eec7a81e60a00651d551d5045def/services/src/main/java/org/keycloak/services/resources/admin/fgap/ClientPermissionsV2.java#L185